### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/docs/3.guide/1.concepts/8.typescript.md
+++ b/docs/3.guide/1.concepts/8.typescript.md
@@ -49,6 +49,8 @@ export default defineNuxtConfig({
 })
 ```
 
+Set it to `'build'` to only type check when building your application, or to `'dev'` to only type check when running the dev server.
+
 ## Auto-generated Types
 
 Nuxt projects rely on auto-generated types to work properly. These types are stored in the [`.nuxt`](/docs/4.x/directory-structure/nuxt) directory and are generated when you run the dev server or build your application. You can also generate these files manually by running `nuxt prepare`.

--- a/docs/4.api/6.nuxt-config.md
+++ b/docs/4.api/6.nuxt-config.md
@@ -1596,7 +1596,7 @@ You can extend the generated tsconfig files with shared options using this optio
 
 Enable build-time type checking.
 
-If set to true, this will type check in development. You can restrict this to build-time type checking by setting it to `build`. Requires to install `typescript` and `vue-tsc` as dev dependencies.
+If set to true, this will type check in development and when building. You can restrict this to build-time type checking by setting it to `build`, or to dev-time type checking by setting it to `dev`. Requires to install `typescript` and `vue-tsc` as dev dependencies.
 
 - **Type**: `boolean`
 - **Default:** `false`

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1862,11 +1862,11 @@ export interface ConfigSchema {
     /**
      * Enable build-time type checking.
      *
-     * If set to true, this will type check in development. You can restrict this to build-time type checking by setting it to `build`. Requires to install `typescript` and `vue-tsc` as dev dependencies.
+     * If set to true, this will type check in development and when building. You can restrict this to build-time type checking by setting it to `build`, or to dev-time type checking by setting it to `dev`. Requires to install `typescript` and `vue-tsc` as dev dependencies.
      *
      * @see [Nuxt TypeScript docs](https://nuxt.com/docs/4.x/guide/concepts/typescript)
      */
-    typeCheck: boolean | 'build'
+    typeCheck: boolean | 'build' | 'dev'
 
     /**
      * Extend the generated tsconfig files with shared options.

--- a/packages/vite/src/plugins/type-check.ts
+++ b/packages/vite/src/plugins/type-check.ts
@@ -11,7 +11,7 @@ export function TypeCheckPlugin (nuxt: Nuxt): Plugin {
     name: 'nuxt:type-check',
     applyToEnvironment: environment => environment.name === 'client' && !environment.config.isProduction,
     apply: () => {
-      return !nuxt.options.test && nuxt.options.typescript.typeCheck === true
+      return !nuxt.options.test && (nuxt.options.typescript.typeCheck === true || nuxt.options.typescript.typeCheck === 'dev')
     },
     configResolved (config) {
       try {

--- a/packages/vite/src/plugins/vite-plugin-checker.ts
+++ b/packages/vite/src/plugins/vite-plugin-checker.ts
@@ -3,7 +3,7 @@ import type { Nuxt } from '@nuxt/schema'
 import { readTSConfig, resolveTSConfig } from 'pkg-types'
 
 export async function VitePluginCheckerPlugin (nuxt: Nuxt, environment?: string): Promise<Array<Plugin | undefined> | undefined> {
-  if (!nuxt.options.test && (nuxt.options.typescript.typeCheck === true || (nuxt.options.typescript.typeCheck === 'build' && !nuxt.options.dev))) {
+  if (!nuxt.options.test && (nuxt.options.typescript.typeCheck === true || (nuxt.options.typescript.typeCheck === 'build' && !nuxt.options.dev) || (nuxt.options.typescript.typeCheck === 'dev' && nuxt.options.dev))) {
     const [checker, tsconfigPath] = await Promise.all([
       import('vite-plugin-checker').then(r => r.default),
       resolveTSConfig(nuxt.options.rootDir),

--- a/packages/vite/test/type-check.test.ts
+++ b/packages/vite/test/type-check.test.ts
@@ -1,0 +1,63 @@
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import type { Nuxt } from '@nuxt/schema'
+import { TypeCheckPlugin } from '../src/plugins/type-check.ts'
+import { VitePluginCheckerPlugin } from '../src/plugins/vite-plugin-checker.ts'
+
+function createNuxt (typeCheck: boolean | 'build' | 'dev', options: { dev?: boolean, test?: boolean } = {}) {
+  return {
+    options: {
+      dev: false,
+      test: false,
+      ssr: false,
+      rootDir: resolve(import.meta.dirname, '../../..'),
+      ...options,
+      typescript: { typeCheck },
+    },
+  } as Nuxt
+}
+
+describe('TypeCheckPlugin', () => {
+  it.each([
+    [true, true],
+    ['build', false],
+    ['dev', true],
+    [false, false],
+  ] as const)('applies in dev when typeCheck is %s: %s', (typeCheck, expected) => {
+    const plugin = TypeCheckPlugin(createNuxt(typeCheck, { dev: true }))
+    expect(typeof plugin.apply === 'function' && plugin.apply({} as never, {} as never)).toBe(expected)
+  })
+
+  it('does not apply in test mode', () => {
+    const plugin = TypeCheckPlugin(createNuxt('dev', { dev: true, test: true }))
+    expect(typeof plugin.apply === 'function' && plugin.apply({} as never, {} as never)).toBe(false)
+  })
+
+  it('only injects the checker runtime into the client entry in development', () => {
+    const plugin = TypeCheckPlugin(createNuxt('dev', { dev: true }))
+    const applyToEnvironment = plugin.applyToEnvironment as (environment: { name: string, config: { isProduction: boolean } }) => boolean
+    expect(applyToEnvironment({ name: 'client', config: { isProduction: false } })).toBe(true)
+    expect(applyToEnvironment({ name: 'ssr', config: { isProduction: false } })).toBe(false)
+    expect(applyToEnvironment({ name: 'client', config: { isProduction: true } })).toBe(false)
+  })
+})
+
+describe('VitePluginCheckerPlugin', () => {
+  it.each([
+    [true, true, true],
+    [true, false, true],
+    ['build', true, false],
+    ['build', false, true],
+    ['dev', true, true],
+    ['dev', false, false],
+    [false, true, false],
+    [false, false, false],
+  ] as const)('returns plugins when typeCheck is %s and dev is %s: %s', async (typeCheck, dev, expected) => {
+    const plugins = await VitePluginCheckerPlugin(createNuxt(typeCheck, { dev }))
+    expect(!!plugins?.length).toBe(expected)
+  })
+
+  it('does not register the checker in test mode', async () => {
+    expect(await VitePluginCheckerPlugin(createNuxt('dev', { dev: true, test: true }))).toBeUndefined()
+  })
+})

--- a/packages/webpack/src/configs/client.ts
+++ b/packages/webpack/src/configs/client.ts
@@ -163,7 +163,7 @@ function clientPlugins (ctx: WebpackConfigContext) {
   // Normally type checking runs in server config, but in `ssr: false` there is
   // no server build, so we inject here instead.
   if (!ctx.nuxt.options.ssr) {
-    if (!ctx.nuxt.options.test && (ctx.nuxt.options.typescript.typeCheck === true || (ctx.nuxt.options.typescript.typeCheck === 'build' && !ctx.nuxt.options.dev))) {
+    if (!ctx.nuxt.options.test && (ctx.nuxt.options.typescript.typeCheck === true || (ctx.nuxt.options.typescript.typeCheck === 'build' && !ctx.nuxt.options.dev) || (ctx.nuxt.options.typescript.typeCheck === 'dev' && ctx.nuxt.options.dev))) {
       ctx.config.plugins!.push(new TsCheckerPlugin({
         logger,
       }))

--- a/packages/webpack/src/configs/server.ts
+++ b/packages/webpack/src/configs/server.ts
@@ -148,7 +148,7 @@ function serverPlugins (ctx: WebpackConfigContext) {
   }
 
   // Add type-checking
-  if (!ctx.nuxt.options.test && (ctx.nuxt.options.typescript.typeCheck === true || (ctx.nuxt.options.typescript.typeCheck === 'build' && !ctx.nuxt.options.dev))) {
+  if (!ctx.nuxt.options.test && (ctx.nuxt.options.typescript.typeCheck === true || (ctx.nuxt.options.typescript.typeCheck === 'build' && !ctx.nuxt.options.dev) || (ctx.nuxt.options.typescript.typeCheck === 'dev' && ctx.nuxt.options.dev))) {
     ctx.config.plugins!.push(new TsCheckerPlugin({
       logger,
     }))


### PR DESCRIPTION
### What

Adds a `'dev'` option to `typescript.typeCheck` (alongside `true`, `false` and `'build'`) so type checking runs **only when the dev server is running**:

- `packages/schema/src/types/schema.ts` — `typeCheck: boolean | 'build' | 'dev'` (+ updated JSDoc; also clarifies that `true` type checks in dev *and* when building)
- `packages/vite/src/plugins/vite-plugin-checker.ts` — registers `vite-plugin-checker` when `typeCheck === 'dev' && nuxt.options.dev`
- `packages/vite/src/plugins/type-check.ts` — injects the checker runtime entry for `'dev'` too (still gated to the client environment in non-production via `applyToEnvironment`, so nothing is injected during `nuxt build`)
- `packages/webpack/src/configs/server.ts` / `client.ts` — same `'dev'` condition for `TsCheckerPlugin`
- Docs: `docs/4.api/6.nuxt-config.md` and `docs/3.guide/1.concepts/8.typescript.md`

### Why

Closes #36004. Use case from the issue: splitting/parallelizing type checking and building in CI (e.g. nx monorepos) — run typecheck during dev, skip it during CD builds. Maintainer labeled the issue `good first issue`.

### Verification

- **Reproduced first on `main`**: new unit tests for the `'dev'` value failed before the change (2 failures: checker plugin not registered in dev, runtime entry not injected) and pass after it.
- `packages/vite/test/type-check.test.ts` (new, 15 tests): truth table for `true`/`false`/`'build'`/`'dev'` × dev/build, `test: true` short-circuit, and the `applyToEnvironment` production gate. `true`/`false`/`'build'` behavior is asserted unchanged.
- `vitest run --project unit packages/vite packages/schema` — 143 passed, 1 skipped.
- `eslint` on all changed files, `markdownlint` + `case-police` + `eslint` on changed docs — clean.
- `vue-tsc --noEmit` (repo typecheck) — clean.
- Diff reviewed by an automated second-pass review (kiro-cli, claude-opus-5); findings addressed where in scope (docs wording, extra test coverage, import style).

### Testing limitations

- Gating logic is unit-tested; I did not run a full dev-server fixture with `typeCheck: 'dev'` end to end.
- Webpack conditions mirror the vite ones but have no unit coverage (the webpack package has no test dir in this repo).

---

*This PR was prepared with AI assistance per the [AI-assisted contributions policy](https://nuxt.com/docs/community/contribution#ai-assisted-contributions); opting in via 🤖🤖🤖 in the title.*