### PR TITLE
build(ui-templates): copy generated templates from resolved output dir

### DIFF
--- a/packages/ui-templates/lib/render.ts
+++ b/packages/ui-templates/lib/render.ts
@@ -219,14 +219,14 @@ export const RenderPlugin = () => {
       const nitroRoot = r('../nitro-server')
       const schemaRoot = r('../schema')
       for (const file of ['error-404.vue', 'error-500.vue', 'welcome.vue']) {
-        await copyFile(r(`dist/templates/${file}`), join(nuxtRoot, 'src/app/components', file))
+        await copyFile(join(outputDir, 'templates', file), join(nuxtRoot, 'src/app/components', file))
       }
       await mkdir(join(nitroRoot, 'src/runtime/templates'), { recursive: true })
-      await copyFile(r(`dist/templates/error-500.ts`), join(nitroRoot, 'src/runtime/templates/error-500.ts'))
+      await copyFile(join(outputDir, 'templates/error-500.ts'), join(nitroRoot, 'src/runtime/templates/error-500.ts'))
       await mkdir(join(nitroRoot, 'src/templates'), { recursive: true })
-      await copyFile(r(`dist/templates/spa-loading-icon.ts`), join(nitroRoot, 'src/templates/spa-loading-icon.ts'))
+      await copyFile(join(outputDir, 'templates/spa-loading-icon.ts'), join(nitroRoot, 'src/templates/spa-loading-icon.ts'))
       await mkdir(join(schemaRoot, 'src/templates'), { recursive: true })
-      await copyFile(r(`dist/templates/loading.ts`), join(schemaRoot, 'src/templates/loading.ts'))
+      await copyFile(join(outputDir, 'templates/loading.ts'), join(schemaRoot, 'src/templates/loading.ts'))
     },
   }
 }

--- a/packages/ui-templates/test/templates.spec.ts
+++ b/packages/ui-templates/test/templates.spec.ts
@@ -11,6 +11,7 @@ const distDir = fileURLToPath(new URL('../node_modules/.temp/dist/templates', im
 describe('template', () => {
   beforeAll(async () => {
     await exec('pnpm', ['build'], {
+      throwOnError: true,
       nodeOptions: {
         cwd: fileURLToPath(new URL('..', import.meta.url)),
         env: {


### PR DESCRIPTION
### 📚 Description

this PR makes the render plugin copy the generated templates from the build's resolved output dir instead of the hardcoded `dist/`

I also noticed that the test was swallowing build errors.