### PR TITLE
fix(nuxt): don't warn about missing `<NuxtPage>` on nav + with slot

### DIFF
--- a/packages/nuxt/src/app/components/route-provider.ts
+++ b/packages/nuxt/src/app/components/route-provider.ts
@@ -1,7 +1,8 @@
-import { defineComponent, h, nextTick, onMounted, provide, shallowReactive } from 'vue'
+import { defineComponent, h, nextTick, onMounted, onUnmounted, provide, shallowReactive } from 'vue'
 import type { DefineSetupFnComponent, Ref, VNode } from 'vue'
 import type { RouteLocationNormalizedLoaded } from 'vue-router'
 import { renderDiagnostics } from '../diagnostics/render'
+import { trackRenderedRecord } from '../diagnostics/rendered-records'
 import { PageRouteSymbol } from './injections'
 
 interface RouteProviderProps {
@@ -41,6 +42,13 @@ export const defineRouteProvider = (name = 'RouteProvider'): RouteProviderCompon
     }
 
     provide(PageRouteSymbol, shallowReactive(route))
+
+    if (import.meta.dev && import.meta.client) {
+      const record = props.route.matched.find(m => m.components?.default === props.vnode?.type)
+      if (record) {
+        onUnmounted(trackRenderedRecord(record))
+      }
+    }
 
     let vnode: VNode
     if (import.meta.dev && import.meta.client && props.trackRootNodes) {

--- a/packages/nuxt/src/app/components/route-provider.ts
+++ b/packages/nuxt/src/app/components/route-provider.ts
@@ -1,6 +1,6 @@
 import { defineComponent, h, nextTick, onMounted, onUnmounted, provide, shallowReactive } from 'vue'
 import type { DefineSetupFnComponent, Ref, VNode } from 'vue'
-import type { RouteLocationNormalizedLoaded } from 'vue-router'
+import type { RouteLocationNormalizedLoaded, RouteRecordNormalized } from 'vue-router'
 import { renderDiagnostics } from '../diagnostics/render'
 import { trackRenderedRecord } from '../diagnostics/rendered-records'
 import { PageRouteSymbol } from './injections'
@@ -11,6 +11,8 @@ interface RouteProviderProps {
   vnodeRef?: Ref<any>
   renderKey?: string
   trackRootNodes?: boolean
+  /** the matched route record this provider renders, used by dev-only render diagnostics */
+  routeRecord?: RouteRecordNormalized
 }
 
 export type RouteProviderComponent = DefineSetupFnComponent<RouteProviderProps>
@@ -26,6 +28,7 @@ export const defineRouteProvider = (name = 'RouteProvider'): RouteProviderCompon
     vnodeRef: Object as () => Ref<any>,
     renderKey: String,
     trackRootNodes: Boolean,
+    routeRecord: Object as () => RouteRecordNormalized,
   },
   setup (props) {
     // Prevent reactivity when the page will be rerendered in a different suspense fork
@@ -44,7 +47,7 @@ export const defineRouteProvider = (name = 'RouteProvider'): RouteProviderCompon
     provide(PageRouteSymbol, shallowReactive(route))
 
     if (import.meta.dev && import.meta.client) {
-      const record = props.route.matched.find(m => m.components?.default === props.vnode?.type)
+      const record = props.routeRecord ?? props.route.matched.find(m => m.components?.default === props.vnode?.type)
       if (record) {
         onUnmounted(trackRenderedRecord(record))
       }

--- a/packages/nuxt/src/app/diagnostics/rendered-records.ts
+++ b/packages/nuxt/src/app/diagnostics/rendered-records.ts
@@ -1,0 +1,19 @@
+import type { RouteRecordNormalized } from 'vue-router'
+
+const mountedRecords = new WeakMap<RouteRecordNormalized, number>()
+
+export function trackRenderedRecord (record: RouteRecordNormalized): () => void {
+  mountedRecords.set(record, (mountedRecords.get(record) ?? 0) + 1)
+  return () => {
+    const count = (mountedRecords.get(record) ?? 0) - 1
+    if (count > 0) {
+      mountedRecords.set(record, count)
+    } else {
+      mountedRecords.delete(record)
+    }
+  }
+}
+
+export function isRecordRendered (record: RouteRecordNormalized): boolean {
+  return (mountedRecords.get(record) ?? 0) > 0
+}

--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -261,6 +261,7 @@ export default defineComponent({
                       renderKey: key || undefined,
                       trackRootNodes: hasTransition,
                       vnodeRef: pageRef,
+                      routeRecord: import.meta.dev ? routeProps.route.matched.find(m => m.components?.default === routeProps.Component.type) : undefined,
                     }
 
                     if (!keepaliveConfig) {

--- a/packages/nuxt/src/pages/runtime/plugins/check-if-page-unused.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/check-if-page-unused.ts
@@ -6,13 +6,17 @@ import { onNuxtReady } from '#app/composables/ready'
 import { useError } from '#app/composables/error'
 import { useRouter } from '#app/composables/router'
 import { renderDiagnostics } from '../../../app/diagnostics/render'
+import { isRecordRendered } from '../../../app/diagnostics/rendered-records'
 
 export function findUnrenderedNestedPage (route: RouteLocationNormalizedLoaded): { parent: RouteRecordNormalized, child: RouteRecordNormalized } | undefined {
   let parent: RouteRecordNormalized | undefined
   for (const record of route.matched) {
     // vue-router renders the child directly at the parent's depth for records without a component
     if (!record.components?.default) { continue }
-    if (!Object.values(record.instances ?? {}).some(Boolean)) {
+    // vue-router clears `instances` when a keyed page vnode unmounts, even if a new instance for
+    // the same record has already mounted (sibling navigation like `/parent/1` -> `/parent/2`),
+    // so fall back to the records Nuxt itself has mounted
+    if (!Object.values(record.instances ?? {}).some(Boolean) && !isRecordRendered(record)) {
       // an unrendered record without a rendered parent is covered by the E4011 check
       return parent ? { parent, child: record } : undefined
     }

--- a/test/nuxt/dev/check-if-page-unused.dev.test.ts
+++ b/test/nuxt/dev/check-if-page-unused.dev.test.ts
@@ -137,14 +137,42 @@ describe('check-if-page-unused: nested page without `<NuxtPage />` (#25077)', ()
     router.removeRoute('sibling-parent')
   })
 
+  it('does not warn on sibling navigation when the parent wraps the page in a slot', async () => {
+    router.addRoute({
+      name: 'slot-parent',
+      path: '/slot-parent',
+      component: defineComponent({
+        name: 'slot-parent-page',
+        setup: () => () => h('div', ['parent content', h(NuxtPage, null, {
+          default: ({ Component }: any) => Component ? h('section', [h(Component)]) : null,
+        })]),
+      }),
+      children: [{ name: 'slot-parent-child', path: ':id', component: child }],
+    })
+
+    const el = await mountAndNavigate('/slot-parent/1')
+    await navigateAndSettle('/slot-parent/2')
+
+    expect(el.html()).toContain('child content')
+    const messages = warn.mock.calls.map(args => args.join(' ')).filter(m => m.includes('NUXT_E4016'))
+    expect(messages).toHaveLength(0)
+
+    el.unmount()
+    router.removeRoute('slot-parent')
+  })
+
   it('does not warn for parent routes without a component', async () => {
     router.addRoute({
       name: 'transparent-parent',
       path: '/transparent-parent',
-      children: [{ name: 'transparent-parent-child', path: 'child', component: child }],
+      children: [
+        { name: 'transparent-parent-child', path: 'child', component: child },
+        { name: 'transparent-parent-other', path: 'other', component: child },
+      ],
     })
 
     const el = await mountAndNavigate('/transparent-parent/child')
+    await navigateAndSettle('/transparent-parent/other')
 
     expect(el.html()).toContain('child content')
     const messages = warn.mock.calls.map(args => args.join(' ')).filter(m => m.includes('NUXT_E4016'))

--- a/test/nuxt/dev/check-if-page-unused.dev.test.ts
+++ b/test/nuxt/dev/check-if-page-unused.dev.test.ts
@@ -118,6 +118,25 @@ describe('check-if-page-unused: nested page without `<NuxtPage />` (#25077)', ()
     router.removeRoute('ok-parent')
   })
 
+  it('does not warn when navigating between sibling child routes (#35945)', async () => {
+    router.addRoute({
+      name: 'sibling-parent',
+      path: '/sibling-parent',
+      component: parentComponent(true),
+      children: [{ name: 'sibling-parent-child', path: ':id', component: child }],
+    })
+
+    const el = await mountAndNavigate('/sibling-parent/1')
+    await navigateAndSettle('/sibling-parent/2')
+
+    expect(el.html()).toContain('child content')
+    const messages = warn.mock.calls.map(args => args.join(' ')).filter(m => m.includes('NUXT_E4016'))
+    expect(messages).toHaveLength(0)
+
+    el.unmount()
+    router.removeRoute('sibling-parent')
+  })
+
   it('does not warn for parent routes without a component', async () => {
     router.addRoute({
       name: 'transparent-parent',


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/35945

### 📚 Description

this solves a couple of false positive warnings (dev-mode only) when a page is rendered as a child or has a slot