### PR TITLE
fix(nuxt): treat `<NuxtTime>` `datetime={0}` as the epoch

### DIFF
--- a/docs/4.api/1.components/13.nuxt-time.md
+++ b/docs/4.api/1.components/13.nuxt-time.md
@@ -37,6 +37,8 @@ The date and time value to display. You can provide:
 - A timestamp (number)
 - An ISO-formatted date string
 
+If no value is provided (`null`, `undefined` or an empty string), the component falls back to the current date and time. Invalid input (such as a malformed date string or `NaN`) renders as `Invalid Date`.
+
 ```vue [app/app.vue]
 <template>
   <NuxtTime :datetime="Date.now()" />

--- a/docs/4.api/1.components/13.nuxt-time.md
+++ b/docs/4.api/1.components/13.nuxt-time.md
@@ -37,7 +37,7 @@ The date and time value to display. You can provide:
 - A timestamp (number)
 - An ISO-formatted date string
 
-If no value is provided (`null`, `undefined` or an empty string), the component falls back to the current date and time. Invalid input (such as a malformed date string or `NaN`) renders as `Invalid Date`.
+If the value is missing at runtime (`null`, `undefined` or an empty string — which the prop types don't allow, but can happen with data that hasn't loaded yet), the component falls back to the current date and time. Invalid input (such as a malformed date string or `NaN`) renders as `Invalid Date`.
 
 ```vue [app/app.vue]
 <template>

--- a/packages/nuxt/src/app/components/nuxt-time.vue
+++ b/packages/nuxt/src/app/components/nuxt-time.vue
@@ -48,7 +48,9 @@ const nuxtApp = useNuxtApp()
 const date = computed(() => {
   const date = props.datetime
   if (renderedDate && nuxtApp.isHydrating) { return new Date(renderedDate) }
-  if (!props.datetime) { return new Date() }
+  // only fall back to the current time when no datetime was provided at all:
+  // `0` is a valid epoch timestamp and invalid input renders as an invalid date
+  if (date === undefined || date === null || date === '') { return new Date() }
   return new Date(date)
 })
 

--- a/test/nuxt/nuxt-time.test.ts
+++ b/test/nuxt/nuxt-time.test.ts
@@ -271,5 +271,37 @@ describe('<NuxtTime>', () => {
       expect(renderedDate.getTime()).toBeGreaterThanOrEqual(beforeMount)
       expect(renderedDate.getTime()).toBeLessThanOrEqual(afterMount)
     })
+
+    it('should treat datetime={0} as the epoch, not as a missing value', async () => {
+      const thing = await mountSuspended(
+        defineComponent({
+          render: () =>
+            h(NuxtTime, {
+              datetime: 0,
+              locale: 'en-GB',
+              dateStyle: 'short',
+              timeZone: 'UTC',
+            }),
+        }),
+      )
+      expect(thing.html()).toMatchInlineSnapshot(
+        `"<time datetime="1970-01-01T00:00:00.000Z">01/01/1970</time>"`,
+      )
+    })
+
+    it('should display "Invalid Date" for datetime={NaN}, like other invalid input', async () => {
+      const thing = await mountSuspended(
+        defineComponent({
+          render: () =>
+            h(NuxtTime, {
+              datetime: Number.NaN,
+              locale: 'en-GB',
+            }),
+        }),
+      )
+      expect(thing.html()).toMatchInlineSnapshot(
+        `"<time>Invalid Date</time>"`,
+      )
+    })
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Follows up on the discussion in #33901.

### 📚 Description

`<NuxtTime>` falls back to the current time when `datetime` is falsy. That is the intended behaviour for a missing value (#33901), but the `!props.datetime` check also swallows two inputs that are valid for the declared `string | number | Date` prop type:

- `datetime={0}` — the Unix epoch, a perfectly valid timestamp — renders the current time instead of 1 January 1970.
- `datetime={NaN}` renders the current time, while an equally invalid *string* (`datetime="xyz"`) renders `Invalid Date`. Two invalid inputs of different types took two different fallbacks.

This PR narrows the fallback to "no value provided" (`undefined`, `null` or an empty string), matching the behaviour discussed in #33901:

- `0` now renders the epoch.
- `NaN` now renders `Invalid Date`, consistent with malformed date strings (the handling added in #33992).
- `null` / `undefined` / `''` keep falling back to the current time (existing test untouched and still passing).

It also documents the fallback on the `datetime` prop page, as requested in #33901.

Added unit tests for the `0` and `NaN` cases; `test/nuxt/nuxt-time.test.ts` is 15/15 locally, eslint + markdownlint + case-police clean.
