### PR TITLE
fix(nitro,nuxt): hoist route matcher to prevent temporal dead zone

### DIFF
--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -453,11 +453,14 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
       }
       const sensitiveMatcher = getNormalizedRouter(false).compileToString(compileOptions)
       const foldedMatcher = getNormalizedRouter(true).compileToString(compileOptions)
+      const needsRouterOptions = foldedMatcher !== sensitiveMatcher || caseSensitiveRouteRules
       return [
         `import { defu } from 'defu'`,
-        `import routerOptions from '#build/router.options.mjs'`,
-        `const sensitiveMatcher = ${sensitiveMatcher}`,
-        foldedMatcher === sensitiveMatcher ? `const foldedMatcher = sensitiveMatcher` : `const foldedMatcher = ${foldedMatcher}`,
+        needsRouterOptions ? `import routerOptions from '#build/router.options.mjs'` : ``,
+        needsRouterOptions ? `const sensitiveMatcher = ${sensitiveMatcher}` : ``,
+        needsRouterOptions
+          ? (foldedMatcher === sensitiveMatcher ? `const foldedMatcher = sensitiveMatcher` : `const foldedMatcher = ${foldedMatcher}`)
+          : `const foldedMatcher = ${foldedMatcher}`,
         // `decodeRoutePath` has no free variables, so it can be inlined by source to keep
         // the runtime lookup and the build-time key normalisation from drifting apart.
         `const decodeRoutePath = ${decodeRoutePath.toString()}`,
@@ -468,10 +471,14 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
         `  const decoded = decodeRoutePath(path)`,
         `  return fold ? decoded.toLowerCase() : decoded`,
         `}`,
-        `export default (path) => routerOptions.sensitive`,
-        `  ? defu({}, ...sensitiveMatcher('', normalizePath(path, false)).map(r => r.data).reverse())`,
-        `  : defu({}, ...foldedMatcher('', normalizePath(path, true)).map(r => r.data).reverse())`,
-      ].join('\n')
+        needsRouterOptions
+          ? [
+              `export default (path) => routerOptions.sensitive`,
+              `  ? defu({}, ...sensitiveMatcher('', normalizePath(path, false)).map(r => r.data).reverse())`,
+              `  : defu({}, ...foldedMatcher('', normalizePath(path, true)).map(r => r.data).reverse())`,
+            ].join('\n')
+          : `export default path => defu({}, ...foldedMatcher('', normalizePath(path, true)).map(r => r.data).reverse())`,
+      ].filter(Boolean).join('\n')
     },
   })
 

--- a/packages/nuxt/src/app/composables/layout.ts
+++ b/packages/nuxt/src/app/composables/layout.ts
@@ -9,7 +9,10 @@ import { useRoute } from './router'
 
 import _routeRulesMatcher from '#build/route-rules.mjs'
 
-const routeRulesMatcher = _routeRulesMatcher as (path: string) => NitroRouteRules
+// hoisted so a circular import cannot hit the TDZ of the `#build/route-rules.mjs` default export
+function routeRulesMatcher (path: string): NitroRouteRules {
+  return (_routeRulesMatcher as (path: string) => NitroRouteRules)(path)
+}
 
 export type LayoutName = keyof NuxtLayouts | 'default' | false
 

--- a/packages/nuxt/src/app/composables/manifest.ts
+++ b/packages/nuxt/src/app/composables/manifest.ts
@@ -6,7 +6,10 @@ import { appManifest as isAppManifestEnabled } from '#build/nuxt.config.mjs'
 import { buildAssetsURL } from '#internal/nuxt/paths'
 import _routeRulesMatcher from '#build/route-rules.mjs'
 
-const routeRulesMatcher = _routeRulesMatcher as (path: string) => NitroRouteRules
+// hoisted so a circular import cannot hit the TDZ of the `#build/route-rules.mjs` default export
+function routeRulesMatcher (path: string): NitroRouteRules {
+  return (_routeRulesMatcher as (path: string) => NitroRouteRules)(path)
+}
 
 export interface NuxtAppManifestMeta {
   id: string

--- a/packages/nuxt/src/pages/runtime/plugins/prerender.server.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/prerender.server.ts
@@ -10,7 +10,10 @@ import routerOptions, { hashMode } from '#build/router.options.mjs'
 import { crawlLinks } from '#build/nuxt.config.mjs'
 import _routeRulesMatcher from '#build/route-rules.mjs'
 
-const routeRulesMatcher = _routeRulesMatcher as (path: string) => NitroRouteRules
+// hoisted so a circular import cannot hit the TDZ of the `#build/route-rules.mjs` default export
+function routeRulesMatcher (path: string): NitroRouteRules {
+  return (_routeRulesMatcher as (path: string) => NitroRouteRules)(path)
+}
 
 let routes: string[]
 

--- a/packages/nuxt/test/route-rules-template.test.ts
+++ b/packages/nuxt/test/route-rules-template.test.ts
@@ -12,12 +12,12 @@ async function getRouteRulesTemplate (sensitive: boolean) {
     ready: true,
     overrides: {
       router: { options: { sensitive } },
-      routeRules: { '/admin/**': { appMiddleware: 'auth' } },
+      routeRules: { '/admin/**': { prerender: true } },
     },
   })
   try {
     const template = nuxt.options.build.templates.find(t => t.filename === 'route-rules.mjs')!
-    return await template.getContents!({ nuxt, app: undefined!, options: template.options, utils: undefined! })
+    return await template.getContents!({ nuxt, app: undefined!, options: template.options })
   } finally {
     await nuxt.close()
   }

--- a/packages/nuxt/test/route-rules-template.test.ts
+++ b/packages/nuxt/test/route-rules-template.test.ts
@@ -1,0 +1,38 @@
+import { fileURLToPath } from 'node:url'
+import { normalize } from 'pathe'
+import { withoutTrailingSlash } from 'ufo'
+import { describe, expect, it } from 'vitest'
+import { loadNuxt } from '../src/index.ts'
+
+const pagesFixtureDir = withoutTrailingSlash(normalize(fileURLToPath(new URL('./pages-fixture', import.meta.url))))
+
+async function getRouteRulesTemplate (sensitive: boolean) {
+  const nuxt = await loadNuxt({
+    cwd: pagesFixtureDir,
+    ready: true,
+    overrides: {
+      router: { options: { sensitive } },
+      routeRules: { '/admin/**': { appMiddleware: 'auth' } },
+    },
+  })
+  try {
+    const template = nuxt.options.build.templates.find(t => t.filename === 'route-rules.mjs')!
+    return await template.getContents!({ nuxt, app: undefined!, options: template.options, utils: undefined! })
+  } finally {
+    await nuxt.close()
+  }
+}
+
+describe('route rules template', () => {
+  it('does not import router options when case-insensitive matching is unconditional', async () => {
+    const contents = await getRouteRulesTemplate(false)
+    expect(contents).not.toContain('router.options.mjs')
+    expect(contents).toContain('normalizePath(path, true)')
+  })
+
+  it('picks the matcher at runtime when route rules are case sensitive', async () => {
+    const contents = await getRouteRulesTemplate(true)
+    expect(contents).toContain('router.options.mjs')
+    expect(contents).toContain('routerOptions.sensitive')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/35982

### 📚 Description

since v4.5.1, apps with an `app/router.options.ts` that imports anything reaching `#app` hit this on load:

```
ReferenceError: Cannot access '_routeRulesMatcher' before initialization
```

this was because `#build/route-rules.mjs` imports `router.options.ts`, and if that looped back through `#app` into `useLayout`/`getRouteRules`, those modules were reading the matcher while it was still evaluating.

this PR reads the matcher inside hoisted functions instead, and also drops the `router.options.mjs` import entirely when both matchers are identical and route rules aren't case sensitive, since the flag can't change the result there
