### PR TITLE
perf(nuxt): render internal `<NuxtLink>` anchors directly on server

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -11,7 +11,7 @@ import type {
 } from 'vue'
 import { computed, defineComponent, h, inject, onBeforeUnmount, onMounted, provide, ref, resolveComponent, shallowRef, unref } from 'vue'
 import type { ComponentSlots } from 'vue-component-type-helpers'
-import type { RouteLocation, RouteLocationRaw, Router, RouterLink, RouterLinkProps, useLink } from 'vue-router'
+import type { RouteLocation, RouteLocationRaw, RouteRecordNormalized, Router, RouterLink, RouterLinkProps, useLink } from 'vue-router'
 import { hasProtocol, isScriptProtocol, joinURL, parseQuery, withTrailingSlash, withoutTrailingSlash } from 'ufo'
 import { preloadRouteComponents } from '../composables/preload'
 import { onNuxtReady } from '../composables/ready'
@@ -283,6 +283,58 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
     }
   }
 
+  function checkNuxtLinkNesting () {
+    if (inject(NuxtLinkDevKeySymbol, false)) {
+      renderDiagnostics.NUXT_E4009()
+    } else {
+      provide(NuxtLinkDevKeySymbol, true)
+    }
+  }
+
+  /**
+   * Render an internal link as a plain anchor, matching the markup `<RouterLink>` produces
+   * for the same location.
+   */
+  function renderStaticInternalLink (props: NuxtLinkProps, slots: { default?: (props?: any) => VNode[] }, router: Router, rawTo: RouteLocationRaw) {
+    if (import.meta.dev) {
+      checkPropConflicts(props, 'to', 'href')
+      checkPropConflicts(props, 'noRel', 'rel')
+    }
+
+    const route = router.resolve(resolveTrailingSlashBehavior(rawTo, router.resolve, props.trailingSlash))
+    const currentRoute = router.currentRoute.value
+    const index = activeRecordIndex(route, currentRoute)
+    const isActive = index > -1 && includesParams(currentRoute.params, route.params)
+    const isExactActive = index > -1 && index === currentRoute.matched.length - 1 && isSameRouteLocationParams(currentRoute.params, route.params)
+
+    let dataInternal: string | undefined
+    if (componentIslands && useNuxtApp().ssrContext?.islandContext) {
+      const flags: string[] = []
+      if (props.replace) { flags.push('replace') }
+      const prefetchOnVisibility = typeof props.prefetchOn === 'string' ? props.prefetchOn === 'visibility' : (props.prefetchOn?.visibility ?? options.prefetchOn?.visibility)
+      if (prefetchOnVisibility && (props.prefetch ?? options.prefetch) !== false && props.noPrefetch !== true) { flags.push('prefetch') }
+      dataInternal = flags.join(' ')
+    }
+
+    const routerOptions = router.options
+    return h('a', {
+      'aria-current': isExactActive ? (props.ariaCurrentValue ?? 'page') : null,
+      'href': route.href,
+      'class': {
+        [getLinkClass(props.activeClass || options.activeClass, routerOptions.linkActiveClass, 'router-link-active')]: isActive,
+        [getLinkClass(props.exactActiveClass || options.exactActiveClass, routerOptions.linkExactActiveClass, 'router-link-exact-active')]: isExactActive,
+      },
+      'rel': props.rel || undefined,
+      'data-internal': dataInternal,
+    }, slots.default?.({
+      route,
+      href: route.href,
+      isActive,
+      isExactActive,
+      navigate: () => navigateTo(route.href, { replace: props.replace }),
+    }))
+  }
+
   return defineComponent({
     name: componentName,
     props: {
@@ -375,15 +427,25 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
     setup (props, { slots }) {
       const router = useRouter()
 
+      // On the server an internal link resolves to a static anchor, so it is rendered directly:
+      // no `<RouterLink>` instance, no reactive link state and none of the client-only
+      // prefetching setup below.
+      if (import.meta.server && !props.custom) {
+        const rawTo = props.to || props.href || ''
+        const isExternalLink = props.external || (typeof rawTo === 'string' && (rawTo === '' || hasProtocol(rawTo, { acceptRelative: true })))
+        if (!isExternalLink && !isHashLinkWithoutHashMode(rawTo) && (!props.target || props.target === '_self')) {
+          if (import.meta.dev) {
+            checkNuxtLinkNesting()
+          }
+          return () => renderStaticInternalLink(props, slots, router, rawTo)
+        }
+      }
+
       const routerLinkComponent = resolveComponent('RouterLink')
 
       // vue-router's `useLink` only backs the `route`/`isActive`/`isExactActive` properties of
       // the public `useLink` API, which this component never reads, so skip resolving it here.
       const { to, href, navigate, isExternal, hasTarget, isAbsoluteUrl } = useNuxtLink(props, false)
-
-      const serverLink = import.meta.server && !props.custom && !isExternal.value && !hasTarget.value && !isHashLinkWithoutHashMode(to.value) && typeof routerLinkComponent !== 'string'
-        ? (routerLinkComponent as unknown as typeof RouterLink).useLink({ to: to as any, replace: props.replace })
-        : undefined
 
       // Prefetching
       const prefetched = shallowRef(false)
@@ -443,12 +505,7 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
       }
 
       if (import.meta.dev && import.meta.server && !props.custom) {
-        const isNuxtLinkChild = inject(NuxtLinkDevKeySymbol, false)
-        if (isNuxtLinkChild) {
-          renderDiagnostics.NUXT_E4009()
-        } else {
-          provide(NuxtLinkDevKeySymbol, true)
-        }
+        checkNuxtLinkNesting()
       }
 
       return () => {
@@ -534,30 +591,6 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
             }
           }
 
-          if (import.meta.server && serverLink) {
-            const routerOptions = (router as Router).options
-            const isActive = serverLink.isActive.value
-            const isExactActive = serverLink.isExactActive.value
-            const href = serverLink.href.value
-            return h('a', {
-              'aria-current': isExactActive ? (props.ariaCurrentValue ?? 'page') : null,
-              href,
-              'class': {
-                [getLinkClass(routerLinkProps.activeClass, routerOptions.linkActiveClass, 'router-link-active')]: isActive,
-                [getLinkClass(routerLinkProps.exactActiveClass, routerOptions.linkExactActiveClass, 'router-link-exact-active')]: isExactActive,
-              },
-              'rel': routerLinkProps.rel,
-              'data-internal': routerLinkProps['data-internal'],
-            }, slots.default?.({
-              // `route` is already resolved as a side effect of reading `href` above
-              route: serverLink.route.value,
-              href,
-              isActive,
-              isExactActive,
-              navigate: serverLink.navigate,
-            }))
-          }
-
           // Internal link
           return h(
             routerLinkComponent,
@@ -618,6 +651,67 @@ const NuxtLink: NuxtLinkComponent & Record<string, any> = defineNuxtLink(nuxtLin
 export default NuxtLink
 
 // -- NuxtLink utils --
+
+/*
+ * Active-link resolution, kept in step with the semantics `<RouterLink>` applies so a
+ * server-rendered anchor hydrates against an identical client-rendered one. Route records are
+ * compared through their alias origin, and a link is active when the current location matches
+ * its deepest record and carries at least its params.
+ */
+function isSameRouteRecord (a: RouteRecordNormalized, b: RouteRecordNormalized): boolean {
+  return (a.aliasOf || a) === (b.aliasOf || b)
+}
+
+function getOriginalPath (record: RouteRecordNormalized | undefined): string {
+  return record ? (record.aliasOf ? record.aliasOf.path : record.path) : ''
+}
+
+function isEquivalentArray (a: readonly unknown[], b: unknown): boolean {
+  return Array.isArray(b) ? a.length === b.length && a.every((value, i) => value === b[i]) : a.length === 1 && a[0] === b
+}
+
+function isSameParamValue (a: unknown, b: unknown): boolean {
+  return Array.isArray(a)
+    ? isEquivalentArray(a, b)
+    : Array.isArray(b) ? isEquivalentArray(b, a) : (a && a.valueOf()) === (b && b.valueOf())
+}
+
+function isSameRouteLocationParams (a: RouteLocation['params'], b: RouteLocation['params']): boolean {
+  if (Object.keys(a).length !== Object.keys(b).length) { return false }
+  for (const key in a) {
+    if (!isSameParamValue(a[key], b[key])) { return false }
+  }
+  return true
+}
+
+function includesParams (outer: RouteLocation['params'], inner: RouteLocation['params']): boolean {
+  for (const key in inner) {
+    const innerValue = inner[key]
+    const outerValue = outer[key]
+    if (typeof innerValue === 'string') {
+      if (innerValue !== outerValue) { return false }
+    } else if (!Array.isArray(outerValue) || outerValue.length !== innerValue!.length || innerValue!.some((value, i) => value.valueOf() !== outerValue[i]!.valueOf())) {
+      return false
+    }
+  }
+  return true
+}
+
+function activeRecordIndex (route: RouteLocation, currentRoute: RouteLocation): number {
+  const { matched } = route
+  const { length } = matched
+  const routeMatched = matched[length - 1]
+  const currentMatched = currentRoute.matched
+  if (!routeMatched || !currentMatched.length) { return -1 }
+  const index = currentMatched.findIndex(isSameRouteRecord.bind(null, routeMatched))
+  if (index > -1) { return index }
+  const parentRecordPath = getOriginalPath(matched[length - 2])
+  return length > 1 && getOriginalPath(routeMatched) === parentRecordPath && currentMatched[currentMatched.length - 1]!.path !== parentRecordPath
+    ? currentMatched.findIndex(isSameRouteRecord.bind(null, matched[length - 2]!))
+    : index
+}
+
+/** Resolve an active-link class, falling back from the per-link value to the router-wide one. */
 function getLinkClass (propClass: string | undefined, globalClass: string | undefined, defaultClass: string): string {
   return propClass ?? globalClass ?? defaultClass
 }

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -190,7 +190,12 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
     return resolvedPath
   }
 
-  function useNuxtLink (props: { [K in keyof NuxtLinkProps]: MaybeRef<NuxtLinkProps[K]> }, resolveRouterLink = true) {
+  /**
+   * The link state `<NuxtLink>` renders with. Kept separate from `useNuxtLink` so the component
+   * does not resolve the `<RouterLink>` link state backing `route`/`isActive`/`isExactActive`,
+   * which it never reads.
+   */
+  function useLinkTarget (props: { [K in keyof NuxtLinkProps]: MaybeRef<NuxtLinkProps[K]> }) {
     const router = useRouter()
     const config = useRuntimeConfig()
 
@@ -201,9 +206,6 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
       const path = unref(props.to) || unref(props.href) || ''
       return typeof path === 'string' && hasProtocol(path, { acceptRelative: true })
     })
-
-    const builtinRouterLink = resolveRouterLink ? resolveComponent('RouterLink') as string | typeof RouterLink : undefined
-    const useBuiltinLink = builtinRouterLink && typeof builtinRouterLink !== 'string' ? builtinRouterLink.useLink : undefined
 
     // Resolving link type
     const isExternal = computed<boolean>(() => {
@@ -229,8 +231,6 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
       if (isExternal.value) { return path }
       return resolveTrailingSlashBehavior(path, router.resolve, unref(props.trailingSlash))
     })
-
-    const link = isExternal.value ? undefined : useBuiltinLink?.({ ...props, to, viewTransition: unref(props.viewTransition) })
 
     // Resolves `to` value if it's a route location object
     const href = computed(() => {
@@ -262,9 +262,6 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
       isExternal,
       //
       href,
-      isActive: link?.isActive ?? computed(() => to.value === router.currentRoute.value.path),
-      isExactActive: link?.isExactActive ?? computed(() => to.value === router.currentRoute.value.path),
-      route: link?.route ?? computed(() => router.resolve(to.value)),
       async navigate (_e?: MouseEvent) {
         if (href.value === null) {
           if (import.meta.dev) {
@@ -274,6 +271,22 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
         }
         await navigateTo(href.value, { replace: unref(props.replace), external: isExternal.value || hasTarget.value })
       },
+    }
+  }
+
+  function useNuxtLink (props: { [K in keyof NuxtLinkProps]: MaybeRef<NuxtLinkProps[K]> }) {
+    const router = useRouter()
+    const target = useLinkTarget(props)
+
+    const builtinRouterLink = resolveComponent('RouterLink') as string | typeof RouterLink
+    const useBuiltinLink = builtinRouterLink && typeof builtinRouterLink !== 'string' ? builtinRouterLink.useLink : undefined
+    const link = target.isExternal.value ? undefined : useBuiltinLink?.({ ...props, to: target.to, viewTransition: unref(props.viewTransition) })
+
+    return {
+      ...target,
+      isActive: link?.isActive ?? computed(() => target.to.value === router.currentRoute.value.path),
+      isExactActive: link?.isExactActive ?? computed(() => target.to.value === router.currentRoute.value.path),
+      route: link?.route ?? computed(() => router.resolve(target.to.value)),
     } satisfies Omit<ReturnType<typeof useLink>, 'href'> & {
       to: ComputedRef<RouteLocationRaw>
       href: ComputedRef<string | null>
@@ -443,9 +456,7 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
 
       const routerLinkComponent = resolveComponent('RouterLink')
 
-      // vue-router's `useLink` only backs the `route`/`isActive`/`isExactActive` properties of
-      // the public `useLink` API, which this component never reads, so skip resolving it here.
-      const { to, href, navigate, isExternal, hasTarget, isAbsoluteUrl } = useNuxtLink(props, false)
+      const { to, href, navigate, isExternal, hasTarget, isAbsoluteUrl } = useLinkTarget(props)
 
       // Prefetching
       const prefetched = shallowRef(false)

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -190,7 +190,7 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
     return resolvedPath
   }
 
-  function useNuxtLink (props: { [K in keyof NuxtLinkProps]: MaybeRef<NuxtLinkProps[K]> }) {
+  function useNuxtLink (props: { [K in keyof NuxtLinkProps]: MaybeRef<NuxtLinkProps[K]> }, resolveRouterLink = true) {
     const router = useRouter()
     const config = useRuntimeConfig()
 
@@ -202,7 +202,7 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
       return typeof path === 'string' && hasProtocol(path, { acceptRelative: true })
     })
 
-    const builtinRouterLink = resolveComponent('RouterLink') as string | typeof RouterLink
+    const builtinRouterLink = resolveRouterLink ? resolveComponent('RouterLink') as string | typeof RouterLink : undefined
     const useBuiltinLink = builtinRouterLink && typeof builtinRouterLink !== 'string' ? builtinRouterLink.useLink : undefined
 
     // Resolving link type
@@ -289,24 +289,20 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
       // Routing
       to: {
         type: [String, Object] as PropType<RouteLocationRaw>,
-        default: undefined,
         required: false,
       },
       href: {
         type: [String, Object] as PropType<RouteLocationRaw>,
-        default: undefined,
         required: false,
       },
 
       // Attributes
       target: {
         type: String as PropType<NuxtLinkProps['target']>,
-        default: undefined,
         required: false,
       },
       rel: {
         type: String as PropType<NuxtLinkProps['rel']>,
-        default: undefined,
         required: false,
       },
       noRel: {
@@ -323,7 +319,6 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
       },
       prefetchOn: {
         type: [String, Object] as PropType<NuxtLinkProps['prefetchOn']>,
-        default: undefined,
         required: false,
       },
       noPrefetch: {
@@ -335,17 +330,14 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
       // Styling
       activeClass: {
         type: String as PropType<NuxtLinkProps['activeClass']>,
-        default: undefined,
         required: false,
       },
       exactActiveClass: {
         type: String as PropType<NuxtLinkProps['exactActiveClass']>,
-        default: undefined,
         required: false,
       },
       prefetchedClass: {
         type: String as PropType<NuxtLinkProps['prefetchedClass']>,
-        default: undefined,
         required: false,
       },
 
@@ -357,7 +349,6 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
       },
       ariaCurrentValue: {
         type: String as PropType<NuxtLinkProps['ariaCurrentValue']>,
-        default: undefined,
         required: false,
       },
 
@@ -377,7 +368,6 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
       // Behavior
       trailingSlash: {
         type: String as PropType<NuxtLinkProps['trailingSlash']>,
-        default: undefined,
         required: false,
       },
     },
@@ -385,7 +375,15 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
     setup (props, { slots }) {
       const router = useRouter()
 
-      const { to, href, navigate, isExternal, hasTarget, isAbsoluteUrl } = useNuxtLink(props)
+      const routerLinkComponent = resolveComponent('RouterLink')
+
+      // vue-router's `useLink` only backs the `route`/`isActive`/`isExactActive` properties of
+      // the public `useLink` API, which this component never reads, so skip resolving it here.
+      const { to, href, navigate, isExternal, hasTarget, isAbsoluteUrl } = useNuxtLink(props, false)
+
+      const serverLink = import.meta.server && !props.custom && !isExternal.value && !hasTarget.value && !isHashLinkWithoutHashMode(to.value) && typeof routerLinkComponent !== 'string'
+        ? (routerLinkComponent as unknown as typeof RouterLink).useLink({ to: to as any, replace: props.replace })
+        : undefined
 
       // Prefetching
       const prefetched = shallowRef(false)
@@ -536,9 +534,33 @@ export function defineNuxtLink (options: NuxtLinkOptions): NuxtLinkComponent & R
             }
           }
 
+          if (import.meta.server && serverLink) {
+            const routerOptions = (router as Router).options
+            const isActive = serverLink.isActive.value
+            const isExactActive = serverLink.isExactActive.value
+            const href = serverLink.href.value
+            return h('a', {
+              'aria-current': isExactActive ? (props.ariaCurrentValue ?? 'page') : null,
+              href,
+              'class': {
+                [getLinkClass(routerLinkProps.activeClass, routerOptions.linkActiveClass, 'router-link-active')]: isActive,
+                [getLinkClass(routerLinkProps.exactActiveClass, routerOptions.linkExactActiveClass, 'router-link-exact-active')]: isExactActive,
+              },
+              'rel': routerLinkProps.rel,
+              'data-internal': routerLinkProps['data-internal'],
+            }, slots.default?.({
+              // `route` is already resolved as a side effect of reading `href` above
+              route: serverLink.route.value,
+              href,
+              isActive,
+              isExactActive,
+              navigate: serverLink.navigate,
+            }))
+          }
+
           // Internal link
           return h(
-            resolveComponent('RouterLink'),
+            routerLinkComponent,
             routerLinkProps,
             props.custom && slots.default
               ? { default: (slotProps: RouterLinkSlotProps) => slots.default!(getCustomSlotProps(slotProps)) }
@@ -596,6 +618,10 @@ const NuxtLink: NuxtLinkComponent & Record<string, any> = defineNuxtLink(nuxtLin
 export default NuxtLink
 
 // -- NuxtLink utils --
+function getLinkClass (propClass: string | undefined, globalClass: string | undefined, defaultClass: string): string {
+  return propClass ?? globalClass ?? defaultClass
+}
+
 function applyTrailingSlashBehavior (to: string, trailingSlash: NuxtLinkOptions['trailingSlash']): string {
   // When `trailingSlash` is unset (or not a valid value) the URL is returned untouched
   if (trailingSlash !== 'append' && trailingSlash !== 'remove') {

--- a/packages/nuxt/src/app/components/nuxt-link.ts
+++ b/packages/nuxt/src/app/components/nuxt-link.ts
@@ -11,7 +11,7 @@ import type {
 } from 'vue'
 import { computed, defineComponent, h, inject, onBeforeUnmount, onMounted, provide, ref, resolveComponent, shallowRef, unref } from 'vue'
 import type { ComponentSlots } from 'vue-component-type-helpers'
-import type { RouteLocation, RouteLocationRaw, RouteRecordNormalized, Router, RouterLink, RouterLinkProps, useLink } from 'vue-router'
+import type { RouteLocation, RouteLocationGeneric, RouteLocationRaw, RouteParamsGeneric, RouteRecordNormalized, Router, RouterLink, RouterLinkProps, useLink } from 'vue-router'
 import { hasProtocol, isScriptProtocol, joinURL, parseQuery, withTrailingSlash, withoutTrailingSlash } from 'ufo'
 import { preloadRouteComponents } from '../composables/preload'
 import { onNuxtReady } from '../composables/ready'
@@ -676,7 +676,7 @@ function isSameParamValue (a: unknown, b: unknown): boolean {
     : Array.isArray(b) ? isEquivalentArray(b, a) : (a && a.valueOf()) === (b && b.valueOf())
 }
 
-function isSameRouteLocationParams (a: RouteLocation['params'], b: RouteLocation['params']): boolean {
+function isSameRouteLocationParams (a: RouteParamsGeneric, b: RouteParamsGeneric): boolean {
   if (Object.keys(a).length !== Object.keys(b).length) { return false }
   for (const key in a) {
     if (!isSameParamValue(a[key], b[key])) { return false }
@@ -684,7 +684,7 @@ function isSameRouteLocationParams (a: RouteLocation['params'], b: RouteLocation
   return true
 }
 
-function includesParams (outer: RouteLocation['params'], inner: RouteLocation['params']): boolean {
+function includesParams (outer: RouteParamsGeneric, inner: RouteParamsGeneric): boolean {
   for (const key in inner) {
     const innerValue = inner[key]
     const outerValue = outer[key]
@@ -697,7 +697,7 @@ function includesParams (outer: RouteLocation['params'], inner: RouteLocation['p
   return true
 }
 
-function activeRecordIndex (route: RouteLocation, currentRoute: RouteLocation): number {
+function activeRecordIndex (route: RouteLocationGeneric, currentRoute: RouteLocationGeneric): number {
   const { matched } = route
   const { length } = matched
   const routeMatched = matched[length - 1]

--- a/packages/nuxt/test/nuxt-link-ssr.test.ts
+++ b/packages/nuxt/test/nuxt-link-ssr.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h } from 'vue'
+import type { VNode } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import type { Router } from 'vue-router'
+
+const nuxtApp = {
+  hooks: { callHook: () => Promise.resolve() },
+  ssrContext: {},
+  $config: { app: { baseURL: '/' }, public: {} },
+  $router: undefined as Router | undefined,
+}
+
+vi.mock('#app/nuxt', () => ({
+  useRuntimeConfig: () => nuxtApp.$config,
+  useNuxtApp: () => nuxtApp,
+  tryUseNuxtApp: () => nuxtApp,
+}))
+
+const { defineNuxtLink } = await import('#app/components/nuxt-link')
+
+const Stub = defineComponent({ setup: () => () => h('div') })
+const routes = [
+  { path: '/', component: Stub },
+  {
+    path: '/parent',
+    component: Stub,
+    children: [
+      { path: '', component: Stub },
+      { path: 'child/:id?', component: Stub },
+    ],
+  },
+  { path: '/named/:id', name: 'named', component: Stub, alias: '/aliased/:id' },
+  { path: '/query', component: Stub },
+]
+
+interface Case {
+  name: string
+  options?: Record<string, unknown>
+  props?: Record<string, unknown>
+  attrs?: Record<string, unknown>
+  at?: string
+  slot?: (props: any) => VNode | VNode[] | string
+  routerOptions?: Record<string, unknown>
+}
+
+async function renderLink (testCase: Case, server: boolean) {
+  vi.stubGlobal('__TEST_SERVER__', server)
+
+  const router = createRouter({ history: createMemoryHistory(), routes, ...testCase.routerOptions })
+  nuxtApp.$router = router
+  await router.push(testCase.at ?? '/')
+  await router.isReady()
+
+  const Link = defineNuxtLink({ componentName: 'NuxtLink', ...testCase.options })
+  const app = createApp(defineComponent({
+    setup: () => () => h('div', [h(Link as any, { ...testCase.props, ...testCase.attrs }, testCase.slot ?? (() => 'text'))]),
+  }))
+  app.use(router)
+
+  return renderToString(app)
+}
+
+// Server-rendered internal links bypass `<RouterLink>`, so the two paths must produce identical
+// markup or the client would fail to hydrate the anchor.
+const cases: Case[] = [
+  { name: 'renders an inactive link' },
+  { name: 'renders an active parent link', props: { to: '/parent' }, at: '/parent/child/1' },
+  { name: 'renders an exact active link', props: { to: '/parent' }, at: '/parent' },
+  { name: 'renders an active leaf link', props: { to: '/parent/child/1' }, at: '/parent/child/1' },
+  { name: 'distinguishes links differing only by params', props: { to: '/parent/child/1' }, at: '/parent/child/2' },
+  { name: 'resolves an aliased route', props: { to: '/aliased/1' }, at: '/named/1' },
+  { name: 'resolves a named route object', props: { to: { name: 'named', params: { id: '2' } } } },
+  { name: 'resolves a route object with query and hash', props: { to: { path: '/query', query: { a: 'b c' }, hash: '#h' } } },
+  { name: 'encodes an unencoded path', props: { to: '/parent/child/a b' } },
+  { name: 'renders an empty `to`', props: {} },
+  { name: 'applies `rel`', props: { to: '/parent', rel: 'nofollow' } },
+  { name: 'merges fallthrough attributes', props: { to: '/parent' }, attrs: { 'class': 'user', 'id': 'x', 'data-foo': '1' }, at: '/parent' },
+  { name: 'applies the `activeClass` prop', props: { to: '/parent', activeClass: 'on' }, at: '/parent' },
+  { name: 'applies the `exactActiveClass` prop', props: { to: '/parent', exactActiveClass: 'exact-on' }, at: '/parent' },
+  { name: 'applies `activeClass` from options', options: { activeClass: 'opt-on' }, props: { to: '/parent' }, at: '/parent' },
+  { name: 'applies active classes from router options', routerOptions: { linkActiveClass: 'r-on', linkExactActiveClass: 'r-exact-on' }, props: { to: '/parent' }, at: '/parent' },
+  { name: 'applies `ariaCurrentValue`', props: { to: '/parent', ariaCurrentValue: 'step' }, at: '/parent' },
+  { name: 'appends a trailing slash', options: { trailingSlash: 'append' }, props: { to: '/parent' } },
+  { name: 'removes a trailing slash', props: { to: '/parent/', trailingSlash: 'remove' } },
+  { name: 'passes slot props', props: { to: '/parent' }, at: '/parent', slot: (p: any) => h('span', { 'class': [p.isActive && 'a', p.isExactActive && 'ea'], 'data-href': p.href, 'data-path': p.route.path }, 'x') },
+  { name: 'renders a multi-node slot', props: { to: '/parent' }, slot: () => [h('span', 'a'), h('span', 'b')] },
+  { name: 'renders an empty slot', props: { to: '/parent' }, slot: () => [] },
+]
+
+describe('nuxt-link ssr', () => {
+  for (const testCase of cases) {
+    it(testCase.name, async () => {
+      const viaRouterLink = await renderLink(testCase, false)
+      const viaServerPath = await renderLink(testCase, true)
+      expect(viaServerPath).toBe(viaRouterLink)
+    })
+  }
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -168,6 +168,7 @@ export default defineConfig({
       {
         define: {
           'import.meta.dev': '(globalThis.__TEST_DEV__ ?? false)',
+          'import.meta.server': '(globalThis.__TEST_SERVER__ ?? false)',
         },
         resolve: {
           alias: {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this is a batch of changes to improve `<NuxtLink>` rendering performance, tested by rendering 200 internal `<NuxtLink>`s to a string, this decreases the time taken by 58%, from 1.36ms to 0.57ms (1.4x _faster_ than `<RouterLink>` on its own).

first, by avoiding passing `default: undefined` for string props, we can remove some props from `needCastKeys` (which triggered `resolvePropValue` by vue) and improve vue's rendering performance....

second, because we only render a static `<a>` anyway on the server, we can totally drop `useLink` in favour of a special render function that only resolves the route, and does everything else inline (with no computed/reactive state at all