### PR TITLE
fix(nuxt): skip cookie watcher entirely when readonly

### DIFF
--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -51,6 +51,8 @@ export interface CookieOptions<T = any> extends _CookieOptions {
    * Note: the expiration is not refreshed automatically — you must
    * assign to `cookie.value` to trigger the refresh.
    *
+   * Ignored when `readonly` is set.
+   *
    * @default false
    */
   refresh?: boolean
@@ -195,9 +197,8 @@ export function useCookie<T = string | null | undefined> (name: string, _opts?: 
       channel.onmessage = ({ data }) => handleChange(data)
     }
 
-    if (opts.watch) {
-      // `readonly` must always win: `refresh` only bypasses the no-op check, never the readonly guard
-      cookieWatcher = watch(cookie, () => callback(!opts.readonly && opts.refresh), { deep: opts.watch !== 'shallow' })
+    if (opts.watch && !opts.readonly) {
+      cookieWatcher = watch(cookie, () => callback(opts.refresh), { deep: opts.watch !== 'shallow' })
     }
 
     if (shouldSetInitialClientCookie) {

--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -198,7 +198,8 @@ export function useCookie<T = string | null | undefined> (name: string, _opts?: 
     if (opts.watch) {
       watch(cookie, () => {
         if (watchPaused) { return }
-        callback(opts.refresh)
+        // `readonly` must always win: `refresh` only bypasses the no-op check, never the readonly guard
+        callback(!opts.readonly && opts.refresh)
       },
       { deep: opts.watch !== 'shallow' })
     }

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -23,7 +23,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const clientStats = await analyzeSizes(['**/*.js'], join(rootDir, '.output/public'), rootDir)
 
     expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"108k"`)
-    expect.soft(roundToKilobytes(clientStats!.gzipBytes)).toMatchInlineSnapshot(`"40.2k"`)
+    expect.soft(roundToKilobytes(clientStats!.gzipBytes)).toMatchInlineSnapshot(`"40.3k"`)
 
     const entry = await fsp.readFile(join(rootDir, '.output/public', clientStats!.files.find(f => f.startsWith('_nuxt/entry'))!), 'utf8')
     expect(entry).not.toContain('[ofetch] global.fetch is not supported')
@@ -40,7 +40,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
   it('does not ship payload revival machinery in a spa build', async () => {
     const clientStats = await analyzeSizes(['**/*.js'], join(spaRootDir, '.output/public'), spaRootDir)
 
-    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"101k"`)
+    expect.soft(roundToKilobytes(clientStats!.totalBytes)).toMatchInlineSnapshot(`"102k"`)
 
     const contents = await Promise.all(
       (await glob(['**/*.js'], { cwd: join(spaRootDir, '.output/public') }))

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -1319,6 +1319,7 @@ describe('useCookie', () => {
     // A stray write to `.value` (e.g. slipping past the `Readonly<>` type) must
     // still never reach the browser cookie: `readonly` always wins over `refresh`.
     ;(cookie as any).value = 'stray-write'
+    expect(cookie.value).toBe('stray-write')
     await nextTick()
 
     expect(document.cookie).not.toContain('readonly-refresh-test=stray-write')

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -1316,12 +1316,12 @@ describe('useCookie', () => {
     document.cookie = 'readonly-refresh-test=; Max-Age=0'
     expect(document.cookie).not.toContain('readonly-refresh-test=original')
 
-    // Whatever triggers the ref to change (e.g. cross-tab sync), `readonly` must
-    // still prevent this composable instance from ever writing the cookie back.
-    ;(cookie as any).value = 'mutated'
+    // A stray write to `.value` (e.g. slipping past the `Readonly<>` type) must
+    // still never reach the browser cookie: `readonly` always wins over `refresh`.
+    ;(cookie as any).value = 'stray-write'
     await nextTick()
 
-    expect(document.cookie).not.toContain('readonly-refresh-test=mutated')
+    expect(document.cookie).not.toContain('readonly-refresh-test=stray-write')
   })
 
   it('should re-evaluate expires getter on each cookie write', async () => {

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -1316,8 +1316,6 @@ describe('useCookie', () => {
     document.cookie = 'readonly-refresh-test=; Max-Age=0'
     expect(document.cookie).not.toContain('readonly-refresh-test=original')
 
-    // A stray write to `.value` (e.g. slipping past the `Readonly<>` type) must
-    // still never reach the browser cookie: `readonly` always wins over `refresh`.
     ;(cookie as any).value = 'stray-write'
     expect(cookie.value).toBe('stray-write')
     await nextTick()

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -1301,6 +1301,29 @@ describe('useCookie', () => {
     expect(document.cookie).not.toContain('no-refresh-test=original')
   })
 
+  it('should never write a readonly cookie, even when refresh is true', async () => {
+    const { nextTick } = await import('vue')
+
+    document.cookie = 'readonly-refresh-test=original'
+    const cookie = useCookie('readonly-refresh-test', {
+      maxAge: 3600,
+      readonly: true,
+      refresh: true,
+    })
+    expect(cookie.value).toBe('original')
+
+    // Clear document.cookie to detect if a write happens
+    document.cookie = 'readonly-refresh-test=; Max-Age=0'
+    expect(document.cookie).not.toContain('readonly-refresh-test=original')
+
+    // Whatever triggers the ref to change (e.g. cross-tab sync), `readonly` must
+    // still prevent this composable instance from ever writing the cookie back.
+    ;(cookie as any).value = 'mutated'
+    await nextTick()
+
+    expect(document.cookie).not.toContain('readonly-refresh-test=mutated')
+  })
+
   it('should re-evaluate expires getter on each cookie write', async () => {
     const { nextTick } = await import('vue')
     let callCount = 0


### PR DESCRIPTION
### Description

`useCookie`'s client side watcher forwards `opts.refresh` directly as the `force` argument to its write callback:

```ts
watch(cookie, () => {
  if (watchPaused) { return }
  callback(opts.refresh)
})
```

Inside callback, force gates both the "value unchanged" no op check and the `opts.readonly` check in a single `if 
(!force)` block. `refresh` is only meant to bypass the no op check, but because both checks share one flag, `refresh: 
true` also disables readonly as a side effect.
As a result, a cookie marked `readonly: true` can still get written to document.cookie once its value changes, for example a stray assignment slipping past the `Readonly<> type`, even though `readonly` is documented to disable writing to the cookie unconditionally.

The server side write path (`writeFinalCookieValue`) already checks `opts.readonly` as its own unconditional condition,
independent of refresh. This change brings the client path in line with that.