### PR TITLE
fix(nitro): keep server auto-import scanning

### DIFF
--- a/packages/nitro-server/src/augments.ts
+++ b/packages/nitro-server/src/augments.ts
@@ -3,7 +3,7 @@ import type { Nitro, NitroConfig, NitroDevEventHandler, NitroEventHandler, Nitro
 import type { EventHandler, H3Event } from 'nitro/h3'
 import type { LogObject } from 'consola'
 import type { NuxtIslandContext, NuxtIslandResponse, NuxtRenderChunkContext, NuxtRenderCloseContext, NuxtRenderHTMLContext, NuxtRenderRouteContext } from '#app/types'
-import type { HookResult, RuntimeConfig, TSReference } from 'nuxt/schema'
+import type { AppConfig, HookResult, RuntimeConfig, TSReference } from 'nuxt/schema'
 
 /**
  * Per-channel toggles for `tracingChannel`. Extends Nitro's own
@@ -292,6 +292,35 @@ declare module 'nuxt/schema' {
 
   interface NuxtPage {
     rules?: NitroRouteConfig
+  }
+}
+
+export interface NuxtRequestContext {
+  'appConfig'?: AppConfig
+  'noSSR'?: boolean
+  /** @internal */
+  '~internal'?: boolean
+  /** @internal */
+  '~rendering-error'?: boolean
+  /**
+   * Dev-only: CSS module URLs the builder has loaded for this request, provided
+   * by a dev integration so the SSR renderer can emit the right stylesheet
+   * links / inline styles. @internal
+   */
+  '~devClientCss'?: string[]
+  /** @internal */
+  '~error-cause'?: unknown
+}
+
+declare module 'srvx' {
+  interface ServerRequestContext {
+    nuxt?: NuxtRequestContext
+  }
+}
+
+declare module 'h3' {
+  interface H3EventContext {
+    nuxt?: NuxtRequestContext
   }
 }
 

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -162,38 +162,36 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
       name: 'nuxt',
       version: nuxtPkg.version || nitroBuilder.version,
     },
-    imports: nuxt.options.experimental.nitroAutoImports === false
-      ? false
-      : {
-          autoImport: nuxt.options.imports.autoImport as boolean,
-          dirs: [...importDirs],
-          presets: nuxt.options.experimental.nitroAutoImports
-            ? [
-                ...v2ImportsPreset,
-                await getH3ImportsPreset(),
-              ]
-            : [],
-          imports: [
-            {
-              as: '__buildAssetsURL',
-              name: 'buildAssetsURL',
-              from: resolve(distDir, 'runtime/utils/paths'),
-            },
-            {
-              as: '__publicAssetsURL',
-              name: 'publicAssetsURL',
-              from: resolve(distDir, 'runtime/utils/paths'),
-            },
-            {
-              // TODO: Remove after https://github.com/nitrojs/nitro/issues/1049
-              as: 'defineAppConfig',
-              name: 'defineAppConfig',
-              from: resolve(distDir, 'runtime/utils/config'),
-              priority: -1,
-            },
-          ],
-          exclude: [...excludePattern, /[\\/]\.git[\\/]/],
+    imports: {
+      autoImport: nuxt.options.imports.autoImport as boolean,
+      dirs: [...importDirs],
+      presets: nuxt.options.experimental.nitroAutoImports
+        ? [
+            ...v2ImportsPreset,
+            await getH3ImportsPreset(),
+          ]
+        : [],
+      imports: [
+        {
+          as: '__buildAssetsURL',
+          name: 'buildAssetsURL',
+          from: resolve(distDir, 'runtime/utils/paths'),
         },
+        {
+          as: '__publicAssetsURL',
+          name: 'publicAssetsURL',
+          from: resolve(distDir, 'runtime/utils/paths'),
+        },
+        {
+          // TODO: Remove after https://github.com/nitrojs/nitro/issues/1049
+          as: 'defineAppConfig',
+          name: 'defineAppConfig',
+          from: resolve(distDir, 'runtime/utils/config'),
+          priority: -1,
+        },
+      ],
+      exclude: [...excludePattern, /[\\/]\.git[\\/]/],
+    },
     // TODO: support for bundle analyser: https://github.com/nitrojs/nitro/pull/3628
     scanDirs: layerDirs.map(dirs => dirs.server),
     renderer: {

--- a/packages/nitro-server/src/runtime/context.ts
+++ b/packages/nitro-server/src/runtime/context.ts
@@ -1,0 +1,3 @@
+import '@nuxt/nitro-server/augments'
+
+export type { NuxtRequestContext } from '@nuxt/nitro-server/augments'

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -14,6 +14,8 @@ import { getRouteRules, useNitroHooks } from 'nitro/app'
 import { SSR_ERROR_PARAM, decodeSSRError, stringifyErrorData } from '../utils/error'
 import { relative } from 'pathe'
 
+import '../context'
+
 import type { NuxtPayload, NuxtRenderHTMLContext, NuxtSSRContext, SerializedErrorCause } from '#app/types'
 import { traceAsync } from '#app/internal/tracing'
 
@@ -34,7 +36,6 @@ import entryIds from 'nuxt/entry-ids'
 import { entryFileName } from 'nuxt/entry-chunk'
 import { iifeChunkFileName } from '#internal/streaming-iife-chunk.mjs'
 import { buildAssetsURL, publicAssetsURL } from '../utils/paths'
-import type { AppConfig } from '@nuxt/schema'
 
 // @ts-expect-error private property consumed by vite-generated url helpers
 globalThis.__buildAssetsURL = buildAssetsURL
@@ -113,7 +114,7 @@ async function renderRoute (event: H3Event, ssrError?: (NuxtPayload['error'] & {
       (ssrError as { data?: unknown }).data = stringifyErrorData(ssrError.data)
     }
     if (import.meta.dev && event.context.nuxt?.['~error-cause'] !== undefined) {
-      (ssrError as { cause?: SerializedErrorCause }).cause = event.context.nuxt['~error-cause']
+      (ssrError as { cause?: SerializedErrorCause }).cause = event.context.nuxt['~error-cause'] as SerializedErrorCause
     }
     setSSRError(ssrContext, ssrError)
   }
@@ -952,35 +953,6 @@ function applyRenderOptions (payload: SSRHeadPayload, options: { omitLineBreaks?
     bodyTagsOpen: payload.bodyTagsOpen.replaceAll('\n', ''),
     htmlAttrs: payload.htmlAttrs,
     bodyAttrs: payload.bodyAttrs,
-  }
-}
-
-interface NuxtRequestContext {
-  'appConfig'?: AppConfig
-  'noSSR'?: boolean
-  /** @internal */
-  '~internal'?: boolean
-  /** @internal */
-  '~rendering-error'?: boolean
-  /**
-   * Dev-only: CSS module URLs the builder has loaded for this request, provided
-   * by a dev integration so the SSR renderer can emit the right stylesheet
-   * links / inline styles. @internal
-   */
-  '~devClientCss'?: string[]
-  /** @internal */
-  '~error-cause'?: SerializedErrorCause
-}
-
-declare module 'srvx' {
-  interface ServerRequestContext {
-    nuxt?: NuxtRequestContext
-  }
-}
-
-declare module 'h3' {
-  interface H3EventContext {
-    nuxt?: NuxtRequestContext
   }
 }
 

--- a/packages/nitro-server/src/runtime/middleware/base-url.ts
+++ b/packages/nitro-server/src/runtime/middleware/base-url.ts
@@ -1,5 +1,7 @@
 import { HTTPError, defineEventHandler } from 'nitro/h3'
 import { useRuntimeConfig } from 'nitro/runtime-config'
+
+import '../context'
 import { serverFetch } from 'nitro'
 
 const config = useRuntimeConfig()

--- a/packages/nitro-server/src/runtime/middleware/no-ssr.ts
+++ b/packages/nitro-server/src/runtime/middleware/no-ssr.ts
@@ -1,5 +1,7 @@
 import { defineEventHandler } from 'nitro/h3'
 
+import '../context'
+
 const handler: ReturnType<typeof defineEventHandler> = defineEventHandler((event) => {
   if (event.req.headers.get('x-nuxt-no-ssr')) {
     event.context.nuxt ||= {}

--- a/packages/nitro-server/src/runtime/utils/app-config.ts
+++ b/packages/nitro-server/src/runtime/utils/app-config.ts
@@ -2,6 +2,7 @@ import type { H3Event } from 'nitro/h3'
 import { klona } from 'klona'
 import type { AppConfig } from '@nuxt/schema'
 
+import '../context'
 import _inlineAppConfig from '#internal/nuxt/app-config'
 
 // App config

--- a/packages/nitro-server/src/runtime/utils/renderer/app.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/app.ts
@@ -1,6 +1,8 @@
 import type { H3Event } from 'nitro/h3'
 import { FastResponse } from 'srvx'
 import { useRuntimeConfig } from 'nitro/runtime-config'
+
+import '../../context'
 import { createHead } from '@unhead/vue/server'
 import type { NuxtPayload, NuxtSSRContext } from '#app/types'
 import { sharedPrerenderCache } from '../cache'

--- a/packages/nitro-server/src/runtime/utils/renderer/dev-client-css.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/dev-client-css.ts
@@ -1,6 +1,8 @@
 import type { H3Event } from 'nitro/h3'
 import { getDevClientCss } from '#internal/nuxt/dev-client-css'
 
+import '../../context'
+
 /**
  * Dev-only: record the CSS modules the builder has loaded for this request
  * into the request context, so the SSR renderer can emit the right stylesheet

--- a/packages/nitro-server/src/runtime/utils/renderer/dev-css.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/dev-css.ts
@@ -2,6 +2,8 @@ import type { H3Event } from 'nitro/h3'
 import type { RendererContext } from 'vue-bundle-renderer/runtime'
 import { normalizeViteManifest } from 'vue-bundle-renderer'
 
+import '../../context'
+
 /**
  * Patch the dev SSR manifest with the CSS modules a dev integration recorded
  * for this request (`event.context.nuxt['~devClientCss']`), so

--- a/packages/nuxt/test/shared-dir-config.test.ts
+++ b/packages/nuxt/test/shared-dir-config.test.ts
@@ -40,11 +40,10 @@ describe('loadNuxt', () => {
     expect(normalized).not.toContain('<rootDir>/server/types')
   })
 
-  it('does not register server type directories when nitro auto-imports are opted out', async () => {
-    const importDirs = await getNitroImportDirs({ experimental: { nitroAutoImports: false } })
-    // `nitro.imports` is disabled entirely, so no directories (incl. `server/types`) are scanned
-    expect(normalizePaths(importDirs)).not.toContain('<rootDir>/server/types')
-    expect(importDirs).toHaveLength(0)
+  it('still registers server type directories when nitro compat auto-imports are opted out', async () => {
+    const { dirs, presets } = await getNitroImports({ experimental: { nitroAutoImports: false } })
+    expect(normalizePaths(dirs)).toContain('<rootDir>/server/types')
+    expect(presets).toHaveLength(0)
   })
 })
 
@@ -57,7 +56,13 @@ function normalizePaths (arr: unknown[]) {
 }
 
 async function getNitroImportDirs (overrides?: NuxtConfig) {
-  const importDirs: unknown[] = []
+  const { dirs } = await getNitroImports(overrides)
+  return dirs
+}
+
+async function getNitroImports (overrides?: NuxtConfig) {
+  const dirs: unknown[] = []
+  const presets: unknown[] = []
   const nuxt = await loadNuxt({
     cwd: fixtureDir,
     ready: true,
@@ -66,14 +71,15 @@ async function getNitroImportDirs (overrides?: NuxtConfig) {
       hooks: {
         'nitro:config' (config) {
           if (config.imports) {
-            importDirs.push(...config.imports.dirs || [])
+            dirs.push(...config.imports.dirs || [])
+            presets.push(...config.imports.presets || [])
           }
         },
       },
     },
   })
   await nuxt.close()
-  return importDirs
+  return { dirs, presets }
 }
 
 async function getAppImportDirs (overrides?: NuxtConfig) {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this temporarily (?) re-enables scanning for `server/` auto imports (and supports `#imports` alias) even when `experimental.nitroAutoImports` is off (which effectively turns off auto-importing `h3`)