### PR TITLE
fix(nitro): define `import.meta.test` for server code

### DIFF
--- a/packages/nitro-server/src/augments.ts
+++ b/packages/nitro-server/src/augments.ts
@@ -21,6 +21,13 @@ export interface NuxtTracingChannelOptions {
   unstorage?: boolean
 }
 
+declare global {
+  interface ImportMeta {
+    dev: boolean
+    test: boolean
+  }
+}
+
 declare module 'nitropack' {
   interface NitroRuntimeConfigApp {
     buildAssetsDir: string

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -352,6 +352,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     },
     replace: {
       '__VUE_PROD_DEVTOOLS__': String(false),
+      'import.meta.test': String(!!nuxt.options.test),
     },
     rollupConfig: {
       output: {

--- a/test/fixtures/basic-types/server/type-context.ts
+++ b/test/fixtures/basic-types/server/type-context.ts
@@ -9,3 +9,6 @@ const appConfig = useAppConfig()
 expectTypeOf(appConfig.fromNuxtConfig).toEqualTypeOf<boolean>()
 expectTypeOf(appConfig.userConfig).toEqualTypeOf<123 | 456 | undefined>()
 expectTypeOf(appConfig.fromLayer).toEqualTypeOf<unknown>()
+
+expectTypeOf(import.meta.dev).toEqualTypeOf<boolean>()
+expectTypeOf(import.meta.test).toEqualTypeOf<boolean>()

--- a/test/fixtures/basic-types/shared/shared-types.ts
+++ b/test/fixtures/basic-types/shared/shared-types.ts
@@ -29,4 +29,9 @@ describe('shared folder', () => {
     expectTypeOf(config.userConfig).toEqualTypeOf<123 | 456 | undefined>()
     expectTypeOf(config.fromLayer).toEqualTypeOf<unknown>()
   })
+
+  it('types build flags', () => {
+    expectTypeOf(import.meta.dev).toEqualTypeOf<boolean>()
+    expectTypeOf(import.meta.test).toEqualTypeOf<boolean>()
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

see https://github.com/npmx-dev/npmx.dev/pull/3094

### 📚 Description

previously the type of `import.meta.test` leaked into nitro code from nuxt app side, but this was never in fact replaced, so it was always falsy. when we fixed leaky types in v4.5, this was exposed.

this both adds support for replacing it properly, and typing it in situations where the app types don't leak into the server