### PR TITLE
docs: add note to avoid using `defineVitestProject` in e2e tests

### DIFF
--- a/docs/1.getting-started/17.testing.md
+++ b/docs/1.getting-started/17.testing.md
@@ -86,11 +86,11 @@ We currently ship an environment for unit testing code that needs a [Nuxt](https
    })
    ```
 
-::note
-`defineVitestProject` is only for the Nuxt runtime environment and can't be used for end-to-end tests. End-to-end tests should be configured as a regular `environment: 'node'` project.
-::
+    ::note
+    `defineVitestProject` is only for the Nuxt-environment tests. End-to-end tests should be configured as a regular `environment: 'node'` project.
+    ::
 
-1. If your Nuxt-environment tests live outside `test/nuxt/`, see [TypeScript Support in Tests](#typescript-support-in-tests) to add them to the TypeScript context.
+3. If your Nuxt-environment tests live outside `test/nuxt/`, see [TypeScript Support in Tests](#typescript-support-in-tests) to add them to the TypeScript context.
 
 ::tip
 When importing `@nuxt/test-utils` in your vitest config, It is necessary to have `"type": "module"` specified in your `package.json` or rename your vitest config file appropriately.

--- a/docs/1.getting-started/17.testing.md
+++ b/docs/1.getting-started/17.testing.md
@@ -87,7 +87,7 @@ We currently ship an environment for unit testing code that needs a [Nuxt](https
    ```
 
     ::note
-    `defineVitestProject` is only for the Nuxt-environment tests. End-to-end tests should be configured as a regular `environment: 'node'` project.
+    `defineVitestProject` is only for Nuxt-environment tests. End-to-end tests should be configured as a regular `test.environment: 'node'` project.
     ::
 
 3. If your Nuxt-environment tests live outside `test/nuxt/`, see [TypeScript Support in Tests](#typescript-support-in-tests) to add them to the TypeScript context.

--- a/docs/1.getting-started/17.testing.md
+++ b/docs/1.getting-started/17.testing.md
@@ -90,7 +90,7 @@ We currently ship an environment for unit testing code that needs a [Nuxt](https
 `defineVitestProject` is only for the Nuxt runtime environment and can't be used for end-to-end tests. End-to-end tests should be configured as a regular `environment: 'node'` project.
 ::
 
-3. If your Nuxt-environment tests live outside `test/nuxt/`, see [TypeScript Support in Tests](#typescript-support-in-tests) to add them to the TypeScript context.
+1. If your Nuxt-environment tests live outside `test/nuxt/`, see [TypeScript Support in Tests](#typescript-support-in-tests) to add them to the TypeScript context.
 
 ::tip
 When importing `@nuxt/test-utils` in your vitest config, It is necessary to have `"type": "module"` specified in your `package.json` or rename your vitest config file appropriately.

--- a/docs/1.getting-started/17.testing.md
+++ b/docs/1.getting-started/17.testing.md
@@ -86,6 +86,10 @@ We currently ship an environment for unit testing code that needs a [Nuxt](https
    })
    ```
 
+::note
+`defineVitestProject` is only for the Nuxt runtime environment and can't be used for end-to-end tests. End-to-end tests should be configured as a regular `environment: 'node'` project.
+::
+
 3. If your Nuxt-environment tests live outside `test/nuxt/`, see [TypeScript Support in Tests](#typescript-support-in-tests) to add them to the TypeScript context.
 
 ::tip


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Added a note explaining that `defineVitestProject` should not be used for E2E testing.

As discussed in the following comment:
https://github.com/nuxt/test-utils/issues/1490#issuecomment-4007983450

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
