### PR TITLE
test: isolate dev fixtures by worker

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -74,6 +74,7 @@ export default defineConfig<E2eConfigOptions>({
       return {
         name,
         testIgnore: testIgnoreForProject(entry),
+        fullyParallel: !entry.isDev && !isCI,
         use: {
           ...devices['Desktop Chrome'],
           isDev: entry.isDev,


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this avoids running dev e2e fixtures in parallel, as they may mutate a shared `.nuxt` dir