### PR TITLE
docs: add `test/` in directory structure

### DIFF
--- a/docs/2.directory-structure/1.test.md
+++ b/docs/2.directory-structure/1.test.md
@@ -1,0 +1,25 @@
+---
+title: 'test'
+head.title: 'test/'
+description: 'Use the test/ directory to organize unit, Nuxt, and end-to-end tests for your application.'
+navigation.icon: i-vscode-icons-folder-type-test
+---
+
+The `test/` directory is the recommended place for your application tests. Nuxt does not scan it the way it does `app/` or `server/`; you choose the runner and layout yourself (typically with [`@nuxt/test-utils`](/docs/4.x/getting-started/testing)).
+
+A common layout separates environments:
+
+```bash [Directory structure]
+-| test/
+---| e2e/
+---| nuxt/
+---| unit/
+```
+
+- `test/unit/` — fast Node tests without the Nuxt runtime
+- `test/nuxt/` — tests that need the Nuxt runtime environment
+- `test/e2e/` — end-to-end tests against a running app
+
+::read-more{to="/docs/4.x/getting-started/testing#organizing-your-tests"}
+See **Organizing Your Tests** for setup, Vitest projects, and TypeScript context.
+::

--- a/docs/2.directory-structure/index.md
+++ b/docs/2.directory-structure/index.md
@@ -46,6 +46,10 @@ The [`server/`](/docs/4.x/directory-structure/server) directory is the directory
 
 The [`shared/`](/docs/4.x/directory-structure/shared) directory is the directory that contains the shared code of the Nuxt application and Nuxt server. This code can be used in both the Vue app and the Nitro server.
 
+## Test Directory
+
+The [`test/`](/docs/4.x/directory-structure/test) directory is the recommended place for application tests (unit, Nuxt runtime, and end-to-end). See [Organizing Your Tests](/docs/4.x/getting-started/testing#organizing-your-tests) for layout and setup details.
+
 ## Content Directory
 
 The [`content/`](/docs/4.x/directory-structure/content) directory is enabled by the [Nuxt Content](https://content.nuxt.com) module. It is used to create a file-based CMS for your application using Markdown files.


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #35983

### 📚 Description

The Directory Structure overview had no `test/` entry. The testing guide already recommends that layout.

I added a short `test/` page and linked it from the overview to the organizing-tests section.