### PR TITLE
fix(nitro,nuxt): give nuxt its own error class instead of extending h3's

### DIFF
--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -342,6 +342,27 @@ In server routes, the error class is now `HTTPError` (replacing `createError` fr
 In the Vue part of your app (the `app/` directory), Nuxt's `createError` composable continues to work and is the recommended way to throw errors.
 ::
 
+#### `createError` No Longer Returns an `HTTPError` Instance
+
+`NuxtError` is now its own class rather than a subclass of h3's `HTTPError`, so `instanceof HTTPError` no longer matches an error created with Nuxt's `createError`. Everything else is unchanged: the error keeps the same properties, serialises the same way, and is still mapped to the right HTTP response during SSR.
+
+If you narrow errors by class, use one of the predicates instead:
+
+```diff
+- if (error instanceof HTTPError) {
++ if (HTTPError.isError(error)) {
+    // handles both `new HTTPError()` and Nuxt's `createError()`
+  }
+```
+
+```diff
++ import { isNuxtError } from '#app'
++
++ if (isNuxtError(error)) {
++   // narrows to errors created with Nuxt's `createError`
++ }
+```
+
 #### Server Event API Changes (h3 v2)
 
 The `H3Event` object now uses Web standard APIs:
@@ -436,6 +457,49 @@ If you previously set `experimental.externalVue` explicitly, you should now remo
 ::note
 If you use `vue.runtimeCompiler: true`, the real compiler packages are still included as before.
 ::
+
+### `experimental.parseErrorData` Is No Longer Configurable
+
+🚦 **Impact Level**: Minimal
+
+#### What Changed
+
+The `experimental.parseErrorData` option is deprecated, and on Nuxt 5 it is forced on. Setting it to `false` logs a warning and is otherwise ignored, so `error.data` on the error page is always the value you passed to `createError`.
+
+On `compatibilityVersion: 4` the option still works and `false` still gives you a stringified `error.data`, so the behaviour only changes when you opt in to Nuxt 5.
+
+#### Reasons for Change
+
+When Nuxt renders an error page it fetches `/__nuxt_error` internally, passing the error along with the request. That used to spread the error across one query parameter per field, and because query values are always strings, `error.data` arrived as a string and had to be parsed back. `parseErrorData` existed to opt out of that parsing.
+
+The error is now sent as a single JSON-encoded parameter, so `error.data` keeps its original shape and is never stringified. Values also keep their types, so `status` is a number and booleans are booleans rather than the strings `'true'` and `'false'`. With nothing stringifying `error.data`, the option only survives to re-stringify it for apps that still expect a string.
+
+#### Migration Steps
+
+Remove the option:
+
+```diff
+  export default defineNuxtConfig({
+    experimental: {
+-     parseErrorData: false,
+    },
+  })
+```
+
+If you set it to `false` in order to keep parsing `error.data` yourself, drop that parsing too, as `error.data` is now always an object:
+
+```diff
+  <script setup lang="ts">
+  import type { NuxtError } from '#app'
+
+  const props = defineProps({
+    error: Object as () => NuxtError
+  })
+
+- const data = JSON.parse(props.error.data)
++ const data = props.error.data
+  </script>
+```
 
 ### `@vitejs/plugin-vue-jsx` Is Now Optional
 

--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -486,7 +486,7 @@ Remove the option:
   })
 ```
 
-If you set it to `false` in order to keep parsing `error.data` yourself, drop that parsing too, as `error.data` is now always an object:
+If you set it to `false` in order to keep parsing `error.data` yourself, drop that parsing too, as `error.data` now keeps whatever value you passed to `createError`:
 
 ```diff
   <script setup lang="ts">

--- a/docs/3.guide/6.going-further/1.experimental-features.md
+++ b/docs/3.guide/6.going-further/1.experimental-features.md
@@ -192,12 +192,19 @@ export default defineNuxtConfig({
 
 ## parseErrorData
 
+::warning
+This option is deprecated and will be removed. With `compatibilityVersion: 5` it is forced on and setting it is ignored.
+::
+
 Whether to parse `error.data` when rendering a server error page.
 
-This flag is enabled by default, but you can disable this feature:
+It existed because the error was previously passed to the error page as individual query parameters, which stringified `error.data` and meant it had to be parsed back. Setting it to `false` opted out of that parsing and left you with the string.
+
+The error is now JSON-encoded as a whole, so `error.data` arrives with its original shape and is never stringified. On `compatibilityVersion: 4`, setting this to `false` stringifies it again so existing error pages that call `JSON.parse(error.data)` keep working:
 
 ```ts twoslash [nuxt.config.ts]
 export default defineNuxtConfig({
+  future: { compatibilityVersion: 4 },
   experimental: {
     parseErrorData: false,
   },

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -236,6 +236,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
           `export const NUXT_VIEW_TRANSITIONS = ${!!(nuxt.options.app.viewTransition && typeof nuxt.options.app.viewTransition === 'object' && nuxt.options.app.viewTransition.enabled)}`,
           `export const NUXT_NO_SCRIPTS_PATTERNS = ${JSON.stringify(noScriptsPatterns)}`,
           `export const NUXT_PAGE_PATTERNS = ${JSON.stringify(pagePatterns)}`,
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
           `export const PARSE_ERROR_DATA = ${!!nuxt.options.experimental.parseErrorData}`,
           `export const NUXT_ASYNC_CONTEXT = ${!!nuxt.options.experimental.asyncContext}`,
           `export const NUXT_SHARED_DATA = ${!!nuxt.options.experimental.sharedPrerenderData}`,

--- a/packages/nitro-server/src/runtime/handlers/error.ts
+++ b/packages/nitro-server/src/runtime/handlers/error.ts
@@ -1,10 +1,11 @@
 import { withQuery } from 'ufo'
 import type { NitroErrorHandler } from 'nitro/types'
-import type { NuxtPayload, SerializedErrorCause } from '#app/types'
+import type { SerializedErrorCause } from '#app/types'
 import type { H3Event } from 'nitro/h3'
 import { serverFetch } from 'nitro'
 
-import { isJsonRequest } from '../utils/error'
+import type { SSRErrorInput } from '../utils/error'
+import { SSR_ERROR_PARAM, encodeSSRError, isJsonRequest } from '../utils/error'
 import { generateErrorOverlayHTML } from '../utils/dev'
 
 export default <NitroErrorHandler> async function errorhandler (error, event, { defaultHandler }) {
@@ -36,10 +37,12 @@ export default <NitroErrorHandler> async function errorhandler (error, event, { 
     defaultRes.body.stack = defaultRes.body.stack.join('\n')
   }
 
-  const errorObject = (defaultRes.body || {}) as Pick<NonNullable<NuxtPayload['error']>, 'status' | 'statusText' | 'message' | 'stack'> & { url?: string, data: any }
+  const errorObject = (defaultRes.body || {}) as SSRErrorInput
   // we will be rendering this error internally so we pass along the error.data safely
   errorObject.data ??= error.data
   errorObject.url = event.req.url
+  // `fatal` is Nuxt-only, so Nitro's error body does not carry it
+  errorObject.fatal = (error as { fatal?: boolean }).fatal ?? false
   const errorCause = import.meta.dev ? serializeErrorCause(error.cause) : undefined
 
   // Merge defaultRes headers, skipping content-type (would be application/json)
@@ -57,7 +60,7 @@ export default <NitroErrorHandler> async function errorhandler (error, event, { 
 
   // HTML response (via SSR)
   const res = !isRenderingError && await serverFetch(
-    withQuery('/__nuxt_error', errorObject),
+    withQuery('/__nuxt_error', { [SSR_ERROR_PARAM]: encodeSSRError(errorObject) }),
     {
       headers: event.req.headers,
       redirect: 'manual',

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -10,8 +10,8 @@ import type { SSRHeadPayload } from '@unhead/vue/server'
 import { createBootstrapScript, renderSSRHeadSuspenseChunk, renderShell } from '@unhead/vue/stream/server'
 import { streamingIifeCode } from '@unhead/vue/stream/iife'
 import type { Link, Script } from '@unhead/vue/types'
-import destr from 'destr'
 import { getRouteRules, useNitroHooks } from 'nitro/app'
+import { SSR_ERROR_PARAM, decodeSSRError, stringifyErrorData } from '../utils/error'
 import { relative } from 'pathe'
 
 import type { NuxtPayload, NuxtRenderHTMLContext, NuxtSSRContext, SerializedErrorCause } from '#app/types'
@@ -68,16 +68,18 @@ export default {
     }
 
     // Whether we're rendering an error page
-    const ssrError = event.url.pathname.startsWith('/__nuxt_error')
-      ? getQuery<NuxtPayload['error'] & { url: string }>(event)
-      : undefined
+    const isErrorRoute = event.url.pathname.startsWith('/__nuxt_error')
 
-    if (ssrError && !event.context.nuxt?.['~rendering-error'] /* allow internal fetch from the error handler */) {
+    if (isErrorRoute && !event.context.nuxt?.['~rendering-error'] /* allow internal fetch from the error handler */) {
       throw new HTTPError({
         status: 404,
         statusText: 'Page Not Found: /__nuxt_error',
       })
     }
+
+    const ssrError = isErrorRoute
+      ? decodeSSRError(getQuery<Record<string, string>>(event)[SSR_ERROR_PARAM])
+      : undefined
 
     // During prerender, refuse to recurse into a URL that is already rendering
     // higher in the same call chain. Without this, a `useFetch`/`$fetch` against
@@ -107,15 +109,8 @@ async function renderRoute (event: H3Event, ssrError?: (NuxtPayload['error'] & {
   ssrContext.head.push(appHead)
 
   if (ssrError) {
-    // @ts-expect-error TODO: investigate creating new error
-    ssrError.status &&= Number.parseInt(ssrError.status.toString())
-    if (PARSE_ERROR_DATA && typeof ssrError.data === 'string') {
-      try {
-        // @ts-expect-error TODO: investigate creating new error
-        ssrError.data = destr(ssrError.data)
-      } catch {
-        // ignore
-      }
+    if (!PARSE_ERROR_DATA) {
+      (ssrError as { data?: unknown }).data = stringifyErrorData(ssrError.data)
     }
     if (import.meta.dev && event.context.nuxt?.['~error-cause'] !== undefined) {
       (ssrError as { cause?: SerializedErrorCause }).cause = event.context.nuxt['~error-cause']

--- a/packages/nitro-server/src/runtime/utils/error.ts
+++ b/packages/nitro-server/src/runtime/utils/error.ts
@@ -1,5 +1,88 @@
 import type { HTTPEvent } from 'nitro/h3'
 import { FastURL } from 'srvx'
+import type { NuxtPayload } from '#app/types'
+
+/**
+ * Query parameter carrying the JSON-encoded error to `/__nuxt_error`.
+ *
+ * @internal
+ */
+export const SSR_ERROR_PARAM = '__nuxt_error_payload'
+
+/**
+ * Mirror of `NUXT_ERROR_SIGNATURE` in `#app/composables/error`, redeclared so
+ * the Nitro handlers do not pull app runtime code into their bundle.
+ *
+ * @internal
+ */
+export const NUXT_ERROR_SIGNATURE = '__nuxt_error'
+
+export type SSRError = NonNullable<NuxtPayload['error']> & { url: string }
+
+/**
+ * Writable subset of {@link SSRError} the error handler assembles from Nitro's
+ * error body before encoding it.
+ *
+ * @internal
+ */
+export type SSRErrorInput = {
+  -readonly [K in 'status' | 'statusText' | 'message' | 'stack' | 'fatal']?: SSRError[K]
+} & { url?: string, data?: unknown }
+
+/**
+ * Encode the error the error handler sends to `/__nuxt_error`.
+ *
+ * `data` is arbitrary user input, so it can be cyclic or hold values JSON
+ * refuses. Dropping it beats throwing, because throwing here loses the error
+ * page along with the error it was reporting.
+ *
+ * @internal
+ */
+export function encodeSSRError (error: SSRErrorInput): string {
+  try {
+    return JSON.stringify(error)
+  } catch {
+    try {
+      return JSON.stringify({ ...error, data: undefined })
+    } catch {
+      return '{}'
+    }
+  }
+}
+
+/**
+ * Rebuild the error the error handler sent to `/__nuxt_error`.
+ *
+ * The result stays a plain object rather than a `NuxtError` instance, to keep
+ * the class out of the Nitro bundle. The signature `isNuxtError` looks for is
+ * added on arrival rather than sent, as every error reaching this route is one
+ * by definition.
+ *
+ * @internal
+ */
+export function decodeSSRError (encoded: string | undefined): SSRError | undefined {
+  if (!encoded) { return undefined }
+  try {
+    return { ...JSON.parse(encoded), [NUXT_ERROR_SIGNATURE]: true } as SSRError
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Restore the stringified `error.data` that `experimental.parseErrorData: false`
+ * used to produce, back when the error reached the error page as query
+ * parameters. Nothing stringifies it now, so it is reproduced here for apps
+ * that still expect a string.
+ *
+ * Callers must guard this with the `PARSE_ERROR_DATA` constant directly, so the
+ * default build folds the branch away and drops this entirely.
+ *
+ * @internal
+ */
+export function stringifyErrorData (data: unknown): unknown {
+  return data === undefined || typeof data === 'string' ? data : JSON.stringify(data)
+}
 
 /**
  * Nitro internal functions extracted from https://github.com/nitrojs/nitro/blob/v2/src/runtime/internal/utils.ts

--- a/packages/nuxt/src/app/composables/error.ts
+++ b/packages/nuxt/src/app/composables/error.ts
@@ -1,10 +1,11 @@
-import { HTTPError } from '@nuxt/nitro-server/h3'
 import { toRef } from 'vue'
+import type { HTTPError } from '@nuxt/nitro-server/h3'
 import type { Ref } from 'vue'
 import { useNuxtApp } from '../nuxt'
 import type { NuxtApp, NuxtPayload } from '../nuxt'
 import type { NuxtError as _NuxtErrorContract } from '../types'
 import { isBotUserAgent } from '../utils'
+import { sanitizeStatusCode, sanitizeStatusMessage } from '../utils/http-status'
 import { useRouter } from './router'
 import { appDiagnostics } from '../diagnostics/core'
 
@@ -16,10 +17,7 @@ export const useError = (): Ref<NuxtPayload['error']> => toRef(useNuxtApp().payl
 
 /** @since 3.0.0 */
 export const showError = <DataT = unknown>(
-  error: string | Error | (Partial<NuxtError<DataT>> & {
-    status?: number
-    statusText?: string
-  }),
+  error: string | Error | NuxtErrorDetails<DataT>,
 ): NuxtError<DataT> => {
   const nuxtError = createError<DataT>(error)
 
@@ -90,22 +88,101 @@ export const isNuxtError = <DataT = unknown>(error: unknown): error is NuxtError
   return !!error && typeof error === 'object' && NUXT_ERROR_SIGNATURE in error
 }
 
-export class NuxtError<DataT = unknown> extends HTTPError<DataT> implements _NuxtErrorContract<DataT> {
-  readonly __nuxt_error = true as const
+/**
+ * Details accepted when constructing a {@link NuxtError}.
+ *
+ * @since 5.0.0
+ */
+export type NuxtErrorDetails<DataT = unknown> = Partial<Omit<NuxtError<DataT>, 'headers' | 'name' | 'toJSON'>> & {
+  /** @deprecated use `status` */
+  statusCode?: number
+  /** @deprecated use `statusText` */
+  statusMessage?: string
+  headers?: HeadersInit
+}
+
+export class NuxtError<DataT = unknown> extends Error implements _NuxtErrorContract<DataT> {
+  readonly [NUXT_ERROR_SIGNATURE] = true as const
+
+  /**
+   * h3 recognises its own errors by constructor name rather than `instanceof`,
+   * so errors thrown during SSR are only mapped to the right HTTP response if
+   * `name` stays `HTTPError`.
+   */
+  override get name (): string {
+    return 'HTTPError'
+  }
+
+  /** HTTP status code in range [100...599] */
+  readonly status: number
+  /** HTTP status text (reason phrase) */
+  readonly statusText: string | undefined
+  /** Additional HTTP headers to be sent with the error response. */
+  readonly headers: Headers | undefined
+  /** Additional data attached to the error JSON body under `data`. */
+  readonly data: DataT | undefined
+  /** Additional top-level properties to attach to the error JSON body. */
+  readonly body: Record<string, unknown> | undefined
+  /** Whether the error was not handled by the application. */
+  readonly unhandled: boolean | undefined
   readonly fatal: boolean
   override readonly cause: unknown
 
-  constructor (message = '', opts: Partial<NuxtError<DataT>> = {}) {
-    super(message, opts)
-    this.cause = opts instanceof Error ? opts : opts.cause
-    this.fatal = opts.fatal ?? !!opts.unhandled
+  constructor (message: string | NuxtErrorDetails<DataT> = '', opts: NuxtErrorDetails<DataT> = {}) {
+    const details = (typeof message === 'string' ? opts : message) || {}
+    const cause = details.cause as NuxtErrorDetails<DataT> | undefined
+
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    const status = sanitizeStatusCode(details.status || details.statusCode || cause?.status || cause?.statusCode, 500)
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    const statusText = sanitizeStatusMessage(details.statusText || details.statusMessage || cause?.statusText || cause?.statusMessage)
+
+    super(
+      (typeof message === 'string' ? message : '') ||
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
+      details.message || cause?.message || details.statusText || details.statusMessage ||
+      ['HTTPError', status, statusText].filter(Boolean).join(' '),
+      { cause: details },
+    )
+
+    this.status = status
+    this.statusText = statusText || undefined
+    const headers = details.headers || cause?.headers
+    this.headers = headers ? new Headers(headers) : undefined
+    this.unhandled = details.unhandled ?? cause?.unhandled ?? undefined
+    this.data = details.data
+    this.body = details.body
+    this.cause = details instanceof Error ? details : details.cause
+    this.fatal = details.fatal ?? !!this.unhandled
+  }
+
+  /** @deprecated use `status` */
+  get statusCode (): number {
+    return this.status
+  }
+
+  /** @deprecated use `statusText` */
+  get statusMessage (): string | undefined {
+    return this.statusText
+  }
+
+  toJSON (): ReturnType<HTTPError<DataT>['toJSON']> {
+    const unhandled = this.unhandled
+    return {
+      status: this.status,
+      statusText: this.statusText,
+      unhandled,
+      message: unhandled ? 'HTTPError' : this.message,
+      data: unhandled ? undefined : this.data,
+      ...unhandled ? undefined : this.body,
+    }
   }
 }
 
 /** @since 3.0.0 */
-export const createError = <DataT = unknown>(error: string | Error | Partial<NuxtError<DataT>>): NuxtError<DataT> => {
+export const createError = <DataT = unknown>(error: string | Error | NuxtErrorDetails<DataT>): NuxtError<DataT> => {
   if (isNuxtError<DataT>(error)) { return error }
   return typeof error === 'string'
     ? new NuxtError<DataT>(error)
-    : new NuxtError<DataT>(error.message, error)
+    : new NuxtError<DataT>(error.message ?? '', error as NuxtErrorDetails<DataT>)
 }

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -1,13 +1,13 @@
 import { getCurrentInstance, getCurrentScope, hasInjectionContext, inject, onScopeDispose } from 'vue'
 import type { ComponentInternalInstance, EffectScope } from 'vue'
 import type { NavigationFailure, NavigationGuard, RouteLocationNormalized, RouteLocationRaw, Router, useRoute as _useRoute, useRouter as _useRouter } from 'vue-router'
-import { sanitizeStatusCode } from '@nuxt/nitro-server/h3'
 import { decodePath, encodePath, hasProtocol, isScriptProtocol, joinURL, parseQuery, parseURL, withQuery } from 'ufo'
 
 import type { NuxtLayouts } from '../../pages/runtime/composables'
 
 import { useNuxtApp, useRuntimeConfig } from '../nuxt'
 import { PageRouteSymbol } from '../components/injections'
+import { sanitizeStatusCode } from '../utils/http-status'
 import type { NuxtError } from './error'
 import { createError, showError } from './error'
 import { getUserTrace } from '../utils'

--- a/packages/nuxt/src/app/plugins/revive-payload.client.ts
+++ b/packages/nuxt/src/app/plugins/revive-payload.client.ts
@@ -16,7 +16,11 @@ function parseRevivedData (data: string) {
 }
 
 const revivers: [string, (data: any) => any][] = [
-  ['NuxtError', data => createError(data)],
+  ['NuxtError', (data) => {
+    const error = createError(data)
+    if (import.meta.dev && data?.stack) { error.stack = data.stack }
+    return error
+  }],
   ['EmptyShallowRef', data => shallowRef(data === '_' ? undefined : data === '0n' ? BigInt(0) : parseRevivedData(data))],
   ['EmptyRef', data => ref(data === '_' ? undefined : data === '0n' ? BigInt(0) : parseRevivedData(data))],
   ['ShallowRef', data => shallowRef(data)],

--- a/packages/nuxt/src/app/plugins/revive-payload.server.ts
+++ b/packages/nuxt/src/app/plugins/revive-payload.server.ts
@@ -7,8 +7,20 @@ import type { ObjectPlugin, Plugin } from '../nuxt'
 import { componentIslands } from '#build/nuxt.config.mjs'
 import { isValidIslandKey } from './utils'
 
-const reducers: [string, (data: any) => any][] = [
-  ['NuxtError', data => isNuxtError(data) && data.toJSON()],
+/** @internal */
+export const reducers: [string, (data: any) => any][] = [
+  // `toJSON` carries only what belongs in an HTTP error body, so `fatal` and
+  // the dev stack are added back or they are lost on revival (#29182). Plain
+  // objects carrying the signature fall through to ordinary serialisation,
+  // which keeps every field they were sent with.
+  ['NuxtError', (data) => {
+    if (!isNuxtError(data) || typeof data.toJSON !== 'function') { return false }
+    return {
+      ...data.toJSON(),
+      ...data.fatal !== !!data.unhandled && { fatal: data.fatal },
+      ...import.meta.dev && data.stack && { stack: data.stack },
+    }
+  }],
   ['EmptyShallowRef', data => isRef(data) && isShallow(data) && !data.value && (typeof data.value === 'bigint' ? '0n' : (JSON.stringify(data.value) || '_'))],
   ['EmptyRef', data => isRef(data) && !data.value && (typeof data.value === 'bigint' ? '0n' : (JSON.stringify(data.value) || '_'))],
   ['ShallowRef', data => isRef(data) && isShallow(data) && data.value],

--- a/packages/nuxt/src/app/plugins/router.ts
+++ b/packages/nuxt/src/app/plugins/router.ts
@@ -1,11 +1,10 @@
 import type { Ref } from 'vue'
 import { computed, defineComponent, h, isReadonly, reactive } from 'vue'
 import { isEqual, joinURL, parseQuery, stringifyParsedURL, stringifyQuery, withoutBase } from 'ufo'
-import { HTTPError } from '@nuxt/nitro-server/h3'
 import { defineNuxtPlugin, useRuntimeConfig } from '../nuxt'
 import type { ObjectPlugin, Plugin } from '../nuxt'
 import { getRouteRules } from '../composables/manifest'
-import { clearError, showError } from '../composables/error'
+import { clearError, createError, showError } from '../composables/error'
 import { navigateTo } from '../composables/router'
 import { navigationDiagnostics } from '../diagnostics/navigation'
 
@@ -281,7 +280,7 @@ const plugin: Plugin<{ route: Route, router: Router }> & ObjectPlugin<{ route: R
             const result = await nuxtApp.runWithContext(() => middleware(to, from))
             if (import.meta.server) {
               if (result === false || result instanceof Error) {
-                const error = result || new HTTPError({
+                const error = result || createError({
                   status: 404,
                   statusText: `Page Not Found: ${initialURL}`,
                   data: {

--- a/packages/nuxt/src/app/types.ts
+++ b/packages/nuxt/src/app/types.ts
@@ -102,6 +102,10 @@ export interface NuxtServerApp {
  * Type-only declaration of the `NuxtError` class in
  * `./composables/error.ts`, which remains the canonical exported value (and
  * the `NuxtError` type exported from `nuxt/app` / `#app`).
+ *
+ * It extends h3's `HTTPError` at the type level only: `NuxtError` is a
+ * standalone class, but errors thrown during SSR have to remain structurally
+ * compatible with what h3 and Nitro read off them.
  */
 export interface NuxtError<DataT = unknown> extends HTTPError<DataT> {
   readonly __nuxt_error: true

--- a/packages/nuxt/src/app/utils/http-status.ts
+++ b/packages/nuxt/src/app/utils/http-status.ts
@@ -1,0 +1,28 @@
+const DISALLOWED_STATUS_CHARS = /[^\t\u0020-\u007E]/g
+
+/**
+ * Clamp a status code to the valid HTTP range, falling back to `defaultStatusCode`.
+ *
+ * @internal
+ */
+export function sanitizeStatusCode (statusCode?: string | number, defaultStatusCode = 200): number {
+  if (!statusCode) {
+    return defaultStatusCode
+  }
+  if (typeof statusCode === 'string') {
+    statusCode = Number(statusCode)
+  }
+  if (Number.isNaN(statusCode) || statusCode < 100 || statusCode > 599) {
+    return defaultStatusCode
+  }
+  return statusCode
+}
+
+/**
+ * Strip characters that are not permitted in an HTTP reason phrase.
+ *
+ * @internal
+ */
+export function sanitizeStatusMessage (statusMessage = ''): string {
+  return statusMessage.replace(DISALLOWED_STATUS_CHARS, '')
+}

--- a/packages/nuxt/test/diagnostics-catalog.test.ts
+++ b/packages/nuxt/test/diagnostics-catalog.test.ts
@@ -23,6 +23,9 @@ import { unheadDiagnostics } from '../src/app/diagnostics/head.ts'
 import { stateDiagnostics } from '../src/app/diagnostics/state.ts'
 import { serverDiagnostics } from '../../nitro-server/src/runtime/diagnostics.ts'
 
+// Schema continues kit's B5xxx configuration range, so it has to be swept too.
+import { schemaDiagnostics } from '../../schema/src/diagnostics.ts'
+
 const catalogs = [
   buildDiagnostics,
   pluginDiagnostics,
@@ -40,6 +43,7 @@ const catalogs = [
   unheadDiagnostics,
   stateDiagnostics,
   serverDiagnostics,
+  schemaDiagnostics,
 ]
 
 describe('diagnostics catalog', () => {

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -1,3 +1,4 @@
+import { schemaDiagnostics } from '../diagnostics.ts'
 import { defineResolvers } from '../utils/definition.ts'
 
 export default defineResolvers({
@@ -249,8 +250,15 @@ export default defineResolvers({
         return typeof val === 'boolean' ? val : false
       },
     },
+    // TODO: remove this option, including from the schema types, before Nuxt 5 is released
     parseErrorData: {
-      $resolve: (val) => {
+      $resolve: async (val, get) => {
+        if ((await get('future.compatibilityVersion')) >= 5) {
+          if (val === false) {
+            schemaDiagnostics.NUXT_B5016()
+          }
+          return true
+        }
         return typeof val === 'boolean' ? val : true
       },
     },

--- a/packages/schema/src/diagnostics.ts
+++ b/packages/schema/src/diagnostics.ts
@@ -34,5 +34,10 @@ export const schemaDiagnostics = /* #__PURE__ */ defineDiagnostics({
       fix: 'Use a known preset name, or pass a function to `postcss.order`.',
       docs: false,
     },
+    NUXT_B5016: {
+      why: '`experimental.parseErrorData` is ignored when `future.compatibilityVersion` >= 5. `error.data` is no longer stringified on its way to the error page, so there is nothing to opt out of.',
+      fix: 'Remove the option, and drop any `JSON.parse(error.data)` from your error page.',
+      docs: false,
+    },
   },
 })

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1588,8 +1588,14 @@ export interface ConfigSchema {
     /**
      * Whether to parse `error.data` when rendering a server error page.
      *
+     * @deprecated The error sent to the error page is JSON-encoded, so
+     * `error.data` keeps its original shape and is never stringified. With
+     * `compatibilityVersion: 5` this is forced on and setting it is ignored;
+     * before that, `false` stringifies `error.data` again for backwards
+     * compatibility.
      * @default true
      */
+    // TODO: remove this option before Nuxt 5 is released
     parseErrorData: boolean
 
     /**

--- a/packages/schema/test/experimental.spec.ts
+++ b/packages/schema/test/experimental.spec.ts
@@ -29,3 +29,32 @@ describe('experimental.watcher default', () => {
     expect((result as unknown as NuxtOptions).experimental.watcher).toBe('parcel')
   })
 })
+
+describe('experimental.parseErrorData', () => {
+  it('is forced on with compatibilityVersion 5, and says so', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const result = await applyDefaults(NuxtConfigSchema, { future: { compatibilityVersion: 5 }, experimental: { parseErrorData: false } })
+
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect((result as unknown as NuxtOptions).experimental.parseErrorData).toBe(true)
+    expect(warn.mock.calls.map(call => String(call[0])).join('\n')).toContain('NUXT_B5016')
+    warn.mockRestore()
+  })
+
+  it('is still configurable with compatibilityVersion 4, without complaining', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const result = await applyDefaults(NuxtConfigSchema, { future: { compatibilityVersion: 4 }, experimental: { parseErrorData: false } })
+
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect((result as unknown as NuxtOptions).experimental.parseErrorData).toBe(false)
+    expect(warn.mock.calls.map(call => String(call[0])).join('\n')).not.toContain('NUXT_B5016')
+    warn.mockRestore()
+  })
+
+  it('defaults to true', async () => {
+    const result = await applyDefaults(NuxtConfigSchema, { future: { compatibilityVersion: 4 } })
+
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    expect((result as unknown as NuxtOptions).experimental.parseErrorData).toBe(true)
+  })
+})

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1194,6 +1194,20 @@ describe('errors', () => {
     expect(data[error.__nuxt_error]).toBe(true)
   })
 
+  it('should expose a recognisable NuxtError on the client error page', async () => {
+    const { page } = await renderPage('/error/not-found')
+    await page.waitForFunction(() => window.useNuxtApp?.() && !window.useNuxtApp?.().isHydrating)
+
+    // #29182: the error survived SSR -> query -> payload -> revival with its
+    // signature and structured `data` intact
+    expect(await page.evaluate(() => {
+      const error = window.useNuxtApp!().payload.error as any
+      return { recognised: '__nuxt_error' in error, status: error.status, data: error.data }
+    })).toEqual({ recognised: true, status: 404, data: { reason: 'missing' } })
+
+    await page.close()
+  })
+
   it('should keep error data structured on the error page', async () => {
     const html = await fetch('/error/not-found', { headers: { accept: 'text/html' } }).then(r => r.text())
     const payload = html.match(/__NUXT_DATA__[^>]*>(.*?)<\/script>/s)![1]!

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1161,6 +1161,48 @@ describe('errors', () => {
     expect(error).not.toHaveProperty('url')
   })
 
+  it('should map a createError status thrown in a page to the HTTP status', async () => {
+    const res = await fetch('/error/not-found', {
+      headers: {
+        accept: 'application/json',
+      },
+    })
+    expect(res.status).toBe(404)
+    expect(res.statusText).toBe('This page does not exist')
+    const error = await res.json()
+    expect(error).toMatchObject({
+      status: 404,
+      statusText: 'This page does not exist',
+      data: { reason: 'missing' },
+    })
+
+    const html = await fetch('/error/not-found').then(r => r.text())
+    expect(html).toContain('This page does not exist')
+  })
+
+  it('should send the error page typed values, not stringified query params', async () => {
+    const html = await fetch('/error', { headers: { accept: 'text/html' } }).then(r => r.text())
+    const payload = html.match(/__NUXT_DATA__[^>]*>(.*?)<\/script>/s)![1]!
+    const data = JSON.parse(payload)
+    const error = data[data[1]!.error]
+
+    expect(data[error.status]).toBe(422)
+    expect(data[error.statusText]).toBe('This is a custom error')
+    // booleans stay booleans, where a query string would make them `'true'`
+    expect(data[error.fatal]).toBe(true)
+    // the signature is what `isNuxtError` checks on the error page (#29182)
+    expect(data[error.__nuxt_error]).toBe(true)
+  })
+
+  it('should keep error data structured on the error page', async () => {
+    const html = await fetch('/error/not-found', { headers: { accept: 'text/html' } }).then(r => r.text())
+    const payload = html.match(/__NUXT_DATA__[^>]*>(.*?)<\/script>/s)![1]!
+    const data = JSON.parse(payload)
+
+    const errorData = data[data[data[1]!.error].data]
+    expect(data[errorData.reason]).toBe('missing')
+  })
+
   it('should render a HTML error page', async () => {
     const res = await fetch('/error')
     expect(res.headers.get('Set-Cookie')).toBe('set-in-plugin=%22true%22; Path=/, some-error=was%20set; Path=/')

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -23,7 +23,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const clientStats = await analyzeSizes(['**/*.js'], join(rootDir, '.output/public'), rootDir)
 
     expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"106k"`)
-    expect.soft(roundToKilobytes(clientStats!.gzipBytes)).toMatchInlineSnapshot(`"39.5k"`)
+    expect.soft(roundToKilobytes(clientStats!.gzipBytes)).toMatchInlineSnapshot(`"39.4k"`)
 
     const entry = await fsp.readFile(join(rootDir, '.output/public', clientStats!.files.find(f => f.startsWith('_nuxt/entry'))!), 'utf8')
     expect(entry).not.toContain('[ofetch] global.fetch is not supported')
@@ -83,7 +83,6 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
       [
         "@unhead/vue+[...]",
         "defu",
-        "destr",
         "devalue",
         "h3+rou3+srvx",
         "nostics",
@@ -105,7 +104,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs'], serverDir, pagesRootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"347k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"348k"`)
 
     const packages = getVendorPackages(await glob(['_libs/**/*'], { cwd: serverDir }))
     expect(packages).toMatchInlineSnapshot(`

--- a/test/fixtures/basic-types/app/app-types.ts
+++ b/test/fixtures/basic-types/app/app-types.ts
@@ -234,6 +234,13 @@ describe('import meta', () => {
   })
 })
 
+describe('errors', () => {
+  it('is throwable, so `only-throw-error` is satisfied', () => {
+    const error: Error = createError({ status: 404 })
+    expectTypeOf(error).toExtend<Error>()
+  })
+})
+
 describe('middleware', () => {
   it('recognizes named middleware', () => {
     definePageMeta({ middleware: 'named' })

--- a/test/fixtures/basic/app/pages/error/not-found.vue
+++ b/test/fixtures/basic/app/pages/error/not-found.vue
@@ -1,0 +1,7 @@
+<template>
+  <div>should not render</div>
+</template>
+
+<script setup lang="ts">
+throw createError({ status: 404, statusText: 'This page does not exist', fatal: true, data: { reason: 'missing' } })
+</script>

--- a/test/fixtures/server-components/app/components/islands/ThrowingComponent.vue
+++ b/test/fixtures/server-components/app/components/islands/ThrowingComponent.vue
@@ -1,0 +1,7 @@
+<template>
+  <div>never rendered</div>
+</template>
+
+<script setup lang="ts">
+throw createError({ status: 404, statusText: 'Island not found', fatal: true })
+</script>

--- a/test/mocks/nitro-config.ts
+++ b/test/mocks/nitro-config.ts
@@ -1,1 +1,2 @@
 export const NUXT_NO_SSR = false
+export const PARSE_ERROR_DATA = true

--- a/test/nuxt/error.test.ts
+++ b/test/nuxt/error.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest'
+import { HTTPError } from 'h3'
+import { NUXT_ERROR_SIGNATURE, NuxtError, createError, isNuxtError } from '#app/composables/error'
+import { reducers } from '#app/plugins/revive-payload.server'
+import { decodeSSRError, encodeSSRError, NUXT_ERROR_SIGNATURE as nitroSignature, stringifyErrorData } from '../../packages/nitro-server/src/runtime/utils/error'
+
+const reduceNuxtError = reducers.find(([name]) => name === 'NuxtError')![1]
+
+describe('NuxtError / h3 interop', () => {
+  it('should be recognised by h3 as an HTTPError', () => {
+    const error = createError({ status: 404, statusText: 'Not Found' })
+    expect(HTTPError.isError(error)).toBe(true)
+    expect(error.name).toBe('HTTPError')
+  })
+
+  it('should expose the same fields as h3 for equivalent input', () => {
+    const inputs = [
+      { status: 404, statusText: 'Not Found', message: 'nope', data: { a: 1 } },
+      { statusCode: 418, statusMessage: 'Teapot' },
+      { status: 999 },
+      { message: 'plain' },
+      { status: 500, unhandled: true, data: { secret: true } },
+      { status: 400, body: { extra: 'field' } },
+      { statusText: 'bad\nvalue' },
+      { cause: { status: 403, statusText: 'Forbidden', message: 'from cause' } },
+    ] as const
+
+    for (const input of inputs) {
+      /* eslint-disable @typescript-eslint/no-deprecated */
+      const nuxtError = createError(input)
+      const h3Error = new HTTPError(input)
+      expect({
+        status: nuxtError.status,
+        statusText: nuxtError.statusText,
+        statusCode: nuxtError.statusCode,
+        statusMessage: nuxtError.statusMessage,
+        message: nuxtError.message,
+        data: nuxtError.data,
+        body: nuxtError.body,
+        unhandled: nuxtError.unhandled,
+        json: nuxtError.toJSON(),
+      }).toEqual({
+        status: h3Error.status,
+        statusText: h3Error.statusText,
+        statusCode: h3Error.statusCode,
+        statusMessage: h3Error.statusMessage,
+        message: h3Error.message,
+        data: h3Error.data,
+        body: h3Error.body,
+        unhandled: h3Error.unhandled,
+        json: h3Error.toJSON(),
+      })
+      /* eslint-enable @typescript-eslint/no-deprecated */
+    }
+  })
+
+  it('should default to a 500 status', () => {
+    expect(createError('boom').status).toBe(500)
+  })
+
+  it('should fall back to a 500 status where h3 yields NaN', () => {
+    expect(new HTTPError({ statusCode: 'abc' as unknown as number }).status).toBeNaN()
+    expect(createError({ statusCode: 'abc' as unknown as number }).status).toBe(500)
+  })
+
+  it('should normalise headers', () => {
+    const error = createError({ status: 400, headers: { 'x-test': '1' } })
+    expect(error.headers).toBeInstanceOf(Headers)
+    expect(error.headers!.get('x-test')).toBe('1')
+    expect(createError('boom').headers).toBeUndefined()
+  })
+
+  it('should set fatal from unhandled unless given explicitly', () => {
+    expect(createError({ status: 500, unhandled: true }).fatal).toBe(true)
+    expect(createError({ status: 500 }).fatal).toBe(false)
+    expect(createError({ status: 500, fatal: true }).fatal).toBe(true)
+    expect(createError({ status: 500, unhandled: true, fatal: false }).fatal).toBe(false)
+  })
+
+  it('should keep the original error as `cause`', () => {
+    const cause = new Error('original')
+    const error = createError(cause)
+    expect(error.cause).toBe(cause)
+    expect(error.message).toBe('original')
+  })
+
+  it('should return existing nuxt errors unchanged', () => {
+    const error = createError({ status: 404 })
+    expect(createError(error)).toBe(error)
+  })
+
+  it('should not identify h3 errors as nuxt errors', () => {
+    expect(isNuxtError(new HTTPError({ status: 404 }))).toBe(false)
+    expect(isNuxtError(createError({ status: 404 }))).toBe(true)
+  })
+
+  // `toJSON` is what Nitro's default handler turns into the HTTP error body, so
+  // anything added here ends up in the JSON every Nuxt app returns to API
+  // clients. Nuxt-only state belongs in the payload reducer instead.
+  it('should keep `toJSON` free of nuxt internals', () => {
+    const error = createError({ status: 404, statusText: 'Not Found', fatal: true })
+    expect(Object.keys(error.toJSON())).toEqual(['status', 'statusText', 'unhandled', 'message', 'data'])
+  })
+
+  it('should survive a payload round trip', () => {
+    const error = createError({ status: 404, statusText: 'Not Found', message: 'missing', data: { id: 1 } })
+    const revived = createError(JSON.parse(JSON.stringify(reduceNuxtError(error))))
+    expect(revived.status).toBe(404)
+    expect(revived.statusText).toBe('Not Found')
+    expect(revived.message).toBe('missing')
+    expect(revived.data).toEqual({ id: 1 })
+    expect(revived.fatal).toBe(false)
+    expect(isNuxtError(revived)).toBe(true)
+  })
+
+  it('should preserve `fatal` across a payload round trip', () => {
+    const error = createError({ status: 404, message: 'missing', fatal: true })
+    const revived = createError(JSON.parse(JSON.stringify(reduceNuxtError(error))))
+    expect(revived.fatal).toBe(true)
+    expect(revived.unhandled).toBeUndefined()
+  })
+
+  it('should hide details of unhandled errors across a payload round trip', () => {
+    const error = createError({ status: 500, message: 'secret', data: { secret: true }, unhandled: true })
+    const revived = createError(JSON.parse(JSON.stringify(reduceNuxtError(error))))
+    expect(revived.message).toBe('HTTPError')
+    expect(revived.data).toBeUndefined()
+    expect(revived.unhandled).toBe(true)
+    expect(revived.fatal).toBe(true)
+  })
+
+  it('should be constructible directly with either signature', () => {
+    expect(new NuxtError('boom', { status: 400 }).status).toBe(400)
+    expect(new NuxtError({ status: 400, message: 'boom' }).message).toBe('boom')
+  })
+})
+
+describe('error signature', () => {
+  it('should match the copy the nitro error handler sends', () => {
+    expect(nitroSignature).toBe(NUXT_ERROR_SIGNATURE)
+  })
+})
+
+describe('ssr error encoding', () => {
+  it('should drop unserialisable data rather than throw', () => {
+    const data: Record<string, unknown> = { name: 'node' }
+    data.self = data
+
+    const encoded = encodeSSRError({ status: 500, message: 'boom', url: '/', data } as any)
+    expect(JSON.parse(encoded)).toMatchObject({ status: 500, message: 'boom' })
+    expect(JSON.parse(encoded).data).toBeUndefined()
+  })
+
+  it('should fall back to an empty object when nothing serialises', () => {
+    const error = { status: 500, url: '/', get message (): string { throw new Error('boom') } }
+    expect(encodeSSRError(error as any)).toBe('{}')
+  })
+})
+
+describe('experimental.parseErrorData compatibility', () => {
+  it('should stringify structured `data` and leave everything else alone', () => {
+    expect(stringifyErrorData({ reason: 'missing' })).toBe('{"reason":"missing"}')
+    expect(stringifyErrorData([1, 2])).toBe('[1,2]')
+    expect(stringifyErrorData('plain')).toBe('plain')
+    expect(stringifyErrorData(undefined)).toBeUndefined()
+  })
+
+  it('should not touch `data` when decoding', () => {
+    const encoded = JSON.stringify({ status: 500, data: { reason: 'missing' } })
+
+    expect(decodeSSRError(encoded)!.data).toEqual({ reason: 'missing' })
+  })
+})

--- a/test/server-components.test.ts
+++ b/test/server-components.test.ts
@@ -604,6 +604,15 @@ describe('hash binding', () => {
     expect(res.status).toBe(400)
   })
 
+  it('maps a nuxt error thrown inside an island to its HTTP status', async () => {
+    const res = await fetch(islandURL('ThrowingComponent'))
+    expect(res.status).toBe(404)
+    expect(await res.json()).toMatchObject({
+      status: 404,
+      statusText: 'Island not found',
+    })
+  })
+
   it('rejects a request with a fabricated hash', async () => {
     const res = await fetch(withQuery('/__nuxt_island/PureComponent_deadbeefcafef00d.json', {
       props: JSON.stringify({ bool: false, number: 1, str: 's', obj: {} }),


### PR DESCRIPTION
### 🔗 Linked issue

resolves #29182
closes #34056
closes #35702

### 📚 Description

for a while, we borrowed the h3 `createError` which makes sense because we want errors thrown by nuxt pages to integrate with nitro's error handling

however, there were a couple of issues with this - it tied the _nuxt app_ too closely with nitro; we've wanted these two different scopes to be separated a little bit more. and there's also a huge performance cost; vite has to process/transform the entirety of h3 + its dependencies in dev mode, even though these are tree-shaken at build time.

this preserves the key signature of nitro's `createError` while handling it separately.