### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/docs/4.api/1.components/2.nuxt-page.md
+++ b/docs/4.api/1.components/2.nuxt-page.md
@@ -54,6 +54,8 @@ In a typical Vue application, a new page component is mounted **only after** the
   - type: `boolean` or [`TransitionProps`](https://vuejs.org/api/built-in-components#transition)
 - `keepalive`: control state preservation of pages rendered with the `NuxtPage` component.
   - type: `boolean` or [`KeepAliveProps`](https://vuejs.org/api/built-in-components#keepalive)
+- `stableContent`: keep the last successfully rendered page visible while a new page is still resolving during rapid/concurrent navigation, instead of tearing down the pending `<Suspense>` boundary and showing a blank frame. Default `false` preserves the existing behaviour.
+  - type: `boolean`
 
 ::tip
 Nuxt automatically resolves the `name` and `route` by scanning and rendering all Vue component files found in the `/pages` directory.
@@ -74,6 +76,20 @@ You can also use a dynamic key based on the current route:
 ```html
 <NuxtPage :page-key="route => route.fullPath" />
 ```
+
+If you want to prevent blank flashes when users click rapidly between links before the new page resolves, you can opt in with `stable-content`:
+
+```vue [app/app.vue]
+<template>
+  <NuxtPage stable-content />
+</template>
+```
+
+With `stable-content` enabled, `<NuxtPage>` skips the internal `suspenseKey` increment on rapid concurrent navigation, allowing Vue's `<Suspense>` to keep the previously-resolved content visible until the new page is ready to swap in.
+
+::note
+This is opt-in because it changes how rapid navigation is reconciled. Existing apps that do not pass the prop see no change in behaviour.
+::
 
 ::warning
 Don't use `$route` object here as it can cause problems with how `<NuxtPage>` renders pages with `<Suspense>`.

--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -27,6 +27,14 @@ export interface NuxtPageProps extends RouterViewProps {
    * Control when the `NuxtPage` component is re-rendered.
    */
   pageKey?: string | ((route: RouteLocationNormalizedLoaded) => string)
+
+  /**
+   * Keep the last successfully rendered page visible while a new page
+   * is still resolving during rapid/concurrent navigation, instead of
+   * tearing down the pending `<Suspense>` boundary and showing a blank
+   * frame. Default `false` preserves the existing behaviour.
+   */
+  stableContent?: boolean
 }
 
 const _routeProviders = import.meta.dev ? new Map<string, ReturnType<typeof defineRouteProvider> | undefined>() : new WeakMap<Component, ReturnType<typeof defineRouteProvider> | undefined>()
@@ -52,6 +60,10 @@ export default defineComponent({
     pageKey: {
       type: [Function, String] as unknown as () => string | ((route: RouteLocationNormalizedLoaded) => string),
       default: null,
+    },
+    stableContent: {
+      type: Boolean,
+      default: false,
     },
   },
   setup (props, { attrs, slots, expose }) {
@@ -160,7 +172,9 @@ export default defineComponent({
 
               // remount suspense on rapid navigation, but not before the first resolve:
               // tearing down a never-resolved suspensible Suspense strands its parent. See #28425, #34683.
-              if (isSuspensePending && previousPageKey !== key && hasResolvedOnce) {
+              // When `stableContent` is opted in, skip the remount so Vue's <Suspense>
+              // keeps the previously-resolved content visible until the new page resolves (see #35236).
+              if (isSuspensePending && previousPageKey !== key && hasResolvedOnce && !props.stableContent) {
                 suspenseKey++
               }
 

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -23,7 +23,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const clientStats = await analyzeSizes(['**/*.js'], join(rootDir, '.output/public'), rootDir)
 
     expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"108k"`)
-    expect.soft(roundToKilobytes(clientStats!.gzipBytes)).toMatchInlineSnapshot(`"40.2k"`)
+    expect.soft(roundToKilobytes(clientStats!.gzipBytes)).toMatchInlineSnapshot(`"40.3k"`)
 
     const entry = await fsp.readFile(join(rootDir, '.output/public', clientStats!.files.find(f => f.startsWith('_nuxt/entry'))!), 'utf8')
     expect(entry).not.toContain('[ofetch] global.fetch is not supported')
@@ -40,7 +40,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
   it('does not ship payload revival machinery in a spa build', async () => {
     const clientStats = await analyzeSizes(['**/*.js'], join(spaRootDir, '.output/public'), spaRootDir)
 
-    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"101k"`)
+    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"102k"`)
 
     const contents = await Promise.all(
       (await glob(['**/*.js'], { cwd: join(spaRootDir, '.output/public') }))

--- a/test/nuxt/nuxt-page.test.ts
+++ b/test/nuxt/nuxt-page.test.ts
@@ -1126,3 +1126,156 @@ describe('NuxtPage with page keys', () => {
     el.unmount()
   })
 })
+
+// https://github.com/nuxt/nuxt/issues/35236
+describe('NuxtPage `stableContent` prop', () => {
+  let router: ReturnType<typeof useRouter>
+  let nuxtApp: ReturnType<typeof useNuxtApp>
+  let resolveAlpha: undefined | (() => void)
+  let resolveBeta: undefined | (() => void)
+  let resolveGamma: undefined | (() => void)
+
+  const counts = {
+    alpha: { setup: 0, render: 0 },
+    beta: { setup: 0, render: 0 },
+    gamma: { setup: 0, render: 0 },
+  }
+
+  function resetCounts () {
+    Object.values(counts).forEach((c) => { c.setup = 0; c.render = 0 })
+  }
+
+  beforeEach(() => {
+    router = useRouter()
+    nuxtApp = useNuxtApp()
+    resolveAlpha = undefined
+    resolveBeta = undefined
+    resolveGamma = undefined
+    resetCounts()
+
+    router.addRoute({
+      name: 'stable-alpha',
+      path: '/stable-alpha',
+      component: defineComponent({
+        name: 'stable-alpha',
+        async setup () {
+          counts.alpha.setup++
+          await new Promise<void>((r) => { resolveAlpha = r })
+          return () => {
+            counts.alpha.render++
+            return h('div', { 'data-testid': 'stable-alpha' }, 'Alpha Content')
+          }
+        },
+      }),
+    })
+    router.addRoute({
+      name: 'stable-beta',
+      path: '/stable-beta',
+      component: defineComponent({
+        name: 'stable-beta',
+        async setup () {
+          counts.beta.setup++
+          await new Promise<void>((r) => { resolveBeta = r })
+          return () => {
+            counts.beta.render++
+            return h('div', { 'data-testid': 'stable-beta' }, 'Beta Content')
+          }
+        },
+      }),
+    })
+    router.addRoute({
+      name: 'stable-gamma',
+      path: '/stable-gamma',
+      component: defineComponent({
+        name: 'stable-gamma',
+        async setup () {
+          counts.gamma.setup++
+          await new Promise<void>((r) => { resolveGamma = r })
+          return () => {
+            counts.gamma.render++
+            return h('div', { 'data-testid': 'stable-gamma' }, 'Gamma Content')
+          }
+        },
+      }),
+    })
+  })
+
+  afterEach(() => {
+    router.removeRoute('stable-alpha')
+    router.removeRoute('stable-beta')
+    router.removeRoute('stable-gamma')
+  })
+
+  it('defaults to false and resolves to the final route after rapid concurrent navigation', async () => {
+    const el = await mountSuspended({
+      setup: () => () => h(NuxtLayout, {}, { default: () => h(NuxtPage) }),
+    })
+
+    // Resolve alpha first to establish hasResolvedOnce
+    await navigateTo('/stable-alpha')
+    resolveAlpha!()
+    await new Promise<void>(resolve => nuxtApp.hooks.hookOnce('page:finish', () => resolve()))
+    await flushPromises()
+    expect(el.html()).toContain('Alpha Content')
+
+    // Navigate to beta (still pending) then immediately to gamma
+    await navigateTo('/stable-beta')
+    await navigateTo('/stable-gamma')
+    resolveGamma!()
+    await new Promise<void>(resolve => nuxtApp.hooks.hookOnce('page:finish', () => resolve()))
+    await flushPromises()
+
+    expect(el.html()).toContain('Gamma Content')
+    expect(el.html()).not.toContain('Alpha Content')
+    expect(el.html()).not.toContain('Beta Content')
+
+    el.unmount()
+  })
+
+  it('with `stableContent` enabled, also resolves to the final route after rapid concurrent navigation', async () => {
+    const el = await mountSuspended({
+      setup: () => () => h(NuxtLayout, {}, { default: () => h(NuxtPage, { stableContent: true }) }),
+    })
+
+    // Resolve alpha first to establish hasResolvedOnce
+    await navigateTo('/stable-alpha')
+    resolveAlpha!()
+    await new Promise<void>(resolve => nuxtApp.hooks.hookOnce('page:finish', () => resolve()))
+    await flushPromises()
+    expect(el.html()).toContain('Alpha Content')
+
+    // Navigate to beta (still pending) then immediately to gamma
+    await navigateTo('/stable-beta')
+    await navigateTo('/stable-gamma')
+    resolveGamma!()
+    await new Promise<void>(resolve => nuxtApp.hooks.hookOnce('page:finish', () => resolve()))
+    await flushPromises()
+
+    // Final state still settles on the most recent route
+    expect(el.html()).toContain('Gamma Content')
+    expect(el.html()).not.toContain('Alpha Content')
+
+    el.unmount()
+  })
+
+  it('with `stableContent` enabled, plain non-concurrent navigation still mounts the new route', async () => {
+    const el = await mountSuspended({
+      setup: () => () => h(NuxtLayout, {}, { default: () => h(NuxtPage, { stableContent: true }) }),
+    })
+
+    await navigateTo('/stable-alpha')
+    resolveAlpha!()
+    await new Promise<void>(resolve => nuxtApp.hooks.hookOnce('page:finish', () => resolve()))
+    await flushPromises()
+    expect(el.html()).toContain('Alpha Content')
+
+    await navigateTo('/stable-beta')
+    resolveBeta!()
+    await new Promise<void>(resolve => nuxtApp.hooks.hookOnce('page:finish', () => resolve()))
+    await flushPromises()
+    expect(el.html()).toContain('Beta Content')
+    expect(el.html()).not.toContain('Alpha Content')
+
+    el.unmount()
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

resolves #35236

### 📚 Description

When navigating quickly between routes (cross-component), `<NuxtPage>` increments `suspenseKey` on every navigation. This recreates `<Suspense>` and tears down the previous component content, even if developers want to keep showing the old content while the new page loads.

This PR introduces a new opt-in prop, `stableContent`, to the `<NuxtPage>` component. 
When enabled via `<NuxtPage stable-content />`, this prop skips the internal `suspenseKey` increment on rapid concurrent navigation. This allows Vue's `<Suspense>` to keep the previously-resolved content visible until the new page is ready to swap in, supporting a seamless url-first navigation model without a blank flash.

The default behaviour is preserved (`stableContent: false`) so existing applications are not affected.

- Added `stableContent` prop to `NuxtPageProps` and `NuxtPage` definition.
- Documented `stable-content` in `NuxtPage` API components.
- Added E2E/runtime tests to verify rapid cross-navigation behaviour with and without the prop.