### PR TITLE
refactor(nuxt): use native vue pausable watcher for `useCookie`

### DIFF
--- a/packages/nuxt/src/app/composables/cookie.ts
+++ b/packages/nuxt/src/app/composables/cookie.ts
@@ -1,4 +1,4 @@
-import type { Ref } from 'vue'
+import type { Ref, WatchHandle } from 'vue'
 import { customRef, getCurrentScope, nextTick, onScopeDispose, ref, watch } from 'vue'
 import type { CookieParseOptions, CookieSerializeOptions } from 'cookie-es'
 import { parse, serialize } from 'cookie-es'
@@ -153,21 +153,21 @@ export function useCookie<T = string | null | undefined> (name: string, _opts?: 
       channel?.postMessage({ value: opts.encode(cookie.value as T) })
     }
 
+    let cookieWatcher: WatchHandle | undefined
+
     const handleChange = (data: { value?: string | null, refresh?: boolean }) => {
       const value = data.refresh ? readRawCookies(opts)?.[name] : opts.decode(data.value)
-      watchPaused = true
+      cookieWatcher?.pause()
       cookie.value = value
       cookies[name] = klona(value)
-      nextTick(() => { watchPaused = false })
+      nextTick(() => cookieWatcher?.resume())
     }
-
-    let watchPaused = false
 
     const hasScope = !!getCurrentScope()
 
     if (hasScope) {
       onScopeDispose(() => {
-        watchPaused = true
+        cookieWatcher?.pause()
         callback()
         channel?.close()
       })
@@ -196,11 +196,7 @@ export function useCookie<T = string | null | undefined> (name: string, _opts?: 
     }
 
     if (opts.watch) {
-      watch(cookie, () => {
-        if (watchPaused) { return }
-        callback(opts.refresh)
-      },
-      { deep: opts.watch !== 'shallow' })
+      cookieWatcher = watch(cookie, () => callback(opts.refresh), { deep: opts.watch !== 'shallow' })
     }
 
     if (shouldSetInitialClientCookie) {


### PR DESCRIPTION
### 🔗 Linked issue

while reviewing #35997 i thought about using native vue pausable watcher for `useCookie`

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This PR uses vues native pause for the watcher, not sure if this will increase performance because the pause will always be only for one tick.