### PR TITLE
fix(nuxt): collect build cache once build outputs are final

### DIFF
--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -92,7 +92,7 @@ export async function build (nuxt: Nuxt): Promise<void> {
       await nuxt.callHook('close', nuxt)
       return
     }
-    nuxt.hooks.hookOnce('nitro:build:before', () => collectCache())
+    nuxt.hooks.hookOnce('build:done', () => collectCache())
     nuxt.hooks.hookOnce('close', () => cleanupCaches(nuxt))
   }
 

--- a/packages/nuxt/test/builder.test.ts
+++ b/packages/nuxt/test/builder.test.ts
@@ -10,12 +10,14 @@ import { build, loadNuxt } from 'nuxt'
 
 describe('builder:watch', { sequential: true }, async () => {
   const tmpDir = join(await findWorkspaceDir(), '.test/builder-watch')
+  const cacheDir = join(await findWorkspaceDir(), '.test/builder-watch-vite-cache')
   beforeEach(async () => {
     await rm(tmpDir, { recursive: true, force: true })
     await mkdir(join(tmpDir, 'project/node_modules'), { recursive: true })
   })
   afterAll(async () => {
-    await rm(tmpDir, { recursive: true, force: true })
+    await rm(tmpDir, { recursive: true, force: true, maxRetries: 3 })
+    await rm(cacheDir, { recursive: true, force: true, maxRetries: 3 })
   })
   const watcherStrategies = ['chokidar', 'chokidar-granular', 'parcel'] as const
   it.each(watcherStrategies)('should restart Nuxt when a file is added with %s strategy', async (watcher) => {
@@ -26,6 +28,7 @@ describe('builder:watch', { sequential: true }, async () => {
       overrides: {
         experimental: { watcher },
         dev: true,
+        vite: { cacheDir },
         watch: ['test', join(rootDir, 'other'), resolve(rootDir, '../higher')],
       },
     })
@@ -179,6 +182,7 @@ describe('builder:watch', { sequential: true }, async () => {
       overrides: {
         experimental: { watcher: 'builder' },
         dev: true,
+        vite: { cacheDir },
         watch: ['test', join(rootDir, 'other'), resolve(rootDir, '../higher')],
       },
     })

--- a/packages/nuxt/test/cache.test.ts
+++ b/packages/nuxt/test/cache.test.ts
@@ -21,6 +21,7 @@ describe('buildCache', { sequential: true, timeout: 120_000 }, async () => {
 
   beforeEach(async () => {
     await rm(tmpDir, { recursive: true, force: true })
+    await mkdir(join(tmpDir, 'node_modules'), { recursive: true })
     await mkdir(join(tmpDir, 'project/node_modules'), { recursive: true })
     // Create a minimal app.vue so the build has something to compile
     await writeFile(join(tmpDir, 'project/app.vue'), '<template><div>hello</div></template>')


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

`build:done` works with nitro/vite environment, unlike `nitro:build:before`