### PR TITLE
perf(nuxt): extract serializable `definePageMeta` keys at build time

### DIFF
--- a/docs/3.guide/6.going-further/1.experimental-features.md
+++ b/docs/3.guide/6.going-further/1.experimental-features.md
@@ -571,6 +571,33 @@ export default defineNuxtConfig({
 
 This allows modules to access additional metadata from the page metadata in the build context. If you are using this within a module, it's recommended also to [augment the `NuxtPage` types with your keys](/docs/4.x/directory-structure/app/pages#typing-custom-metadata).
 
+## extractSerializablePageMeta
+
+Enabled by default when `future.compatibilityVersion` is `5` or higher.
+
+By default Nuxt only reads a fixed list of `definePageMeta()` keys at build time (plus anything in `extraPageMetaExtractionKeys`); everything else is resolved at runtime from a separate module generated per page. With this option Nuxt writes every JSON-serializable property straight into the generated route record instead.
+
+When every property of a page's `definePageMeta()` can be resolved statically, the route no longer imports that page's meta module at all, which removes one module per page from the dev module graph.
+
+```vue
+<script lang="ts" setup>
+definePageMeta({
+  layout: { name: 'admin', props: { collapsed: true } },
+  title: 'Dashboard',
+})
+</script>
+```
+
+Properties whose values cannot be serialized (functions, variable references, spreads, computed keys) are unaffected and still resolved at runtime.
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  experimental: {
+    extractSerializablePageMeta: false,
+  },
+})
+```
+
 ## navigationRepaint
 
 Wait for a single animation frame before navigation, which gives an opportunity for the browser to repaint, acknowledging user interaction.

--- a/docs/3.guide/6.going-further/1.experimental-features.md
+++ b/docs/3.guide/6.going-further/1.experimental-features.md
@@ -590,6 +590,8 @@ definePageMeta({
 
 Properties whose values cannot be serialized (functions, variable references, spreads, computed keys) are unaffected and still resolved at runtime.
 
+This has no effect when [`scanPageMeta`](#scanpagemeta) is `false`, as the route record does not override the meta module in that case.
+
 ```ts twoslash [nuxt.config.ts]
 export default defineNuxtConfig({
   experimental: {

--- a/docs/3.guide/6.going-further/1.experimental-features.md
+++ b/docs/3.guide/6.going-further/1.experimental-features.md
@@ -575,7 +575,7 @@ This allows modules to access additional metadata from the page metadata in the 
 
 Enabled by default when `future.compatibilityVersion` is `5` or higher.
 
-By default Nuxt only reads a fixed list of `definePageMeta()` keys at build time (plus anything in `extraPageMetaExtractionKeys`); everything else is resolved at runtime from a separate module generated per page. With this option Nuxt writes every JSON-serializable property straight into the generated route record instead.
+By default, Nuxt only reads a fixed list of `definePageMeta()` keys at build time (plus anything in `extraPageMetaExtractionKeys`); everything else is resolved at runtime from a separate module generated per page. With this option, Nuxt writes every JSON-serializable property straight into the generated route record instead.
 
 When every property of a page's `definePageMeta()` can be resolved statically, the route no longer imports that page's meta module at all, which removes one module per page from the dev module graph.
 

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -13,7 +13,7 @@ import { distDir } from '../dirs.ts'
 import { linkToAlias, logger } from '../utils.ts'
 import picomatch from 'picomatch'
 import { rou3PatternToURLPattern } from 'unrouting'
-import { resolvePagesRoutes as _resolvePagesRoutes, augmentAndResolve, createPagesContext, normalizeRoutes, relativizeToParent, resolvePageMetaExtractionKeys, resolveRoutePaths, toRou3Patterns } from './utils.ts'
+import { resolvePagesRoutes as _resolvePagesRoutes, augmentAndResolve, createPagesContext, normalizeRoutes, relativizeToParent, resolvePageMetaExtractionKeys, resolveRoutePaths, shouldExtractSerializablePageMeta, toRou3Patterns } from './utils.ts'
 import type { PagesContext } from './utils.ts'
 import { globRouteRulesFromPages, removePagesRules } from './route-rules.ts'
 import { markPagesCoveredByRouteRule } from './route-coverage.ts'
@@ -678,7 +678,7 @@ export default defineNuxtModule({
         isPage,
         routesId: toVirtualId(resolve(nuxt.options.buildDir, 'routes.mjs'), nuxt),
         extractedKeys: nuxt.options.experimental.scanPageMeta ? extractedKeys : [],
-        extractSerializable: !!nuxt.options.experimental.scanPageMeta && !!nuxt.options.experimental.extractSerializablePageMeta,
+        extractSerializable: shouldExtractSerializablePageMeta(nuxt),
       }))
     })
 

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -678,6 +678,7 @@ export default defineNuxtModule({
         isPage,
         routesId: toVirtualId(resolve(nuxt.options.buildDir, 'routes.mjs'), nuxt),
         extractedKeys: nuxt.options.experimental.scanPageMeta ? extractedKeys : [],
+        extractSerializable: !!nuxt.options.experimental.scanPageMeta && !!nuxt.options.experimental.extractSerializablePageMeta,
       }))
     })
 

--- a/packages/nuxt/src/pages/plugins/page-meta.ts
+++ b/packages/nuxt/src/pages/plugins/page-meta.ts
@@ -17,6 +17,7 @@ interface PageMetaPluginOptions {
   isPage?: (file: string) => boolean
   routesId?: string
   extractedKeys?: string[]
+  extractSerializable?: boolean
 }
 
 const HAS_MACRO_RE = /\bdefinePageMeta\s*\(\s*/
@@ -47,6 +48,7 @@ if (import.meta.webpackHot) {
 
 export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnplugin(() => {
   const extractedKeys = new Set(options.extractedKeys)
+  const classifyOptions = { extractSerializable: options.extractSerializable }
 
   return {
     name: 'nuxt:pages-macros-transform',
@@ -252,10 +254,10 @@ export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnp
 
               for (let i = 0; i < meta.properties.length; i++) {
                 const prop = meta.properties[i]!
-                const classification = classifyPageMetaProperty(prop, extractedKeys)
+                const classification = classifyPageMetaProperty(prop, extractedKeys, classifyOptions)
 
                 // The route record now carries the value, so drop it here to keep the two in step.
-                if (classification.kind === 'extract') {
+                if (classification.kind === 'extract' || (classification.kind === 'reshape' && classification.value)) {
                   omitProp(prop, i)
                   continue
                 }

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -133,6 +133,7 @@ export async function augmentAndResolve (pages: NuxtPage[], trackedFiles: Set<st
       'middleware',
       ...extraPageMetaExtractionKeys,
     ]),
+    extractSerializable: !!nuxt.options.experimental.extractSerializablePageMeta,
     fullyResolvedPaths: trackedFiles,
     originalPagePaths,
   }
@@ -156,6 +157,7 @@ interface AugmentPagesContext {
   pagesToSkip?: Set<string>
   augmentedPages?: Set<string>
   extraExtractionKeys?: Set<string>
+  extractSerializable?: boolean
   originalPagePaths?: WeakMap<NuxtPage, string>
 }
 
@@ -164,7 +166,7 @@ export async function augmentPages (routes: NuxtPage[], vfs: Record<string, stri
   for (const route of routes) {
     if (route.file && !ctx.pagesToSkip?.has(route.file)) {
       const fileContent = vfs[route.file] ?? fs.readFileSync(ctx.fullyResolvedPaths?.has(route.file) ? route.file : await resolvePath(route.file), 'utf-8')
-      const routeMeta = getRouteMeta(fileContent, route.file, ctx.extraExtractionKeys)
+      const routeMeta = getRouteMeta(fileContent, route.file, ctx.extraExtractionKeys, { extractSerializable: ctx.extractSerializable })
       if (route.meta) {
         routeMeta.meta = defu({}, routeMeta.meta, route.meta)
       }
@@ -258,16 +260,25 @@ export function resolvePageMetaExtractionKeys (extraKeys: Iterable<string> = [])
  * - `dynamic` - an extracted key whose value needs evaluating, so that one route field falls back
  *   to the macro module.
  * - `reshape` - the macro transform rewrites the property into keys the route record cannot
- *   express (`layout: { name, props }` becomes `layout` plus `layoutProps`), so the macro module
- *   resolves it.
+ *   express (`layout: { name, props }` becomes `layout` plus `layoutProps`). A `value` means the
+ *   reshaped keys are statically known, so the route record owns them; without one the macro
+ *   module resolves it.
  * - `runtime` - the property is not extracted at all, so the whole meta object falls back to the
  *   macro module.
  */
 export type PageMetaProperty =
   | { kind: 'extract', key: string, value: any }
   | { kind: 'dynamic', key: string }
-  | { kind: 'reshape', key: string, node: ESTree.ObjectExpression }
+  | { kind: 'reshape', key: string, node: ESTree.ObjectExpression, value?: { name: any, props?: any } }
   | { kind: 'runtime' }
+
+export interface ClassifyPageMetaOptions {
+  /**
+   * Extract any JSON-serializable property, not just the keys in `extractionKeys`. Properties
+   * whose values cannot be serialized still fall back to the macro module.
+   */
+  extractSerializable?: boolean
+}
 
 /**
  * Classify a property of a `definePageMeta` object literal.
@@ -276,7 +287,7 @@ export type PageMetaProperty =
  * record, and vice versa, or its value is lost. Both sides call this so that the two cannot
  * drift apart.
  */
-export function classifyPageMetaProperty (property: ESTree.ObjectPropertyKind, extractionKeys: ReadonlySet<string>): PageMetaProperty {
+export function classifyPageMetaProperty (property: ESTree.ObjectPropertyKind, extractionKeys: ReadonlySet<string>, options: ClassifyPageMetaOptions = {}): PageMetaProperty {
   // Spreads, computed keys, getters and methods cannot be resolved without evaluating the module.
   if (property.type !== 'Property' || property.computed || property.kind !== 'init' || property.method) {
     return { kind: 'runtime' }
@@ -300,34 +311,56 @@ export function classifyPageMetaProperty (property: ESTree.ObjectPropertyKind, e
       subProperty.type === 'Property' && !subProperty.computed && subProperty.kind === 'init' && !subProperty.method
       && subProperty.key.type === 'Identifier' && (subProperty.key.name === 'name' || subProperty.key.name === 'props'),
     )
-    return reshapable ? { kind: 'reshape', key, node: value } : { kind: 'runtime' }
+    if (!reshapable) {
+      return { kind: 'runtime' }
+    }
+    if (options.extractSerializable) {
+      const serialized = isSerializable(value)
+      // Without a `name` there is no `layout` key to write, and a route record cannot express
+      // `layoutProps` on its own, so leave the whole object to the macro module.
+      if (serialized.serializable && serialized.value && 'name' in serialized.value) {
+        return { kind: 'reshape', key, node: value, value: serialized.value }
+      }
+    }
+    return { kind: 'reshape', key, node: value }
   }
 
-  if (!extractionKeys.has(key)) {
+  const isExtractionKey = extractionKeys.has(key)
+  if (!isExtractionKey && !options.extractSerializable) {
     return { kind: 'runtime' }
   }
 
   const serialized = isSerializable(property.value)
-  return serialized.serializable ? { kind: 'extract', key, value: serialized.value } : { kind: 'dynamic', key }
+  if (serialized.serializable) {
+    return { kind: 'extract', key, value: serialized.value }
+  }
+  // An unlisted key has no route field of its own to fall back to, so the whole meta object has
+  // to come from the macro module.
+  return isExtractionKey ? { kind: 'dynamic', key } : { kind: 'runtime' }
 }
 
+const SERIALIZABLE_CACHE_SUFFIX = '\0serializable'
 const pageContentsCache: Record<string, string> = {}
 const extractCache: Record<string, Partial<Record<keyof NuxtPage, any>>> = {}
-export function getRouteMeta (contents: string, absolutePath: string, extraExtractionKeys: Set<string> = new Set()): Partial<Record<keyof NuxtPage, any>> {
+export function getRouteMeta (contents: string, absolutePath: string, extraExtractionKeys: Set<string> = new Set(), options: ClassifyPageMetaOptions = {}): Partial<Record<keyof NuxtPage, any>> {
+  // The extracted metadata differs between the two extraction modes, but the file contents do not.
+  const cacheKey = options.extractSerializable ? absolutePath + SERIALIZABLE_CACHE_SUFFIX : absolutePath
+
   // set/update pageContentsCache, invalidate extractCache on cache mismatch
   if (!(absolutePath in pageContentsCache) || pageContentsCache[absolutePath] !== contents) {
     pageContentsCache[absolutePath] = contents
     delete extractCache[absolutePath]
+    delete extractCache[absolutePath + SERIALIZABLE_CACHE_SUFFIX]
   }
 
-  if (absolutePath in extractCache && extractCache[absolutePath]) {
-    return klona(extractCache[absolutePath])
+  if (cacheKey in extractCache && extractCache[cacheKey]) {
+    return klona(extractCache[cacheKey])
   }
 
   const loader = getLoader(absolutePath)
   const scriptBlocks = !loader ? null : loader === 'vue' ? extractScriptContent(contents) : [{ code: contents, loader, offset: 0 }]
   if (!scriptBlocks) {
-    extractCache[absolutePath] = {}
+    extractCache[cacheKey] = {}
     return {}
   }
 
@@ -394,12 +427,12 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
         continue
       }
 
-      const classified = new Map<string, Extract<PageMetaProperty, { kind: 'extract' | 'dynamic' }>>()
+      const classified = new Map<string, Extract<PageMetaProperty, { kind: 'extract' | 'dynamic' | 'reshape' }>>()
       let hasRuntimeProperty = false
 
       for (const property of argument.properties) {
-        const classification = classifyPageMetaProperty(property, extractionKeys)
-        if (classification.kind === 'extract' || classification.kind === 'dynamic') {
+        const classification = classifyPageMetaProperty(property, extractionKeys, options)
+        if (classification.kind === 'extract' || classification.kind === 'dynamic' || (classification.kind === 'reshape' && classification.value)) {
           // A duplicate key keeps its last occurrence, mirroring object-literal evaluation.
           classified.set(classification.key, classification)
           continue
@@ -411,7 +444,7 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
       // independent of the order they were written in.
       for (const key of extractionKeys) {
         const classification = classified.get(key)
-        if (!classification) { continue }
+        if (!classification || classification.kind === 'reshape') { continue }
 
         if (classification.kind === 'dynamic') {
           logger.debug(`Skipping extraction of \`${key}\` metadata as it is not JSON-serializable (reading \`${fileAt(script.offset + node.start)}\`).`)
@@ -427,6 +460,21 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
         }
       }
 
+      // Keys with no route field of their own keep the order they were written in.
+      for (const [key, classification] of classified) {
+        if (classification.kind === 'reshape') {
+          extractedData.meta ??= {}
+          extractedData.meta.layout = classification.value!.name
+          if (classification.value!.props !== undefined) {
+            extractedData.meta.layoutProps = classification.value!.props
+          }
+          continue
+        }
+        if (extractionKeys.has(key) || classification.kind !== 'extract') { continue }
+        extractedData.meta ??= {}
+        extractedData.meta[key] = classification.value
+      }
+
       if (hasRuntimeProperty) {
         dynamicProperties.add('meta')
       }
@@ -438,7 +486,7 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
     extractedData.meta[DYNAMIC_META_KEY] = dynamicProperties
   }
 
-  extractCache[absolutePath] = extractedData
+  extractCache[cacheKey] = extractedData
   return klona(extractedData)
 }
 

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -368,6 +368,8 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
   const fileAt = (offset: number) => linkToAlias(absolutePath, undefined, offsetToPosition(contents, offset))
 
   const extractionKeys = resolvePageMetaExtractionKeys(extraExtractionKeys)
+  // Widened for lookups by a property name that may not be a route field at all.
+  const routeFieldKeys: ReadonlySet<string> = extractionKeys
   const dynamicProperties = new Set<keyof NuxtPage>()
 
   for (const script of scriptBlocks) {
@@ -470,7 +472,7 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
           }
           continue
         }
-        if (extractionKeys.has(key) || classification.kind !== 'extract') { continue }
+        if (routeFieldKeys.has(key) || classification.kind !== 'extract') { continue }
         extractedData.meta ??= {}
         extractedData.meta[key] = classification.value
       }

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -118,6 +118,17 @@ export async function resolvePagesRoutes (pattern: string | string[], nuxt = use
 // augmentAndResolve — downstream pipeline (augmentation + hooks)
 // ---------------------------------------------------------------------------
 
+/**
+ * Whether serializable page meta is written into the route record.
+ *
+ * The macro transform and route augmentation both have to agree on this, and neither can
+ * extract when page meta is not scanned at all: the route record does not override the macro
+ * module in that case, so extracting would duplicate the values rather than replace them.
+ */
+export function shouldExtractSerializablePageMeta (nuxt = useNuxt()): boolean {
+  return !!nuxt.options.experimental.scanPageMeta && !!nuxt.options.experimental.extractSerializablePageMeta
+}
+
 export async function augmentAndResolve (pages: NuxtPage[], trackedFiles: Set<string>, nuxt = useNuxt(), originalPagePaths?: WeakMap<NuxtPage, string>): Promise<NuxtPage[]> {
   const shouldAugment = nuxt.options.experimental.scanPageMeta || nuxt.options.experimental.typedPages
 
@@ -133,7 +144,7 @@ export async function augmentAndResolve (pages: NuxtPage[], trackedFiles: Set<st
       'middleware',
       ...extraPageMetaExtractionKeys,
     ]),
-    extractSerializable: !!nuxt.options.experimental.extractSerializablePageMeta,
+    extractSerializable: shouldExtractSerializablePageMeta(nuxt),
     fullyResolvedPaths: trackedFiles,
     originalPagePaths,
   }

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -6,7 +6,7 @@ import { klona } from 'klona'
 import { parse as toAst } from 'acorn'
 
 import { PageMetaPlugin } from '../src/pages/plugins/page-meta.ts'
-import { augmentPages, defaultExtractionKeys, getRouteMeta, normalizeRoutes } from '../src/pages/utils.ts'
+import { augmentPages, defaultExtractionKeys, getRouteMeta, normalizeRoutes, shouldExtractSerializablePageMeta } from '../src/pages/utils.ts'
 import type { NuxtPage } from '../schema.ts'
 
 const filePath = '/app/pages/index.vue'
@@ -580,6 +580,23 @@ describe('page metadata macro position', () => {
     `, '/app/pages/nested.vue')
 
     expect(warn).toHaveBeenCalledWith({ fnName: 'defineRouteRules', file: expect.stringMatching(/app\/pages\/nested\.vue:4:7$/) })
+  })
+})
+
+describe('shouldExtractSerializablePageMeta', () => {
+  const nuxt = (experimental: Record<string, unknown>) => ({ options: { experimental } }) as any
+
+  it.each([
+    { scanPageMeta: 'after-resolve', extractSerializablePageMeta: true, expected: true },
+    { scanPageMeta: true, extractSerializablePageMeta: true, expected: true },
+    { scanPageMeta: 'after-resolve', extractSerializablePageMeta: false, expected: false },
+    // `typedPages` still augments pages when meta is not scanned, but the route record does not
+    // override the macro module then, so extracting would duplicate values rather than replace
+    // them, and would leak extra keys into the generated route types.
+    { scanPageMeta: false, extractSerializablePageMeta: true, expected: false },
+    { scanPageMeta: false, extractSerializablePageMeta: false, expected: false },
+  ])('$scanPageMeta + $extractSerializablePageMeta -> $expected', ({ expected, ...experimental }) => {
+    expect(shouldExtractSerializablePageMeta(nuxt(experimental))).toBe(expected)
   })
 })
 

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -1347,4 +1347,265 @@ definePageMeta({ get name () { return 'from-getter' } })
       })
     })
   })
+
+  describe('extractSerializablePageMeta', () => {
+    const options = { extractSerializable: true }
+    let fileCounter = 0
+
+    function extract (sfc: string, extraExtractionKeys = new Set<string>()) {
+      return getRouteMeta(sfc, `/app/pages/serializable-${fileCounter++}.vue`, extraExtractionKeys, options)
+    }
+
+    function macroModule (sfc: string, extractedKeys: string[] = [...defaultExtractionKeys]) {
+      const plugin = PageMetaPlugin({ extractedKeys, extractSerializable: true }).raw({}, {} as any) as { transform: { handler: (code: string, id: string) => { code: string } | null } }
+      const res = compileScript(parse(sfc).descriptor, { id: 'component.vue' })
+      return plugin.transform.handler(res.content, 'component.vue?macro=true')?.code
+    }
+
+    it('should extract an unlisted serializable key into route meta', () => {
+      const sfc = `
+<script setup lang="ts">
+definePageMeta({ title: 'hello', order: -2, tags: ['a', 'b'], nested: { deep: true } })
+</script>
+      `
+      expect(extract(sfc)).toEqual({
+        meta: { title: 'hello', order: -2, tags: ['a', 'b'], nested: { deep: true } },
+      })
+      const macro = macroModule(sfc)
+      expect(macro).not.toContain('hello')
+      expect(macro).toContain('const __nuxt_page_meta = {')
+    })
+
+    it('should fall back to the macro module for an unlisted key that is not serializable', () => {
+      const sfc = `
+<script setup lang="ts">
+definePageMeta({ title: 'hello', validate: () => true })
+</script>
+      `
+      expect(extract(sfc)).toEqual({
+        meta: { title: 'hello', __nuxt_dynamic_meta_key: new Set(['meta']) },
+      })
+      expect(macroModule(sfc)).toContain('validate')
+    })
+
+    it('should still mark a listed key as dynamic rather than runtime', () => {
+      const sfc = `
+<script setup lang="ts">
+definePageMeta({ path: ref('/dynamic') })
+</script>
+      `
+      expect(extract(sfc)).toEqual({
+        meta: { __nuxt_dynamic_meta_key: new Set(['path']) },
+      })
+      expect(macroModule(sfc)).toContain('ref(\'/dynamic\')')
+    })
+
+    it('should keep the last occurrence of a duplicate unlisted key', () => {
+      const sfc = `
+<script setup lang="ts">
+definePageMeta({ title: 'first', title: 'last' })
+</script>
+      `
+      expect(extract(sfc)).toEqual({ meta: { title: 'last' } })
+      const macro = macroModule(sfc)
+      expect(macro).not.toContain('first')
+      expect(macro).not.toContain('last')
+    })
+
+    it('should key the extraction cache on the flag', () => {
+      const sfc = `<script setup lang="ts">definePageMeta({ title: 'hello' })</script>`
+      const path = '/app/pages/cache-key.vue'
+      expect(getRouteMeta(sfc, path, new Set(), options)).toEqual({ meta: { title: 'hello' } })
+      expect(getRouteMeta(sfc, path)).toEqual({
+        meta: { __nuxt_dynamic_meta_key: new Set(['meta']) },
+      })
+    })
+
+    it('should invalidate both extraction modes when contents change', () => {
+      const path = '/app/pages/cache-invalidation.vue'
+      getRouteMeta(`<script setup lang="ts">definePageMeta({ title: 'hello' })</script>`, path, new Set(), options)
+      getRouteMeta(`<script setup lang="ts">definePageMeta({ title: 'hello' })</script>`, path)
+
+      const updated = `<script setup lang="ts">definePageMeta({ title: 'goodbye' })</script>`
+      expect(getRouteMeta(updated, path, new Set(), options)).toEqual({ meta: { title: 'goodbye' } })
+      expect(getRouteMeta(updated, path)).toEqual({
+        meta: { __nuxt_dynamic_meta_key: new Set(['meta']) },
+      })
+    })
+
+    describe('layout reshapes', () => {
+      it('should extract a string layout', () => {
+        const sfc = `
+<script setup lang="ts">
+definePageMeta({ layout: 'dark' })
+</script>
+        `
+        expect(extract(sfc)).toEqual({ meta: { layout: 'dark' } })
+        expect(macroModule(sfc)).not.toContain('dark')
+      })
+
+      it('should extract `layout: false`', () => {
+        const sfc = `
+<script setup lang="ts">
+definePageMeta({ layout: false })
+</script>
+        `
+        expect(extract(sfc)).toEqual({ meta: { layout: false } })
+        expect(macroModule(sfc)).not.toContain('layout')
+      })
+
+      it('should split `{ name }` into `layout`', () => {
+        const sfc = `
+<script setup lang="ts">
+definePageMeta({ layout: { name: 'admin' } })
+</script>
+        `
+        expect(extract(sfc)).toEqual({ meta: { layout: 'admin' } })
+        const macro = macroModule(sfc)
+        expect(macro).not.toContain('admin')
+        expect(macro).not.toContain('layoutProps')
+      })
+
+      it('should split `{ name, props }` into `layout` and `layoutProps`', () => {
+        const sfc = `
+<script setup lang="ts">
+definePageMeta({ layout: { name: 'admin', props: { collapsed: true } } })
+</script>
+        `
+        expect(extract(sfc)).toEqual({ meta: { layout: 'admin', layoutProps: { collapsed: true } } })
+        const macro = macroModule(sfc)
+        expect(macro).not.toContain('admin')
+        expect(macro).not.toContain('collapsed')
+      })
+
+      it('should unwrap a statically wrapped layout object', () => {
+        const sfc = `
+<script setup lang="ts">
+definePageMeta({ layout: { name: 'admin', props: { collapsed: true } } as const })
+</script>
+        `
+        expect(extract(sfc)).toEqual({ meta: { layout: 'admin', layoutProps: { collapsed: true } } })
+        expect(macroModule(sfc)).not.toContain('admin')
+      })
+
+      it('should leave `{ props }` without a name to the macro module', () => {
+        const sfc = `
+<script setup lang="ts">
+definePageMeta({ layout: { props: { collapsed: true } } })
+</script>
+        `
+        expect(extract(sfc)).toEqual({ meta: { __nuxt_dynamic_meta_key: new Set(['meta']) } })
+        const macro = macroModule(sfc)
+        expect(macro).toContain('layoutProps: { collapsed: true }')
+        expect(macro).not.toContain('layout:')
+      })
+
+      it('should leave an empty layout object to the macro module', () => {
+        const sfc = `
+<script setup lang="ts">
+definePageMeta({ layout: {} })
+</script>
+        `
+        expect(extract(sfc)).toEqual({ meta: { __nuxt_dynamic_meta_key: new Set(['meta']) } })
+      })
+
+      it('should leave a non-serializable layout name to the macro module', () => {
+        const sfc = `
+<script setup lang="ts">
+const layoutName = 'admin'
+definePageMeta({ layout: { name: layoutName } })
+</script>
+        `
+        expect(extract(sfc)).toEqual({ meta: { __nuxt_dynamic_meta_key: new Set(['meta']) } })
+        expect(macroModule(sfc)).toContain('layout: layoutName')
+      })
+
+      it('should leave non-serializable layout props to the macro module', () => {
+        const sfc = `
+<script setup lang="ts">
+definePageMeta({ layout: { name: 'admin', props: { onClick: () => {} } } })
+</script>
+        `
+        expect(extract(sfc)).toEqual({ meta: { __nuxt_dynamic_meta_key: new Set(['meta']) } })
+        const macro = macroModule(sfc)
+        expect(macro).toContain('layout: \'admin\'')
+        expect(macro).toContain('layoutProps: { onClick: () => {} }')
+      })
+
+      it('should leave a spread layout object to the macro module', () => {
+        const sfc = `
+<script setup lang="ts">
+const shared = { name: 'admin' }
+definePageMeta({ layout: { ...shared } })
+</script>
+        `
+        expect(extract(sfc)).toEqual({ meta: { __nuxt_dynamic_meta_key: new Set(['meta']) } })
+        expect(macroModule(sfc)).toContain('...shared')
+      })
+
+      it('should leave a layout object with unknown keys to the macro module', () => {
+        const sfc = `
+<script setup lang="ts">
+definePageMeta({ layout: { name: 'admin', other: 1 } })
+</script>
+        `
+        expect(extract(sfc)).toEqual({ meta: { __nuxt_dynamic_meta_key: new Set(['meta']) } })
+        expect(macroModule(sfc)).toContain('other: 1')
+      })
+
+      it('should keep the last occurrence when a string layout follows an object layout', () => {
+        const sfc = `
+<script setup lang="ts">
+definePageMeta({ layout: { name: 'admin', props: { collapsed: true } }, layout: 'dark' })
+</script>
+        `
+        expect(extract(sfc)).toEqual({ meta: { layout: 'dark' } })
+        const macro = macroModule(sfc)
+        expect(macro).not.toContain('admin')
+        expect(macro).not.toContain('dark')
+      })
+
+      it('should reshape into meta when `layout` is also an extraction key', () => {
+        const sfc = `
+<script setup lang="ts">
+definePageMeta({ layout: { name: 'admin', props: { collapsed: true } } })
+</script>
+        `
+        expect(extract(sfc, new Set(['layout']))).toEqual({
+          meta: { layout: 'admin', layoutProps: { collapsed: true } },
+        })
+        expect(macroModule(sfc, [...defaultExtractionKeys, 'layout'])).not.toContain('admin')
+      })
+    })
+
+    it('should not import the macro module when every key is serializable', () => {
+      const page: NuxtPage = { path: '/', file: filePath }
+      Object.assign(page, getRouteMeta(`
+      <script setup>
+      definePageMeta({
+        name: 'some-custom-name',
+        layout: { name: 'admin', props: { collapsed: true } },
+        title: 'hello',
+      })
+      </script>
+      `, filePath, new Set(), options))
+
+      const { routes, imports } = normalizeRoutes([page], new Set(), {
+        clientComponentRuntime: '<client-component-runtime>',
+        serverComponentRuntime: '<server-component-runtime>',
+        overrideMeta: true,
+      })
+      expect(imports).toEqual(new Set())
+      expect(routes).toMatchInlineSnapshot(`
+        "[
+          {
+            name: "some-custom-name",
+            path: "/",
+            meta: {"layout":"admin","layoutProps":{"collapsed":true},"title":"hello"},
+            component: () => import("/app/pages/index.vue")
+          }
+        ]"
+      `)
+    })
+  })
 })

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -168,6 +168,11 @@ export default defineResolvers({
       },
     },
     extraPageMetaExtractionKeys: [],
+    extractSerializablePageMeta: {
+      async $resolve (val, get) {
+        return typeof val === 'boolean' ? val : (await get('future.compatibilityVersion')) >= 5
+      },
+    },
     sharedPrerenderData: {
       $resolve (val) {
         return typeof val === 'boolean' ? val : true

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1301,6 +1301,19 @@ export interface ConfigSchema {
     extraPageMetaExtractionKeys: string[]
 
     /**
+     * Extract every JSON-serializable `definePageMeta` property into the generated route record,
+     * rather than only the keys Nuxt reads at build time.
+     *
+     * When every property of a page's `definePageMeta` can be resolved statically, the generated
+     * route no longer imports the page's macro module at all, removing one module per page from
+     * the dev module graph. Properties whose values cannot be serialized are unaffected and are
+     * still resolved by the macro module at runtime.
+     *
+     * @default true
+     */
+    extractSerializablePageMeta: boolean
+
+    /**
      * Automatically share payload _data_ between pages that are prerendered. This can result in a significant performance improvement when prerendering sites that use `useAsyncData` or `useFetch` and fetch the same data in different pages.
      *
      * It is particularly important when enabling this feature to make sure that any unique key of your data is always resolvable to the same data. For example, if you are using `useAsyncData` to fetch data related to a particular page, you should provide a key that uniquely matches that data. (`useFetch` should do this automatically for you.)

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1309,7 +1309,8 @@ export interface ConfigSchema {
      * the dev module graph. Properties whose values cannot be serialized are unaffected and are
      * still resolved by the macro module at runtime.
      *
-     * @default true
+     * @default false
+     * @default true with compatibilityVersion >= 5
      */
     extractSerializablePageMeta: boolean
 

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1309,6 +1309,9 @@ export interface ConfigSchema {
      * the dev module graph. Properties whose values cannot be serialized are unaffected and are
      * still resolved by the macro module at runtime.
      *
+     * This has no effect when `experimental.scanPageMeta` is `false`, as the route record does
+     * not override the macro module in that case.
+     *
      * @default false
      * @default true with compatibilityVersion >= 5
      */

--- a/test/e2e/hmr.test.ts
+++ b/test/e2e/hmr.test.ts
@@ -192,6 +192,8 @@ test.describe('vite-only HMR tests', () => {
     await expect(page.getByTestId('meta')).toHaveText(JSON.stringify({ some: 'final stuff' }, null, 2))
 
     write(`some: 'stuff'`)
+    await expect(page.getByTestId('meta')).toHaveText(JSON.stringify({ some: 'stuff' }, null, 2))
+
     expect(page).toHaveNoErrorsOrWarnings()
   })
 

--- a/test/e2e/hmr.test.ts
+++ b/test/e2e/hmr.test.ts
@@ -174,6 +174,27 @@ test.describe('vite-only HMR tests', () => {
     expect(page).toHaveNoErrorsOrWarnings()
   })
 
+  test('HMR for page meta crossing the static extraction boundary', async ({ page, goto }) => {
+    const pageContents = readFileSync(join(sourceDir, 'app/pages/page-meta.vue'), 'utf8')
+    const write = (value: string) => writeFileSync(join(fixtureDir, 'app/pages/page-meta.vue'), pageContents.replace(`some: 'stuff'`, value))
+
+    write(`some: 'stuff'`)
+    await goto('/page-meta')
+    await expect(page.getByTestId('meta')).toHaveText(JSON.stringify({ some: 'stuff' }, null, 2))
+
+    // A template literal cannot be serialized, so the route record hands `meta` back to the
+    // macro module and the generated route gains an import it did not previously have.
+    write('some: `other ${\'stuff\'}`')
+    await expect(page.getByTestId('meta')).toHaveText(JSON.stringify({ some: 'other stuff' }, null, 2))
+
+    // ...and dropping back to a serializable value has to remove that import again.
+    write(`some: 'final stuff'`)
+    await expect(page.getByTestId('meta')).toHaveText(JSON.stringify({ some: 'final stuff' }, null, 2))
+
+    write(`some: 'stuff'`)
+    expect(page).toHaveNoErrorsOrWarnings()
+  })
+
   test('HMR on page should keep ref state when updating template', async ({ goto, page }) => {
     await goto('/state-component')
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

another perf improvement.

for `definePageMeta` that is entirely serializable, we can extract them all at scan time rather than needing to run a vite transform of the entire page component at runtime. this can significantly decrease the number of requests in a vite dev server