### PR TITLE
perf(nuxt,kit)!: make `jiti` an optional peer dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,6 +280,9 @@ jobs:
           - name: Test (unit)
             run: vp run test:unit
 
+          - name: Test (no jiti)
+            run: vp run test:no-jiti
+
       - name: Cancel workflow on failure
         if: failure() && github.event_name == 'merge_group'
         run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,7 @@ jobs:
           cache: true
 
       - name: Prepare
-        run: vp run dev:prepare && vp run test:prepare
+        run: vp run dev:prepare && vp run test:prepare && vp run build:kit
 
       - parallel:
           - name: Lint

--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -215,7 +215,7 @@ bun add -D jiti
 
 ::
 
-A `nuxt.schema.ts` file always needs `jiti`, whatever Node version you are on: its JSDoc annotations are read by an import-time transform rather than by importing the file.
+A `nuxt.schema` file always needs `jiti`, whatever Node version you are on: its JSDoc annotations are read by an import-time transform rather than by importing the file.
 
 One smaller change comes with this: PostCSS plugins named in `postcss.plugins` are now resolved by the runtime, so a plugin name that only resolves through a Nuxt `alias` entry no longer loads. Use the package name, or a path.
 

--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -127,6 +127,98 @@ export default defineNuxtConfig({
 })
 ```
 
+### `jiti` Is No Longer Bundled
+
+🚦 **Impact Level**: Medium
+
+#### What Changed
+
+Nuxt no longer depends on [`jiti`](https://github.com/unjs/jiti). Files loaded outside the bundler (`nuxt.config.ts`, files in `modules/`, and layer configs) are now imported by the runtime itself.
+
+**You can still write your config in TypeScript.** Nuxt 5 requires Node `22.19` or later, where type stripping is on by default, so `nuxt.config.ts` and TypeScript modules load natively. Two things the runtime does not do, which `jiti` used to paper over, are guess file extensions and compile TypeScript syntax that emits code.
+
+Both would otherwise only surface when Nuxt loads the file, so the generated `node` tsconfig now describes the environment the way the runtime sees it (`module` and `moduleResolution` set to `nodenext`, plus [`erasableSyntaxOnly`](https://www.typescriptlang.org/tsconfig/#erasableSyntaxOnly)) and TypeScript reports both up front.
+
+That covers `nuxt.config`, `modules/` and layer configs only. Your app and `shared/` code goes through Vite and resolves the way it always has. If you need the previous behaviour, override it:
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  typescript: {
+    nodeTsConfig: {
+      compilerOptions: {
+        module: 'preserve',
+        moduleResolution: 'bundler',
+        erasableSyntaxOnly: false,
+      },
+    },
+  },
+})
+```
+
+#### Reasons for Change
+
+`jiti` was pulled into every Nuxt install to load a handful of files, most of which the runtime can now load unaided. Removing it makes a default install smaller.
+
+#### Migration Steps
+
+**1. Add file extensions to relative imports.**
+
+Relative imports in `nuxt.config.ts`, `modules/`, and layer configs need an explicit extension:
+
+```diff [nuxt.config.ts]
+- import { myPlugin } from './build/my-plugin'
++ import { myPlugin } from './build/my-plugin.ts'
+```
+
+TypeScript reports a missing extension as `TS2835`. Note that its quick fix suggests `./build/my-plugin.js`; write the extension the file actually has (`.ts`), which Node resolves directly.
+
+Bare package imports (`import { defu } from 'defu'`) are unaffected.
+
+**2. Use erasable TypeScript syntax.**
+
+Type annotations are erased, but syntax that emits runtime code cannot be. In config and module files, replace:
+
+- `enum Foo {}` with a `const` object
+- `namespace` / `module` blocks with plain exports
+- constructor parameter properties (`constructor(private x: string) {}`) with an explicit assignment
+- experimental decorators
+
+TypeScript reports all of these for you as `TS1294`.
+
+**3. If you publish a layer or module, ship compiled JavaScript.**
+
+This one is specific to packages. The runtime refuses to strip types from any file inside `node_modules`, whatever the configuration, so a published entrypoint written in TypeScript cannot be loaded natively however new the Node version is. Build to JavaScript before publishing, and if your package ships a `nuxt.config`, emit it as `nuxt.config.mjs`. Otherwise every consuming project has to install `jiti`.
+
+This does not apply to layers inside your own project: `layers/*/nuxt.config.ts` loads natively.
+
+**4. Install `jiti` if you still need it.**
+
+`jiti` is now an optional peer dependency. Install it and Nuxt will pick it up automatically as a fallback whenever the runtime cannot load a file on its own:
+
+::code-group{sync="pm"}
+
+```bash [npm]
+npm i -D jiti
+```
+
+```bash [yarn]
+yarn add -D jiti
+```
+
+```bash [pnpm]
+pnpm add -D jiti
+```
+
+```bash [bun]
+bun add -D jiti
+```
+
+::
+
+A `nuxt.schema.ts` file always needs `jiti`, whatever Node version you are on: its JSDoc annotations are read by an import-time transform rather than by importing the file.
+
+One smaller change comes with this: PostCSS plugins named in `postcss.plugins` are now resolved by the runtime, so a plugin name that only resolves through a Nuxt `alias` entry no longer loads. Use the package name, or a path.
+
 ### Migration to Vite Environment API
 
 🚦 **Impact Level**: Medium

--- a/knip.json
+++ b/knip.json
@@ -130,7 +130,6 @@
         "file-loader",
         "h3",
         "h3-next",
-        "jiti",
         "knitwork",
         "memfs",
         "mini-css-extract-plugin",

--- a/knip.json
+++ b/knip.json
@@ -26,6 +26,7 @@
         "scripts/*",
         "test/*.ts",
         "test/e2e/*.ts",
+        "test/no-jiti/*.mjs",
         "test/runtime/app/**/*.ts",
         "test/mocks/app-config.ts"
       ]

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:runtime": "vitest run --project nuxt --project nuxt-universal --project nuxt-legacy --project nuxt-dev --project nuxt-insensitive --project nuxt-sensitive",
     "test:types": "node ./test/ensure-prepared.ts && pnpm --filter './test/fixtures/**' test:types",
     "test:bundle": "pnpm build && vitest run bundle",
+    "test:no-jiti": "vitest run --project no-jiti",
     "test:unit": "vitest run --project unit",
     "test:attw": "pnpm --filter './packages/**' test:attw",
     "test:e2e": "playwright test",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "type": "module",
   "scripts": {
     "build": "pnpm --filter './packages/**' build",
+    "build:kit": "pnpm --filter @nuxt/kit build",
     "build:stub": "pnpm dev:prepare",
     "dev": "pnpm play",
     "dev:prepare": "nuxt prepare",

--- a/packages/kit/src/diagnostics/config.ts
+++ b/packages/kit/src/diagnostics/config.ts
@@ -63,6 +63,11 @@ export const configDiagnostics = /* #__PURE__ */ defineDiagnostics({
       fix: (p: { source: string, installCommand: string }) => `Add the layer to \`package.json\` instead, so it is pinned and in your lockfile (for example \`"my-layer": "${p.source.replace(/^gh:/, 'github:')}#<commit>"\`), then extend from its package name. Otherwise run \`${p.installCommand}\` to keep downloading it.`,
       docs: false,
     },
+    NUXT_B5019: {
+      why: (p: { filePath: string }) => `The Nuxt schema in \`${p.filePath}\` was skipped because \`jiti\` is not installed. A schema file's JSDoc annotations are read by an import-time transform, which is the one part of loading it the runtime cannot do on its own.`,
+      fix: (p: { installCommand: string }) => `Run \`${p.installCommand}\` to load it, or remove the \`nuxt.schema\` file.`,
+      docs: false,
+    },
     NUXT_B5017: {
       why: (p: { filePath: string, error: string }) => `The config file \`${p.filePath}\` could not be loaded: ${p.error}`,
       fix: (p: { installCommand: string }) => `Relative imports need an explicit file extension (\`./foo.ts\`, not \`./foo\`), and TypeScript syntax that emits code (such as \`enum\`) cannot be stripped. Alternatively, run \`${p.installCommand}\` and Nuxt will load it through jiti instead.`,

--- a/packages/kit/src/index.ts
+++ b/packages/kit/src/index.ts
@@ -43,6 +43,7 @@ export type { ResolvePathOptions, Resolver } from './resolve.ts'
 export { addServerHandler, addDevServerHandler, addServerPlugin, addPrerenderRoutes, useNitro, addServerImports, addServerImportsDir, addServerScanDir } from './nitro.ts'
 export { addTemplate, addServerTemplate, addTypeTemplate, normalizeTemplate, updateTemplates, writeTypes } from './template.ts'
 export { packageName, resolveDeclarationPath, resolveTypePaths } from './types.ts'
+export type { ResolveTypePathsOptions } from './types.ts'
 export { recoverThrottledChanges } from './watch.ts'
 export type { RecoverableWatcher } from './watch.ts'
 export { logger, useLogger } from './logger.ts'
@@ -68,3 +69,6 @@ export type { EnsureDependencyInstalledOptions } from './dependency.ts'
 // eslint-disable-next-line @typescript-eslint/no-deprecated
 export { directoryToURL, resolveModule, tryResolveModule, importModule, tryImportModule, requireModule, tryRequireModule } from './internal/esm.ts'
 export type { ImportModuleOptions, ResolveModuleOptions } from './internal/esm.ts'
+
+/** @internal */
+export { loadJiti } from './internal/jiti.ts'

--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -21,9 +21,7 @@ import { getAddDependencyCommand } from '../dependency.ts'
 
 /**
  * A layer as it comes back from the underlying config loader, before its directory options have
- * been normalised into a {@link NuxtConfigLayer}. Shaped like a layer from a custom resolver,
- * except that the loader can report one whose config could not be read. Declared here rather than
- * imported so no type from the loader reaches this package's public surface.
+ * been normalised into a {@link NuxtConfigLayer}.
  */
 interface LoadedConfigLayer extends Omit<ResolvedNuxtLayer, 'config'> {
   config: NuxtConfig | null

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -230,6 +230,28 @@ export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: stri
 async function getPathSubstitution (absolutePath: string, buildDir: string): Promise<string> {
   return relativeWithDot(buildDir, await resolveDeclarationPath(absolutePath))
 }
+
+// Ordered by how specific the declaration is, so a hand-written `.d.ts` wins over the source it
+// describes, and TypeScript sources win over emitted JavaScript.
+const TS_PATH_TARGET_EXTENSIONS = ['.d.ts', '.d.mts', '.d.cts', '.ts', '.tsx', '.mts', '.cts', '.js', '.jsx', '.mjs', '.cjs']
+
+/**
+ * Resolve an extensionless `paths` target to the file TypeScript should load for it.
+ *
+ * `bundler` resolution retries a fixed set of extensions when a substitution is extensionless,
+ * but the `node` environment is resolved as `nodenext`, which does not: the target has to name a
+ * real file. Returns `undefined` when nothing matches, leaving the target untouched.
+ */
+async function resolveExtensionlessTarget (absolutePath: string): Promise<string | undefined> {
+  for (const extension of TS_PATH_TARGET_EXTENSIONS) {
+    const candidate = absolutePath + extension
+    if (await fsp.stat(candidate).then(s => s.isFile(), () => false)) {
+      return candidate
+    }
+  }
+  return undefined
+}
+
 // Exclude bridge alias types to support Volar
 const excludedAlias = [/^@vue\/.*$/, /^#internal\/nuxt/]
 
@@ -446,9 +468,18 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
     return { ...compilerOptions, noEmit: true, types: [], paths: {} }
   }
 
-  // This describes the environment where we load `nuxt.config.ts` (and modules)
+  // This describes the environment where we load `nuxt.config.ts` (and modules).
   const nodeTsConfig: TSConfig = defu(nuxt.options.typescript?.nodeTsConfig, {
-    compilerOptions: nonAppCompilerOptions(),
+    compilerOptions: {
+      ...nonAppCompilerOptions(),
+      ...isV5OrHigher
+        ? {
+            module: 'nodenext',
+            moduleResolution: 'nodenext',
+            erasableSyntaxOnly: true,
+          }
+        : {},
+    },
     include: [...nodeInclude],
     exclude: [...nodeExclude],
   } satisfies TSConfig)
@@ -552,9 +583,16 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
       tsConfig.compilerOptions!.paths[alias] = [...new Set(await Promise.all(paths.map(async (path: string) => {
         if (!isAbsolute(path)) { return path }
         const stats = await fsp.stat(path).catch(() => null /* file does not exist */)
-        return stats?.isFile()
-          ? getPathSubstitution(path, nuxt.options.buildDir)
-          : relativeWithDot(nuxt.options.buildDir, path)
+        if (stats?.isFile()) {
+          return getPathSubstitution(path, nuxt.options.buildDir)
+        }
+        // A declaration file next to the target wins over a directory of the same name, which is
+        // how `#app/types` resolves to `types.ts` rather than the `types/` directory beside it.
+        const resolved = await resolveExtensionlessTarget(path)
+        if (resolved) {
+          return relativeWithDot(nuxt.options.buildDir, resolved)
+        }
+        return relativeWithDot(nuxt.options.buildDir, path)
       })))]
     }
 

--- a/packages/kit/src/types.ts
+++ b/packages/kit/src/types.ts
@@ -54,6 +54,16 @@ export function packageName (specifier: string): string {
   return specifier[0] === '@' ? segments.slice(0, 2).join('/') : segments[0]!
 }
 
+export interface ResolveTypePathsOptions {
+  /**
+   * Resolve a bare package to the file its entry resolves to, rather than to the package root.
+   *
+   * A `paths` substitution naming a directory is only followed under `bundler` resolution.
+   * `nodenext`, which the `node` environment's tsconfig uses, requires it to name a file.
+   */
+  entry?: boolean
+}
+
 const rootCache = new Map<string, Promise<string | undefined>>()
 
 function resolveRoot (basePkg: string, from: Array<string | URL>): Promise<string | undefined> {
@@ -83,17 +93,22 @@ function resolveRoot (basePkg: string, from: Array<string | URL>): Promise<strin
  *
  * Returns `[specifier, absolutePath]` pairs, omitting any specifier that cannot be resolved.
  */
-export async function resolveTypePaths (packages: string[], searchPaths: string[]): Promise<Array<[string, string]>> {
+export async function resolveTypePaths (packages: string[], searchPaths: string[], options: ResolveTypePathsOptions = {}): Promise<Array<[string, string]>> {
   const from = searchPaths.map(d => directoryToURL(d))
 
   const settled = await Promise.allSettled(packages.map(async (pkg): Promise<[string, string] | undefined> => {
-    if (pkg === packageName(pkg)) {
+    if (pkg === packageName(pkg) && !options.entry) {
       const root = await resolveRoot(pkg, from)
       return root ? [pkg, root] : undefined
     }
 
     const resolved = resolveModulePath(pkg, { from, try: true, ...TYPE_RESOLVE_OPTIONS })
-    return resolved ? [pkg, await resolveDeclarationPath(resolved)] : undefined
+    if (resolved) {
+      return [pkg, await resolveDeclarationPath(resolved)]
+    }
+
+    const root = options.entry ? await resolveRoot(pkg, from) : undefined
+    return root ? [pkg, root] : undefined
   }))
 
   return settled.flatMap(result => result.status === 'fulfilled' && result.value ? [result.value] : [])

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -125,6 +125,37 @@ describe('tsConfig generation', () => {
     }
   })
 
+  it('should resolve the node tsconfig as nodenext so unloadable syntax is reported', async () => {
+    const { tsConfig, nodeTsConfig, sharedTsConfig } = await _generateTypes(mockNuxtWithOptions({
+      future: { compatibilityVersion: 5 },
+    }))
+    expect(nodeTsConfig.compilerOptions?.module).toBe('nodenext')
+    expect(nodeTsConfig.compilerOptions?.moduleResolution).toBe('nodenext')
+    expect(nodeTsConfig.compilerOptions?.allowImportingTsExtensions).toBe(true)
+    expect(nodeTsConfig.compilerOptions?.erasableSyntaxOnly).toBe(true)
+    for (const config of [tsConfig, sharedTsConfig]) {
+      expect(config.compilerOptions?.moduleResolution).not.toBe('nodenext')
+      expect(config.compilerOptions?.erasableSyntaxOnly).toBeUndefined()
+    }
+  })
+
+  it('should keep the previous node tsconfig module resolution before v5', async () => {
+    const { nodeTsConfig } = await _generateTypes(mockNuxtWithOptions({
+      future: { compatibilityVersion: 4 },
+    }))
+    expect(nodeTsConfig.compilerOptions?.moduleResolution).not.toBe('nodenext')
+    expect(nodeTsConfig.compilerOptions?.erasableSyntaxOnly).toBeUndefined()
+  })
+
+  it('should let a user override the node tsconfig module resolution', async () => {
+    const { nodeTsConfig } = await _generateTypes(mockNuxtWithOptions({
+      future: { compatibilityVersion: 5 },
+      typescript: { nodeTsConfig: { compilerOptions: { module: 'preserve', moduleResolution: 'bundler' } } },
+    }))
+    expect(nodeTsConfig.compilerOptions?.module).toBe('preserve')
+    expect(nodeTsConfig.compilerOptions?.moduleResolution).toBe('bundler')
+  })
+
   it('should let per-context options override the global tsConfig', async () => {
     const { nodeTsConfig, sharedTsConfig } = await _generateTypes(mockNuxtWithOptions({
       typescript: {

--- a/packages/kit/test/jiti-resolution.spec.ts
+++ b/packages/kit/test/jiti-resolution.spec.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import process from 'node:process'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { exec } from 'tinyexec'
 import { resolveModulePath } from 'exsolve'
@@ -23,11 +23,8 @@ const BLOCK_BARE = `export function resolve (specifier, context, next) {
   return next(specifier, context)
 }`
 
-/** Hook that makes `jiti` unreachable entirely. */
-const BLOCK_ALL = `export function resolve (specifier, context, next) {
-  if (specifier === 'jiti' || /[/\\\\]jiti[/\\\\]/.test(specifier)) { throw new Error('jiti blocked') }
-  return next(specifier, context)
-}`
+/** Hook that makes `jiti` unreachable entirely, shared with the `no-jiti` test project. */
+const BLOCK_ALL = pathToFileURL(join(repoRoot, 'test/no-jiti/block-jiti-loader.mjs')).href
 
 const RUNNER = `import { register } from 'node:module'
 register(new URL(process.argv[2], import.meta.url))
@@ -51,7 +48,7 @@ describe('jiti resolution', { sequential: true }, () => {
   let projectDir: string
   let projectJiti: string
 
-  async function run (hook: 'block-bare.mjs' | 'block-all.mjs') {
+  async function run (hook: string) {
     const { stdout } = await exec(process.execPath, [join(tempDir, 'run.mjs'), hook, kitEntry, projectDir], {
       nodeOptions: { cwd: repoRoot },
     })
@@ -65,7 +62,6 @@ describe('jiti resolution', { sequential: true }, () => {
     projectJiti = join(projectDir, 'node_modules/jiti')
 
     await writeFile(join(tempDir, 'block-bare.mjs'), BLOCK_BARE)
-    await writeFile(join(tempDir, 'block-all.mjs'), BLOCK_ALL)
     await writeFile(join(tempDir, 'run.mjs'), RUNNER)
 
     await mkdir(join(projectDir, 'node_modules/enum-module'), { recursive: true })
@@ -117,7 +113,7 @@ describe('jiti resolution', { sequential: true }, () => {
   }, 60_000)
 
   it('reports how to install jiti when it cannot be found anywhere', async () => {
-    const result = await run('block-all.mjs')
+    const result = await run(BLOCK_ALL)
     expect(result.ok).toBe(false)
     expect(result.code).toBe('NUXT_B5017')
     expect(result.message).toMatch(/could not be loaded/)

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -16,7 +16,10 @@
     "nuxt": "bin/nuxt.mjs"
   },
   "exports": {
-    ".": "./src/index.ts",
+    ".": {
+      "types": "./types.dev.d.ts",
+      "default": "./src/index.ts"
+    },
     "./config": {
       "types": "./config.d.ts",
       "import": "./config.js",
@@ -103,7 +106,6 @@
     "hookable": "catalog:app-runtime",
     "ignore": "catalog:build",
     "impound": "catalog:build",
-    "jiti": "catalog:build",
     "klona": "catalog:app-runtime",
     "knitwork": "catalog:build",
     "magic-string": "catalog:vite",
@@ -146,6 +148,7 @@
     "@vitejs/plugin-vue": "catalog:vue",
     "@vitejs/plugin-vue-jsx": "catalog:dev",
     "@vue/compiler-sfc": "catalog:vue",
+    "jiti": "catalog:build",
     "rolldown": "catalog:vite",
     "tsdown": "catalog:dev",
     "typescript": "catalog:dev",
@@ -157,6 +160,7 @@
   "peerDependencies": {
     "@parcel/watcher": "^2.1.0",
     "@types/node": ">=18.12.0",
+    "jiti": "catalog:build",
     "rolldown": "^1.1.5"
   },
   "peerDependenciesMeta": {
@@ -164,6 +168,9 @@
       "optional": true
     },
     "@types/node": {
+      "optional": true
+    },
+    "jiti": {
       "optional": true
     }
   },

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -6,7 +6,7 @@ import { AsyncLocalStorage } from 'node:async_hooks'
 import { isAbsolute, join, normalize, relative, resolve } from 'pathe'
 import { createDebugger, createHooks } from 'hookable'
 import ignore from 'ignore'
-import type { LoadNuxtOptions } from '@nuxt/kit'
+import type { LoadNuxtOptions, ResolveTypePathsOptions } from '@nuxt/kit'
 import { addBuildPlugin, addComponent, addPlugin, addPluginTemplate, addRouteMiddleware, addTypeTemplate, addVitePlugin, configDiagnostics, ensureDependencyInstalled, getAddDependencyCommand, getLayerDirectories, installModules, loadNuxtConfig, nuxtCtx, resolveAlias, resolveFiles, resolveIgnorePatterns, resolveModuleWithOptions, resolveTypePaths, runWithNuxtContext } from '@nuxt/kit'
 import type { PackageJson } from 'pkg-types'
 import { readPackageJSON } from 'pkg-types'
@@ -301,6 +301,7 @@ async function initNuxt (nuxt: Nuxt) {
 
   // Set nitro resolutions for types that might be obscured with shamefully-hoist=false
   let paths: Record<string, [string]> | undefined
+  let nodePaths: Record<string, [string]> | undefined
   const applyNitroTypePaths = async (nitroConfig: NuxtOptions['nitro']) => {
     paths ||= await resolveTypescriptPaths(nuxt)
     nitroConfig.typescript = defu(nitroConfig.typescript, {
@@ -363,8 +364,11 @@ async function initNuxt (nuxt: Nuxt) {
 
     // Set Nuxt resolutions for types that might be obscured with shamefully-hoist=false
     paths ||= await resolveTypescriptPaths(nuxt)
+    // The `node` environment resolves as `nodenext`, which will not follow a substitution that
+    // names a directory, so its packages are resolved to the entry file itself.
+    nodePaths ||= await resolveTypescriptPaths(nuxt, { entry: true })
     opts.tsConfig.compilerOptions = defu(opts.tsConfig.compilerOptions, { paths: { ...paths } })
-    opts.nodeTsConfig.compilerOptions = defu(opts.nodeTsConfig.compilerOptions, { paths: { ...paths } })
+    opts.nodeTsConfig.compilerOptions = defu(opts.nodeTsConfig.compilerOptions, { paths: { ...nodePaths } })
     // required for the server builder's augmentations (referenced above)
     opts.nodeTsConfig.compilerOptions!.paths!['#app/types'] ||= [resolve(nuxt.options.appDir, 'types')]
     opts.sharedTsConfig.compilerOptions = defu(opts.sharedTsConfig.compilerOptions, { paths: { ...paths } })
@@ -1177,7 +1181,7 @@ async function resolveModules (nuxt: Nuxt) {
 }
 
 const NESTED_PKG_RE = /^[^@]+\//
-async function resolveTypescriptPaths (nuxt: Nuxt): Promise<Record<string, [string]>> {
+async function resolveTypescriptPaths (nuxt: Nuxt, options?: ResolveTypePathsOptions): Promise<Record<string, [string]>> {
   nuxt.options.typescript.hoist ||= []
 
   const packagesToResolve: string[] = []
@@ -1200,7 +1204,7 @@ async function resolveTypescriptPaths (nuxt: Nuxt): Promise<Record<string, [stri
     packagesToResolve.push(pkg)
   }
 
-  const resolved = await resolveTypePaths(packagesToResolve, nuxt.options.modulesDir)
+  const resolved = await resolveTypePaths(packagesToResolve, nuxt.options.modulesDir, options)
 
   const paths: Record<string, [string]> = {}
   const nightlyResolved = new Set<string>() // track which originals were resolved via nightly

--- a/packages/nuxt/src/core/plugins/plugin-metadata.ts
+++ b/packages/nuxt/src/core/plugins/plugin-metadata.ts
@@ -5,7 +5,7 @@ import type { Nuxt } from '@nuxt/schema'
 import { createUnplugin } from 'unplugin'
 import { generateTransform, rolldownString } from 'rolldown-string'
 import { normalize } from 'pathe'
-import type { NuxtAppLiterals, PluginMeta } from '../../app/types'
+import type { NuxtAppLiterals, PluginMeta } from '../../app/types.ts'
 
 import { parseAndWalk } from 'oxc-walker'
 import type { ESTree } from 'rolldown/utils'

--- a/packages/nuxt/src/core/schema.ts
+++ b/packages/nuxt/src/core/schema.ts
@@ -5,11 +5,9 @@ import { join, relative, resolve } from 'pathe'
 import { watch } from 'chokidar'
 import { defu } from 'defu'
 import { debounce } from 'perfect-debounce'
-import { configDiagnostics, createIsIgnored, createResolver, defineNuxtModule, directoryToURL, getAddDependencyCommand, getLayerDirectories, importModule } from '@nuxt/kit'
+import { configDiagnostics, createIsIgnored, createResolver, defineNuxtModule, directoryToURL, getAddDependencyCommand, getLayerDirectories, importModule, loadJiti } from '@nuxt/kit'
 import { generateTypes, resolveSchema as resolveUntypedSchema } from 'untyped'
 import type { Schema, SchemaDefinition } from 'untyped'
-import { createJiti } from 'jiti'
-import type { Jiti } from 'jiti'
 import { linkToAlias } from '../utils.ts'
 
 export default defineNuxtModule({
@@ -19,19 +17,36 @@ export default defineNuxtModule({
   async setup (_, nuxt) {
     const resolver = createResolver(import.meta.url)
 
-    // `untyped/babel-plugin` pulls in the whole of `@babel/core`, so the loader is
-    // only created if a layer actually ships a `nuxt.schema.*` file.
-    let _resolveSchema: Promise<Jiti> | undefined
+    // A schema file's JSDoc annotations are extracted by `untyped/babel-plugin`, which has to run
+    // as an import-time transform, so this is the one place Nuxt cannot fall back to loading the
+    // file with the runtime's own importer. `jiti` is an optional peer dependency and
+    // `untyped/babel-plugin` pulls in the whole of `@babel/core`, so neither is loaded unless a
+    // layer actually ships a `nuxt.schema.*` file.
+    let _resolveSchema: ReturnType<typeof createSchemaLoader> | undefined
     function getSchemaLoader () {
-      _resolveSchema ||= import('untyped/babel-plugin').then(({ default: untypedPlugin }) => createJiti(fileURLToPath(import.meta.url), {
+      _resolveSchema ||= createSchemaLoader()
+      return _resolveSchema
+    }
+
+    async function createSchemaLoader () {
+      const jiti = await loadJiti({
+        rootDir: nuxt.options.rootDir,
+        searchPaths: nuxt.options.modulesDir,
+      })
+
+      if (!jiti) {
+        return undefined
+      }
+
+      const { default: untypedPlugin } = await import('untyped/babel-plugin')
+      return jiti.createJiti(fileURLToPath(import.meta.url), {
         fsCache: false,
         transformOptions: {
           babel: {
             plugins: [untypedPlugin],
           },
         },
-      }))
-      return _resolveSchema
+      })
     }
 
     // Register module types
@@ -119,10 +134,18 @@ export default defineNuxtModule({
       for (const dirs of layerDirs) {
         const filePath = await resolver.resolvePath(join(dirs.root, 'nuxt.schema'))
         if (filePath && existsSync(filePath)) {
+          const loader = await getSchemaLoader()
+          if (!loader) {
+            configDiagnostics.NUXT_B5019({
+              filePath: linkToAlias(filePath, nuxt),
+              installCommand: await getAddDependencyCommand('jiti', nuxt.options.rootDir, { dev: true }),
+            })
+            continue
+          }
           let loadedConfig: SchemaDefinition
           try {
             // TODO: fix type for second argument of `import`
-            loadedConfig = await (await getSchemaLoader()).import(filePath, { default: true }) as SchemaDefinition
+            loadedConfig = await loader.import(filePath, { default: true }) as SchemaDefinition
           } catch (err) {
             configDiagnostics.NUXT_B5005({ filePath: linkToAlias(filePath, nuxt), cause: err })
             continue

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -253,7 +253,30 @@ export const schemaNodeTemplate: NuxtTemplate = {
   dependsOn: [],
   getContents: ({ nuxt }) => {
     const relativeRoot = relative(resolve(nuxt.options.buildDir, 'types'), nuxt.options.rootDir)
-    const getImportName = (name: string) => (name[0] === '.' ? './' + join(relativeRoot, name) : name).replace(IMPORT_NAME_RE, '')
+    // The `node` environment resolves as `nodenext` from v5, which will not retry extensions for
+    // a path that does not name a file, so a module's own entry has to be named in full.
+    const keepExtension = (nuxt.options.future?.compatibilityVersion ?? 4) >= 5
+    const moduleExtensions = [...nuxt.options.extensions, '.mjs', '.cjs']
+    const getImportName = (name: string) => {
+      const specifier = name[0] === '.' ? './' + join(relativeRoot, name) : name
+      if (!keepExtension) {
+        return specifier.replace(IMPORT_NAME_RE, '')
+      }
+      if (IMPORT_NAME_RE.test(specifier) || (name[0] !== '.' && name[0] !== '/')) {
+        return specifier
+      }
+      // A module registered by an aliased or extensionless path is recorded without one
+      const absolutePath = resolve(nuxt.options.rootDir, name)
+      for (const extension of moduleExtensions) {
+        if (existsSync(absolutePath + extension)) {
+          return specifier + extension
+        }
+        if (existsSync(join(absolutePath, 'index' + extension))) {
+          return specifier + '/index' + extension
+        }
+      }
+      return specifier
+    }
 
     const modules: [string, string, NuxtOptions['_installedModules'][number]][] = []
     for (const m of nuxt.options._installedModules) {

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
 import { genArrayFromRaw, genDynamicImport, genExport, genImport, genObjectFromRawEntries, genSafeVariableName, genString } from 'knitwork'
-import { join, relative, resolve } from 'pathe'
+import { isAbsolute, join, relative, resolve } from 'pathe'
 import type { JSValue } from 'untyped'
 import { generateTypes, resolveSchema } from 'untyped'
 import escapeRE from 'escape-string-regexp'
@@ -262,7 +262,7 @@ export const schemaNodeTemplate: NuxtTemplate = {
       if (!keepExtension) {
         return specifier.replace(IMPORT_NAME_RE, '')
       }
-      if (IMPORT_NAME_RE.test(specifier) || (name[0] !== '.' && name[0] !== '/')) {
+      if (IMPORT_NAME_RE.test(specifier) || (name[0] !== '.' && !isAbsolute(name))) {
         return specifier
       }
       // A module registered by an aliased or extensionless path is recorded without one

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -40,7 +40,6 @@
     "escape-string-regexp": "catalog:build",
     "exsolve": "catalog:build",
     "file-loader": "catalog:webpack",
-    "jiti": "catalog:build",
     "knitwork": "catalog:build",
     "memfs": "catalog:webpack",
     "mini-css-extract-plugin": "catalog:webpack",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -38,7 +38,6 @@
     "exsolve": "catalog:build",
     "generic-names": "catalog:build",
     "get-port-please": "catalog:build",
-    "jiti": "catalog:build",
     "js-tokens": "catalog:build",
     "knitwork": "catalog:build",
     "mlly": "catalog:build",

--- a/packages/vite/src/css.ts
+++ b/packages/vite/src/css.ts
@@ -1,8 +1,7 @@
 import type { Nuxt, NuxtOptions } from '@nuxt/schema'
 import type { InlineConfig as ViteConfig } from 'vite'
 import type { Plugin } from 'postcss'
-import { createJiti } from 'jiti'
-import { bundlerDiagnostics, ensureDependencyInstalled, getAddDependencyCommand } from '@nuxt/kit'
+import { bundlerDiagnostics, directoryToURL, ensureDependencyInstalled, getAddDependencyCommand, tryImportModule } from '@nuxt/kit'
 
 function sortPlugins ({ plugins, order }: NuxtOptions['postcss']): string[] {
   const names = Object.keys(plugins)
@@ -18,13 +17,11 @@ export async function resolveCSSOptions (nuxt: Nuxt): Promise<ViteConfig['css']>
 
   const postcssOptions = nuxt.options.postcss
 
-  const jiti = createJiti(nuxt.options.rootDir, { alias: nuxt.options.alias })
-
   for (const pluginName of sortPlugins(postcssOptions)) {
     const pluginOptions = postcssOptions.plugins[pluginName]
     if (!pluginOptions) { continue }
 
-    const pluginFn = await resolvePostcssPlugin(jiti, pluginName, nuxt)
+    const pluginFn = await resolvePostcssPlugin(pluginName, nuxt)
     if (typeof pluginFn === 'function') {
       css.postcss.plugins.push(pluginFn(pluginOptions))
     }
@@ -33,12 +30,14 @@ export async function resolveCSSOptions (nuxt: Nuxt): Promise<ViteConfig['css']>
   return css
 }
 
-async function resolvePostcssPlugin (jiti: ReturnType<typeof createJiti>, pluginName: string, nuxt: Nuxt): Promise<((opts: Record<string, any>) => Plugin) | undefined> {
-  for (const parentURL of nuxt.options.modulesDir) {
-    const pluginFn = await jiti.import(pluginName, { parentURL: parentURL.replace(/\/node_modules\/?$/, ''), try: true, default: true }) as (opts: Record<string, any>) => Plugin
-    if (typeof pluginFn === 'function') {
-      return pluginFn
-    }
+async function resolvePostcssPlugin (pluginName: string, nuxt: Nuxt): Promise<((opts: Record<string, any>) => Plugin) | undefined> {
+  const parentURLs = nuxt.options.modulesDir.map(dir => directoryToURL(dir.replace(/\/node_modules\/?$/, '')))
+
+  const importPlugin = () => tryImportModule<(opts: Record<string, any>) => Plugin>(pluginName, { url: parentURLs })
+
+  let pluginFn = await importPlugin()
+  if (typeof pluginFn === 'function') {
+    return pluginFn
   }
 
   // Plugin not found - prompt the user to install it
@@ -49,12 +48,9 @@ async function resolvePostcssPlugin (jiti: ReturnType<typeof createJiti>, plugin
   })
 
   if (installed) {
-    // Retry resolution after installation
-    for (const parentURL of nuxt.options.modulesDir) {
-      const pluginFn = await jiti.import(pluginName, { parentURL: parentURL.replace(/\/node_modules\/?$/, ''), try: true, default: true }) as (opts: Record<string, any>) => Plugin
-      if (typeof pluginFn === 'function') {
-        return pluginFn
-      }
+    pluginFn = await importPlugin()
+    if (typeof pluginFn === 'function') {
+      return pluginFn
     }
   }
 

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -41,7 +41,6 @@
     "file-loader": "catalog:webpack",
     "fork-ts-checker-webpack-plugin": "catalog:webpack",
     "hash-sum": "catalog:webpack",
-    "jiti": "catalog:build",
     "knitwork": "catalog:build",
     "memfs": "catalog:webpack",
     "mini-css-extract-plugin": "catalog:webpack",

--- a/packages/webpack/src/utils/postcss.ts
+++ b/packages/webpack/src/utils/postcss.ts
@@ -1,9 +1,8 @@
 import createResolver from 'postcss-import-resolver'
 import type { Nuxt, NuxtOptions } from '@nuxt/schema'
 import { defu } from 'defu'
-import { createJiti } from 'jiti'
 import type { Plugin } from 'postcss'
-import { bundlerDiagnostics, getAddDependencyCommand } from '@nuxt/kit'
+import { bundlerDiagnostics, directoryToURL, getAddDependencyCommand, tryImportModule } from '@nuxt/kit'
 
 const isPureObject = (obj: unknown): obj is object => obj !== null && !Array.isArray(obj) && typeof obj === 'object'
 
@@ -45,8 +44,6 @@ export async function getPostcssConfig (nuxt: Nuxt) {
 
   const defaultPluginNames = new Set(Object.keys(defaultPlugins))
 
-  const jiti = createJiti(nuxt.options.rootDir, { alias: nuxt.options.alias })
-
   // Keep the order of default plugins
   if (!Array.isArray(postcssOptions.plugins) && isPureObject(postcssOptions.plugins)) {
     // Map postcss plugins into instances on object mode once
@@ -56,18 +53,14 @@ export async function getPostcssConfig (nuxt: Nuxt) {
       if (!pluginOptions) { continue }
 
       const isDefault = defaultPluginNames.has(pluginName)
-      const parentURLs = isDefault ? [import.meta.url] : nuxt.options.modulesDir
+      const parentURLs = isDefault
+        ? [new URL(import.meta.url)]
+        : nuxt.options.modulesDir.map(dir => directoryToURL(dir.replace(/\/node_modules\/?$/, '')))
 
-      let pluginFn: ((opts: Record<string, any>) => Plugin) | undefined
-      for (const parentURL of parentURLs) {
-        pluginFn = await jiti.import(pluginName, { parentURL: parentURL.replace(/\/node_modules\/?$/, ''), try: true, default: true }) as (opts: Record<string, any>) => Plugin
-        if (typeof pluginFn === 'function') {
-          plugins.push(pluginFn(pluginOptions))
-          break
-        }
-      }
-
-      if (typeof pluginFn !== 'function') {
+      const pluginFn = await tryImportModule<(opts: Record<string, any>) => Plugin>(pluginName, { url: parentURLs })
+      if (typeof pluginFn === 'function') {
+        plugins.push(pluginFn(pluginOptions))
+      } else {
         const installCommand = await getAddDependencyCommand(pluginName, nuxt.options.rootDir, { dev: true })
         if (isDefault) {
           bundlerDiagnostics.NUXT_B7011({ pluginName, installCommand })

--- a/patches/nitropack@2.13.4.patch
+++ b/patches/nitropack@2.13.4.patch
@@ -1,0 +1,8 @@
+diff --git a/types.d.ts b/types.d.ts
+index 888993344aa6dfe9b4986cbd34596d34d647af3c..b4ea20e8c0baeca7cd3b4c08934afed993b90b08 100644
+--- a/types.d.ts
++++ b/types.d.ts
+@@ -1 +1 @@
+-export * from "./dist/types/index";
+\ No newline at end of file
++export * from "./dist/types/index.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -589,6 +589,7 @@ overrides:
 patchedDependencies:
   changelogen: 8aee9e31504b2889cfb6b9bae91ba797bea8acef312c723134cb1e70cc7e4c2b
   nitro@3.0.260610-beta: 9273407579edf95350876c36b226440ebe6482463a007ad87c2f535365e21162
+  nitropack@2.13.4: 14fc1a0de87a798e71fa108469f4b19797146bf7e82bee35ba801b43c2919ab8
 
 importers:
 
@@ -881,7 +882,7 @@ importers:
         version: 3.0.260610-beta(patch_hash=9273407579edf95350876c36b226440ebe6482463a007ad87c2f535365e21162)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(ioredis@5.10.1(supports-color@10.2.2))(jiti@2.7.0)(lru-cache@11.5.2)(rollup@4.62.3)(vite@8.1.5)
       nitropack:
         specifier: catalog:dev
-        version: 2.13.4(@rspack/core@2.1.5(@swc/helpers@0.5.23))(oxc-parser@0.141.0)(rolldown@1.1.5)(srvx@0.12.4)(supports-color@10.2.2)(vite@8.1.5)(webpack@5.109.0(cssnano@8.0.2(postcss@8.5.23))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23))
+        version: 2.13.4(patch_hash=14fc1a0de87a798e71fa108469f4b19797146bf7e82bee35ba801b43c2919ab8)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(oxc-parser@0.141.0)(rolldown@1.1.5)(srvx@0.12.4)(supports-color@10.2.2)(vite@8.1.5)(webpack@5.109.0(cssnano@8.0.2(postcss@8.5.23))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23))
       tsdown:
         specifier: catalog:dev
         version: 0.22.14(@arethetypeswrong/core@0.18.5)(@vitejs/devtools@0.3.1)(@volar/typescript@2.4.28)(oxc-resolver@11.24.2)(publint@0.3.21)(typescript@7.0.2)(vue-tsc@3.3.8(typescript@7.0.2))
@@ -1096,9 +1097,6 @@ importers:
       impound:
         specifier: catalog:build
         version: 1.1.6(@rspack/core@2.1.5(@swc/helpers@0.5.23))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.3)(vite@8.1.5)(webpack@5.109.0(cssnano@8.0.2(postcss@8.5.23))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23))
-      jiti:
-        specifier: catalog:build
-        version: 2.7.0
       klona:
         specifier: catalog:app-runtime
         version: 2.0.6
@@ -1220,6 +1218,9 @@ importers:
       '@vue/compiler-sfc':
         specifier: catalog:vue
         version: 3.5.40
+      jiti:
+        specifier: catalog:build
+        version: 2.7.0
       rolldown:
         specifier: 1.1.5
         version: 1.1.5
@@ -1283,9 +1284,6 @@ importers:
       file-loader:
         specifier: catalog:webpack
         version: 6.2.0(webpack@5.109.0(cssnano@8.0.2(postcss@8.5.23))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23))
-      jiti:
-        specifier: catalog:build
-        version: 2.7.0
       knitwork:
         specifier: catalog:build
         version: 1.3.0
@@ -1597,9 +1595,6 @@ importers:
       get-port-please:
         specifier: catalog:build
         version: 3.2.0
-      jiti:
-        specifier: catalog:build
-        version: 2.7.0
       js-tokens:
         specifier: catalog:build
         version: 10.0.0
@@ -1675,7 +1670,7 @@ importers:
         version: h3@2.0.1-rc.22(crossws@0.4.10(srvx@0.12.4))
       nitropack:
         specifier: catalog:dev
-        version: 2.13.4(@rspack/core@2.1.5(@swc/helpers@0.5.23))(oxc-parser@0.141.0)(rolldown@1.1.5)(srvx@0.12.4)(supports-color@10.2.2)(vite@8.1.5)(webpack@5.109.0(cssnano@8.0.2(postcss@8.5.23))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23))
+        version: 2.13.4(patch_hash=14fc1a0de87a798e71fa108469f4b19797146bf7e82bee35ba801b43c2919ab8)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(oxc-parser@0.141.0)(rolldown@1.1.5)(srvx@0.12.4)(supports-color@10.2.2)(vite@8.1.5)(webpack@5.109.0(cssnano@8.0.2(postcss@8.5.23))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23))
       postcss:
         specifier: catalog:build
         version: 8.5.23
@@ -1739,9 +1734,6 @@ importers:
       hash-sum:
         specifier: catalog:webpack
         version: 2.0.0
-      jiti:
-        specifier: catalog:build
-        version: 2.7.0
       knitwork:
         specifier: catalog:build
         version: 1.3.0
@@ -17650,7 +17642,7 @@ snapshots:
       - uploadthing
       - wrangler
 
-  nitropack@2.13.4(@rspack/core@2.1.5(@swc/helpers@0.5.23))(oxc-parser@0.141.0)(rolldown@1.1.5)(srvx@0.12.4)(supports-color@10.2.2)(vite@8.1.5)(webpack@5.109.0(cssnano@8.0.2(postcss@8.5.23))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23)):
+  nitropack@2.13.4(patch_hash=14fc1a0de87a798e71fa108469f4b19797146bf7e82bee35ba801b43c2919ab8)(@rspack/core@2.1.5(@swc/helpers@0.5.23))(oxc-parser@0.141.0)(rolldown@1.1.5)(srvx@0.12.4)(supports-color@10.2.2)(vite@8.1.5)(webpack@5.109.0(cssnano@8.0.2(postcss@8.5.23))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.23)):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.62.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,8 @@ packages:
 patchedDependencies:
   changelogen: patches/changelogen.patch
   nitro@3.0.260610-beta: patches/nitro@3.0.260610-beta.patch
+  # `types.d.ts` re-exports an extensionless path, which `nodenext` cannot resolve
+  nitropack@2.13.4: patches/nitropack@2.13.4.patch
 
 publicHoistPattern:
   - '*-loader'

--- a/test/no-jiti/block-jiti-loader.mjs
+++ b/test/no-jiti/block-jiti-loader.mjs
@@ -1,0 +1,14 @@
+/**
+ * Module customisation hook that makes any attempt to load `jiti` fail loudly.
+ *
+ * `jiti` is an optional peer dependency of `@nuxt/kit` and `nuxt`, and it is present in this
+ * repository's `node_modules` as a transitive dependency, so its absence cannot be asserted by
+ * installation alone. Registering this hook in a child process is what lets the tests prove that
+ * a default project never reaches for it.
+ */
+export function resolve (specifier, context, next) {
+  if (specifier === 'jiti' || /[/\\]jiti[/\\]/.test(specifier)) {
+    throw new Error(`jiti was requested (${specifier})`)
+  }
+  return next(specifier, context)
+}

--- a/test/no-jiti/no-jiti.test.ts
+++ b/test/no-jiti/no-jiti.test.ts
@@ -1,0 +1,102 @@
+import { existsSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { exec } from 'tinyexec'
+import { glob } from 'tinyglobby'
+import { join, relative } from 'pathe'
+
+const repoRoot = fileURLToPath(new URL('../..', import.meta.url))
+const runner = fileURLToPath(new URL('./run-without-jiti.mjs', import.meta.url))
+
+const kitSource = join(repoRoot, 'packages/kit/src/index.ts')
+const kitDist = join(repoRoot, 'packages/kit/dist/index.mjs')
+
+/** Packages allowed to declare `jiti`, and only as an optional peer dependency. */
+const OPTIONAL_JITI_PACKAGES = new Set(['@nuxt/kit', 'nuxt'])
+
+async function runWithoutJiti (kitEntry: string, task: 'config' | 'build', cwds: string[]) {
+  const { stdout, stderr, exitCode } = await exec(process.execPath, [runner, kitEntry, task, ...cwds], {
+    nodeOptions: { cwd: repoRoot },
+  })
+  // the child reports `ok <cwd>` per success, so a failure can be attributed to the fixture
+  // that caused it rather than just to the run as a whole
+  const completed = stdout.split('\n').filter(line => line.startsWith('ok ')).map(line => line.slice(3))
+  const failedOn = cwds.find(cwd => !completed.includes(cwd))
+  return {
+    exitCode,
+    completed,
+    /** Message describing where and why the child stopped, for use as an assertion message. */
+    report: [
+      failedOn && `failed on ${relative(repoRoot, failedOn)} (${completed.length}/${cwds.length} succeeded)`,
+      stderr.trim().split('\n').slice(-40).join('\n'),
+    ].filter(Boolean).join('\n\n'),
+  }
+}
+
+async function fixtureDirs () {
+  const configs = await glob(['test/fixtures/*/nuxt.config.ts', 'playground/nuxt.config.ts'], { cwd: repoRoot, absolute: true })
+  return configs.map(config => join(config, '..')).sort()
+}
+
+describe('jiti is not required', () => {
+  it('is not a hard dependency of any published package', async () => {
+    const manifests = await glob('packages/*/package.json', { cwd: repoRoot, absolute: true })
+    expect(manifests.length).toBeGreaterThan(0)
+
+    const offenders: string[] = []
+    for (const manifest of manifests) {
+      const pkg = JSON.parse(await readFile(manifest, 'utf8')) as {
+        name: string
+        private?: boolean
+        dependencies?: Record<string, string>
+        peerDependencies?: Record<string, string>
+        peerDependenciesMeta?: Record<string, { optional?: boolean }>
+      }
+      if (pkg.private) { continue }
+
+      if (pkg.dependencies?.jiti) {
+        offenders.push(`${pkg.name} lists jiti in dependencies`)
+      }
+      if (pkg.peerDependencies?.jiti) {
+        if (!OPTIONAL_JITI_PACKAGES.has(pkg.name)) {
+          offenders.push(`${pkg.name} should not declare jiti at all`)
+        } else if (!pkg.peerDependenciesMeta?.jiti?.optional) {
+          offenders.push(`${pkg.name} declares jiti as a required peer dependency`)
+        }
+      }
+    }
+
+    expect(offenders).toEqual([])
+  })
+
+  it.skipIf(!existsSync(kitDist))('does not statically import jiti from the built kit', async () => {
+    const dist = await readFile(kitDist, 'utf8')
+    expect(dist).not.toMatch(/^import[^\n]*['"]jiti['"]/m)
+    // the fallback is still expected, as a lazy import
+    expect(dist).toMatch(/import\(['"]jiti['"]\)/)
+  })
+
+  it('loads the config of every fixture', async () => {
+    const dirs = await fixtureDirs()
+    expect(dirs.length).toBeGreaterThan(10)
+
+    const { exitCode, completed, report } = await runWithoutJiti(kitSource, 'config', dirs)
+    expect(exitCode, report).toBe(0)
+    expect(completed).toEqual(dirs)
+  }, 120_000)
+
+  it.skipIf(!existsSync(kitDist))('loads the config of every fixture from the built kit', async () => {
+    const dirs = await fixtureDirs()
+    const { exitCode, completed, report } = await runWithoutJiti(kitDist, 'config', dirs)
+    expect(exitCode, report).toBe(0)
+    expect(completed).toEqual(dirs)
+  }, 120_000)
+
+  it.skipIf(process.env.SKIP_NO_JITI_BUILD === 'true')('builds a minimal application', async () => {
+    const cwd = join(repoRoot, 'test/fixtures/minimal')
+    const { exitCode, report } = await runWithoutJiti(kitSource, 'build', [cwd])
+    expect(exitCode, report).toBe(0)
+  }, 300_000)
+})

--- a/test/no-jiti/run-without-jiti.mjs
+++ b/test/no-jiti/run-without-jiti.mjs
@@ -1,0 +1,35 @@
+/**
+ * Child-process entry for the `no-jiti` tests.
+ *
+ * Usage: `node run-without-jiti.mjs <kitEntry> <task> <cwd...>`
+ *
+ * `task` is either `config` (load the config of every `cwd`) or `build` (load and build the first
+ * `cwd`). Reports one `ok <cwd>` line per success and exits non-zero on the first failure, so the
+ * test can attribute a failure to a specific fixture.
+ */
+import { register } from 'node:module'
+import { pathToFileURL } from 'node:url'
+
+register(new URL('block-jiti-loader.mjs', import.meta.url))
+
+const [kitEntry, task, ...cwds] = process.argv.slice(2)
+
+const kit = await import(pathToFileURL(kitEntry).href)
+
+if (task === 'build') {
+  const nuxt = await kit.loadNuxt({ cwd: cwds[0] })
+  try {
+    await kit.buildNuxt(nuxt)
+  } finally {
+    await nuxt.close()
+  }
+  console.log(`ok ${cwds[0]}`)
+} else {
+  for (const cwd of cwds) {
+    const options = await kit.loadNuxtConfig({ cwd })
+    if (!options.rootDir) {
+      throw new Error(`no rootDir resolved for ${cwd}`)
+    }
+    console.log(`ok ${cwd}`)
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -148,6 +148,16 @@ export default defineConfig({
         },
       },
       {
+        test: {
+          name: 'no-jiti',
+          include: ['test/no-jiti/*.test.ts'],
+          globalSetup: ['./test/setup-prepare.ts'],
+          setupFiles: ['./test/setup-env.ts'],
+          testTimeout: 300_000,
+          benchmark: { include: [] },
+        },
+      },
+      {
         define: {
           'import.meta.dev': '(globalThis.__TEST_DEV__ ?? false)',
         },


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this drops `jiti` as a direct dependency of nuxt, just as nitro has done. in cases where users still need its transformations, nuxt will prompt to install it