### PR TITLE
fix(nuxt): stub client-only components + map test components in server build

### DIFF
--- a/packages/nuxt/src/app/components/test-component-wrapper.ts
+++ b/packages/nuxt/src/app/components/test-component-wrapper.ts
@@ -5,7 +5,7 @@ import { isAbsolute, relative, resolve } from 'pathe'
 import { renderDiagnostics } from '../diagnostics/render'
 import { devRootDir } from '#build/nuxt.config.mjs'
 
-const testComponentWrapper = (url: string): DefineSetupFnComponent<{}> => defineComponent({
+const testComponentWrapper = (url: string, componentLoaders: Record<string, () => Promise<any>> = {}): DefineSetupFnComponent<{}> => defineComponent({
   name: 'NuxtTestComponentWrapper',
   inheritAttrs: false,
   async setup (props, { attrs }) {
@@ -26,7 +26,8 @@ const testComponentWrapper = (url: string): DefineSetupFnComponent<{}> => define
     if (rel.startsWith('..') || isAbsolute(rel)) {
       throw renderDiagnostics.NUXT_E4008({ path })
     }
-    const comp = await import(/* @vite-ignore */ path as string).then(r => r.default)
+    const loader = componentLoaders[path]
+    const comp = await (loader ? loader() : import(/* @vite-ignore */ path as string)).then(r => r.default)
     return () => [
       h('div', 'Component Test Wrapper for ' + path),
       h('div', { id: 'nuxt-component-root' }, [

--- a/packages/nuxt/src/components/module.ts
+++ b/packages/nuxt/src/components/module.ts
@@ -14,6 +14,7 @@ import { LoaderPlugin } from './plugins/loader.ts'
 import { ComponentsChunkPlugin, IslandsTransformPlugin } from './plugins/islands-transform.ts'
 import { TransformPlugin } from './plugins/transform.ts'
 import { TreeShakeTemplatePlugin } from './plugins/tree-shake.ts'
+import { ClientComponentStubPlugin } from './plugins/client-component-stub.ts'
 import { ComponentNamePlugin } from './plugins/component-names.ts'
 import { LazyHydrationTransformPlugin } from './plugins/lazy-hydration-transform.ts'
 import { LazyHydrationMacroTransformPlugin } from './plugins/lazy-hydration-macro-transform.ts'
@@ -245,6 +246,13 @@ export default defineNuxtModule<ComponentsOptions>({
     })
 
     addBuildPlugin(TreeShakeTemplatePlugin({ getComponents }), { client: false })
+
+    addBuildPlugin(ClientComponentStubPlugin({
+      getComponents,
+      serverPlaceholderPath,
+      alias: nuxt.options.alias,
+      dev: nuxt.options.dev,
+    }), { client: false })
 
     const clientDelayedComponentRuntime = await findPath(join(distDir, 'components/runtime/lazy-hydrated-component')) ?? join(distDir, 'components/runtime/lazy-hydrated-component')
 

--- a/packages/nuxt/src/components/plugins/client-component-stub.ts
+++ b/packages/nuxt/src/components/plugins/client-component-stub.ts
@@ -1,0 +1,128 @@
+import { createUnplugin } from 'unplugin'
+import { dirname, isAbsolute, normalize, resolve } from 'pathe'
+import escapeRE from 'escape-string-regexp'
+import { resolveAlias } from '@nuxt/kit'
+import type { Component } from '@nuxt/schema'
+import { parseModuleId } from '../../core/utils/plugins.ts'
+
+interface ClientComponentStubPluginOptions {
+  getComponents (): Component[]
+  serverPlaceholderPath: string
+  alias: Record<string, string>
+  dev: boolean
+}
+
+const NUXT_COMPONENT_QUERY_RE = /[?&]nuxt_component=/
+const RELATIVE_RE = /^\.{1,2}\//
+const EXTENSION_RE = /\.\w+$/
+const CLIENT_SUFFIX_RE = /\.client(?:\.\w+)?(?:\?|$)/
+
+function basename (id: string) {
+  const query = id.indexOf('?')
+  const end = query < 0 ? id.length : query
+  let start = 0
+  for (let i = end - 1; i >= 0; i--) {
+    const char = id[i]
+    if (char === '/' || char === '\\') {
+      start = i + 1
+      break
+    }
+  }
+  return id.slice(start, end)
+}
+
+function isClientOnly (component: Component) {
+  // a file registered in more than one mode (or exporting more than the component itself) still
+  // has to be resolvable in the server build
+  return !component._raw && component.mode === 'client' && (!component.export || component.export === 'default')
+}
+
+/**
+ * Resolve direct imports of client-only component files to the server placeholder in the server
+ * build. Components rendered through `#components` are already mapped to the placeholder, but a
+ * component imported by path would otherwise be evaluated (and its side effects run) during SSR.
+ */
+export const ClientComponentStubPlugin = (options: ClientComponentStubPluginOptions) => createUnplugin(() => {
+  let cachedComponents: Component[] | undefined
+  let clientOnlyPaths = new Set<string>()
+  // ids reaching the handler are still checked exactly, so this only has to be a cheap rejection
+  let clientOnlyFileNames = new Set<string>()
+
+  function syncComponents () {
+    const components = options.getComponents()
+    if (components === cachedComponents) { return }
+
+    cachedComponents = components
+    clientOnlyPaths = new Set()
+    clientOnlyFileNames = new Set()
+    const nonClientPaths = new Set<string>()
+
+    for (const component of components) {
+      const filePath = normalize(component.filePath)
+      if (!isClientOnly(component)) {
+        nonClientPaths.add(filePath)
+        continue
+      }
+      clientOnlyPaths.add(filePath)
+      clientOnlyPaths.add(filePath.replace(EXTENSION_RE, ''))
+    }
+
+    for (const path of nonClientPaths) {
+      clientOnlyPaths.delete(path)
+      clientOnlyPaths.delete(path.replace(EXTENSION_RE, ''))
+    }
+
+    for (const path of clientOnlyPaths) {
+      clientOnlyFileNames.add(basename(path))
+    }
+  }
+
+  function handler (id: string, importer: string | undefined) {
+    syncComponents()
+
+    if (!clientOnlyFileNames.has(basename(id)) || NUXT_COMPONENT_QUERY_RE.test(id)) { return }
+
+    const { pathname } = parseModuleId(id)
+    if (!pathname) { return }
+
+    const aliased = resolveAlias(pathname, options.alias)
+    const path = isAbsolute(aliased)
+      ? normalize(aliased)
+      : RELATIVE_RE.test(aliased) && importer
+        ? resolve(dirname(parseModuleId(importer).pathname || importer), aliased)
+        : undefined
+
+    if (!path || !clientOnlyPaths.has(path)) { return }
+
+    return options.serverPlaceholderPath
+  }
+
+  return {
+    name: 'nuxt:components:client-component-stub',
+    enforce: 'pre',
+    // A hook filter is resolved once, so it can only be used where the set of components is final.
+    // In dev a module can still register a component at an arbitrary path on a later scan, and the
+    // handler's own check is what keeps up with that.
+    resolveId: options.dev
+      ? handler
+      : {
+          // otherwise every resolution in the server build reaches the handler
+          filter: { id: { include: [CLIENT_SUFFIX_RE, ...unconventionalClientPaths(options.getComponents())] } },
+          handler,
+        },
+  }
+})
+
+/**
+ * Client components are conventionally suffixed with `.client`, which a filter can match directly,
+ * but a module can register one at any path, so those have to be listed.
+ */
+function unconventionalClientPaths (components: Component[]) {
+  const paths: RegExp[] = []
+  for (const component of components) {
+    if (isClientOnly(component) && !CLIENT_SUFFIX_RE.test(component.filePath)) {
+      paths.push(new RegExp(escapeRE(normalize(component.filePath).replace(EXTENSION_RE, ''))))
+    }
+  }
+  return paths
+}

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -76,7 +76,27 @@ export const islandRendererTemplate: NuxtTemplate = {
 export const testComponentWrapperTemplate: NuxtTemplate = {
   filename: 'test-component-wrapper.mjs',
   dependsOn: [],
-  getContents: ctx => genExport(resolve(ctx.nuxt.options.appDir, 'components/test-component-wrapper'), ['default']),
+  getContents: (ctx) => {
+    if (!ctx.nuxt.options.test || !ctx.nuxt.options.dev) {
+      return genExport(resolve(ctx.nuxt.options.appDir, 'components/test-component-wrapper'), ['default'])
+    }
+
+    const paths = new Set<string>()
+    for (const component of ctx.app.components) {
+      if (!component._raw) {
+        paths.add(component.filePath)
+      }
+    }
+    return [
+      genImport(resolve(ctx.nuxt.options.appDir, 'components/test-component-wrapper'), 'testComponentWrapper'),
+      // bundlers that cannot resolve a fully dynamic import (webpack, rspack) need a static map of
+      // the files that may be requested
+      `const componentLoaders = {`,
+      ...[...paths].map(path => `  ${JSON.stringify(path)}: () => ${genDynamicImport(path, { wrapper: false })},`),
+      `}`,
+      `export default url => testComponentWrapper(url, componentLoaders)`,
+    ].join('\n')
+  },
 }
 
 export const cssTemplate: NuxtTemplate = {

--- a/packages/nuxt/test/component-client-stub.test.ts
+++ b/packages/nuxt/test/component-client-stub.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import type { Component } from '@nuxt/schema'
+import { ClientComponentStubPlugin } from '../src/components/plugins/client-component-stub.ts'
+
+const SERVER_PLACEHOLDER = '/nuxt/app/components/server-placeholder.ts'
+
+function component (partial: Partial<Component> & { filePath: string }): Component {
+  return {
+    pascalName: 'Component',
+    kebabName: 'component',
+    chunkName: 'components/component',
+    shortPath: partial.filePath,
+    export: 'default',
+    prefetch: false,
+    preload: false,
+    mode: 'all',
+    ...partial,
+  } as Component
+}
+
+function createResolver (componentsOrGetter: Component[] | (() => Component[]), dev = false) {
+  const raw = ClientComponentStubPlugin({
+    getComponents: typeof componentsOrGetter === 'function' ? componentsOrGetter : () => componentsOrGetter,
+    serverPlaceholderPath: SERVER_PLACEHOLDER,
+    alias: { '~': '/src', '@': '/src' },
+    dev,
+  }).raw({}, { framework: 'rollup' } as any)
+
+  const plugin = Array.isArray(raw) ? raw[0]! : raw
+  const hook = plugin.resolveId!
+  if (typeof hook === 'function') {
+    return (id: string, importer?: string) => hook.call({} as any, id, importer, { isEntry: false })
+  }
+
+  // apply the hook filter the way the bundler does, so the tests cover it too
+  const include = (hook.filter!.id as { include: RegExp[] }).include
+  return (id: string, importer?: string) => {
+    if (!include.some(pattern => pattern.test(id))) { return }
+    return hook.handler.call({} as any, id, importer, { isEntry: false })
+  }
+}
+
+describe('components:client-component-stub', () => {
+  const clientOnly = component({ filePath: '/src/components/Interactive.client.vue', pascalName: 'Interactive', mode: 'client' })
+
+  it('stubs absolute, aliased and relative imports of a client-only component', () => {
+    const resolveId = createResolver([clientOnly])
+
+    expect(resolveId('/src/components/Interactive.client.vue')).toBe(SERVER_PLACEHOLDER)
+    expect(resolveId('~/components/Interactive.client')).toBe(SERVER_PLACEHOLDER)
+    expect(resolveId('~/components/Interactive.client.vue')).toBe(SERVER_PLACEHOLDER)
+    expect(resolveId('./Interactive.client.vue', '/src/components/Page.vue')).toBe(SERVER_PLACEHOLDER)
+    expect(resolveId('../components/Interactive.client', '/src/pages/index.vue')).toBe(SERVER_PLACEHOLDER)
+  })
+
+  it('does not stub other components or same-named files elsewhere', () => {
+    const resolveId = createResolver([clientOnly])
+
+    expect(resolveId('/src/components/Interactive.vue')).toBeUndefined()
+    expect(resolveId('/src/other/Interactive.client.vue')).toBeUndefined()
+    expect(resolveId('vue')).toBeUndefined()
+    expect(resolveId('#components')).toBeUndefined()
+  })
+
+  it('does not stub components registered through `#components`', () => {
+    const resolveId = createResolver([clientOnly])
+
+    expect(resolveId('/src/components/Interactive.client.vue?nuxt_component=client&nuxt_component_name=Interactive&nuxt_component_export=default')).toBeUndefined()
+  })
+
+  it('stubs a client component registered at a path without a `.client` suffix', () => {
+    const resolveId = createResolver([
+      component({ filePath: '/module/runtime/interactive.ts', pascalName: 'Interactive', mode: 'client' }),
+    ])
+
+    expect(resolveId('/module/runtime/interactive.ts')).toBe(SERVER_PLACEHOLDER)
+  })
+
+  it('does not stub a file also registered in another mode', () => {
+    const shared = '/src/runtime/components.ts'
+    const resolveId = createResolver([
+      component({ filePath: shared, pascalName: 'NCompClient', export: 'NComp', mode: 'client' }),
+      component({ filePath: shared, pascalName: 'NCompServer', export: 'NComp', mode: 'server' }),
+      component({ filePath: shared, pascalName: 'NCompAll', export: 'NComp', mode: 'all' }),
+    ])
+
+    expect(resolveId(shared)).toBeUndefined()
+  })
+
+  it('does not stub a client component exposing a named export', () => {
+    const resolveId = createResolver([
+      component({ filePath: '/src/components/Named.client.ts', pascalName: 'Named', export: 'Named', mode: 'client' }),
+    ])
+
+    expect(resolveId('/src/components/Named.client.ts')).toBeUndefined()
+  })
+
+  it('picks up components discovered by a later scan', () => {
+    let components: Component[] = []
+    const resolveId = createResolver(() => components)
+
+    expect(resolveId('/src/components/Interactive.client.vue')).toBeUndefined()
+
+    components = [clientOnly]
+    expect(resolveId('/src/components/Interactive.client.vue')).toBe(SERVER_PLACEHOLDER)
+  })
+
+  it('is not filtered in dev, where a later scan can add a component at any path', () => {
+    let components: Component[] = []
+    const resolveId = createResolver(() => components, true)
+
+    components = [component({ filePath: '/module/runtime/interactive.ts', pascalName: 'Interactive', mode: 'client' })]
+    expect(resolveId('/module/runtime/interactive.ts')).toBe(SERVER_PLACEHOLDER)
+  })
+})

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -11,8 +11,6 @@ import { createRegExp, exactly } from 'magic-regexp'
 import { asyncContext, isDev, isTestingAppManifest, isWebpack, runsOnceInMatrix } from './matrix'
 import { expectNoClientErrors, gotoPath, parseData, parsePayload, renderPage } from './utils'
 
-const itFailsIf = (condition: boolean) => condition ? it.fails : it
-
 await setup({
   rootDir: fileURLToPath(new URL('./fixtures/basic', import.meta.url)),
   dev: isDev,
@@ -428,7 +426,7 @@ describe('pages', () => {
     await page.close()
   })
 
-  itFailsIf(isWebpack && isDev)('/client-only-components', async () => {
+  it('/client-only-components', async () => {
     const html = await $fetch<string>('/client-only-components')
     expect(html).toContain('<div>Fallback</div>')
     // ensure components are not rendered server-side
@@ -2130,12 +2128,10 @@ describe.skipIf(isWindows)('useAsyncData', () => {
 })
 
 describe.runIf(isDev)('component testing', () => {
-  itFailsIf(isWebpack && isDev)('should work', async () => {
-    // TODO: fix in nuxt/test-utils
+  it('should work', async () => {
     const comp1 = await $fetchComponent('app/components/Counter.vue', { multiplier: 2 })
     expect(comp1).toContain('12 x 2 = 24')
 
-    // TODO: fix in nuxt/test-utils
     const comp2 = await $fetchComponent('app/components/Counter.vue', { multiplier: 4 })
     expect(comp2).toContain('12 x 4 = 48')
   })

--- a/test/server-components.test.ts
+++ b/test/server-components.test.ts
@@ -12,8 +12,6 @@ import { MAX_ISLAND_BODY_BYTES } from '../packages/nitro-server/src/runtime/util
 import { isDev, isWebpack } from './matrix'
 import { renderPage } from './utils'
 
-const itFailsIf = (condition: boolean) => condition ? it.fails : it
-
 function islandURL (name: string, opts: { props?: Record<string, any>, context?: Record<string, any> } = {}) {
   const serializedProps = serializeIslandProps(opts.props)
   const ctx = opts.context ?? {}
@@ -412,7 +410,7 @@ describe('component islands', () => {
     })
   }
 
-  itFailsIf(isWebpack && isDev)('renders pure components', async () => {
+  it('renders pure components', async () => {
     const result = await $fetch<NuxtIslandResponse>(islandURL('PureComponent', {
       props: {
         bool: false,
@@ -445,6 +443,11 @@ describe('component islands', () => {
           ],
         }
       `)
+    } else if (isWebpack) {
+      // island CSS is delivered by the vite dev server module graph, which webpack/rspack have no
+      // equivalent for in dev: https://github.com/nuxt/nuxt/issues/35573
+      expect(result.head.link).toBeUndefined()
+      expect(result.head.style).toBeUndefined()
     } else {
       // TODO: resolve dev bug triggered by earlier fetch of /vueuse-head page
       // https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/core/runtime/nitro/handlers/renderer.ts#L139


### PR DESCRIPTION
### 🔗 Linked issue

resolves #35573

### 📚 Description

this resolves two of the three `it.fails` from #35571 (and I think the remaining one has no webpack solution so I'm marking it closed when this merges)

#### client-only tree-shaking

`/client-only-components` failed for webpack/rspack dev with `window is not defined`. this was because `vue-loader` split script and template into separate modules in dev, so `nuxt:tree-shake-template` never saw a `.client` import next to the `ssrRender` that would prove it unused. this PR resolves those imports to `server-placeholder` in the server build instead, matching what `#components` already does.

#### test component wrapper

the test wrapper's `await import(path)` became a context module that webpack can't resolve, so `#build/test-component-wrapper.mjs` now passes down a static map of component to lazy import.
