### PR TITLE
fix(vite): prefix windows paths properly

### DIFF
--- a/packages/vite/src/plugins/client-manifest.ts
+++ b/packages/vite/src/plugins/client-manifest.ts
@@ -11,7 +11,7 @@ import type { Plugin, Manifest as ViteClientManifest } from 'vite'
 import { bundlerDiagnostics, setBuildOutput } from '@nuxt/kit'
 import type { Nuxt } from '@nuxt/schema'
 import { resolveClientEntry, resolveClientManifestFile } from '../utils/config.ts'
-import { collectGlobalCss } from '../utils/css.ts'
+import { collectGlobalCss, toFsUrl } from '../utils/css.ts'
 
 export function ClientManifestPlugin (nuxt: Nuxt): Plugin {
   let clientEntry: string
@@ -48,7 +48,7 @@ export function ClientManifestPlugin (nuxt: Nuxt): Plugin {
   // from the ssr graph is pushed to the ssr runner over the env hot channel and
   // patched into the renderer manifest at render time (see `patchDevClientCss`).
   const buildDevClientManifest = (): RendererManifest => {
-    const entryFile = envApi ? `/@fs${clientEntry}` : clientEntry
+    const entryFile = envApi ? toFsUrl(clientEntry) : clientEntry
     return {
       '@vite/client': {
         isEntry: true,

--- a/packages/vite/src/utils/css.test.ts
+++ b/packages/vite/src/utils/css.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { toFsUrl } from './css.ts'
+
+describe('toFsUrl', () => {
+  it('should prefix a posix path', () => {
+    expect(toFsUrl('/project/packages/nuxt/src/app/entry.async.ts')).toBe('/@fs/project/packages/nuxt/src/app/entry.async.ts')
+  })
+
+  it('should keep a separator before a windows drive letter', () => {
+    expect(toFsUrl('D:/project/packages/nuxt/src/app/entry.async.ts')).toBe('/@fs/D:/project/packages/nuxt/src/app/entry.async.ts')
+  })
+})

--- a/packages/vite/src/utils/css.ts
+++ b/packages/vite/src/utils/css.ts
@@ -9,8 +9,11 @@ import { isCSS } from './index.ts'
 
 /**
  * Convert an absolute file path to the dev-server URL Vite serves it from.
+ *
+ * Windows paths start with a drive letter rather than a slash, so the separator
+ * has to be added rather than assumed.
  */
-function toFsUrl (path: string): string {
+export function toFsUrl (path: string): string {
   return '/@fs' + path.replace(/^(?!\/)/, '/')
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this caused no css to be loaded on windows in dev mode 😱 (nitro vite environment only) - because we ended up with urls like `/@fsC:...`