### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/docs/errors/e2012.md
+++ b/docs/errors/e2012.md
@@ -1,0 +1,24 @@
+---
+title: 'NUXT_E2012'
+description: 'Infinite redirect loop in route middleware.'
+navigation: false
+---
+
+# E2012
+
+A route middleware redirected to a new location on every navigation (for example `a → b → a`), so the navigation never settled. On the server Nuxt responds with a `500 Too Many Redirects` error instead of hanging the request; on the client the navigation is aborted.
+
+## Resolution
+
+Make sure your middleware has an exit condition so it does not redirect on every navigation. For example, only redirect when `to.path` matches a specific value:
+
+```ts [middleware/auth.ts]
+export default defineNuxtRouteMiddleware((to) => {
+  if (to.path !== '/login') {
+    return navigateTo('/login')
+  }
+})
+```
+
+::read-more{to="/docs/guide/directory-structure/middleware"}
+::

--- a/packages/nuxt/src/app/diagnostics/navigation.ts
+++ b/packages/nuxt/src/app/diagnostics/navigation.ts
@@ -60,5 +60,9 @@ export const navigationDiagnostics = !import.meta.dev
           fix: 'Script protocols (e.g. `javascript:`) are blocked for security. Use a valid `http:` or `https:` URL.',
           docs: false,
         },
+        NUXT_E2012: {
+          why: (p: { chain: string }) => `Detected an infinite redirect loop in route middleware: ${p.chain}.`,
+          fix: 'Ensure your middleware has an exit condition so it does not redirect on every navigation (e.g. only redirect when `to.path` matches a specific value).',
+        },
       },
     })

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -44,6 +44,9 @@ function createCurrentLocation (
   return path + (path.includes('?') ? '' : search) + hash
 }
 
+// Maximum consecutive middleware redirects before considering it an infinite loop (#13565)
+const MAX_MIDDLEWARE_REDIRECTS = 30
+
 const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
   name: 'nuxt:router',
   enforce: 'pre',
@@ -149,11 +152,24 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
     }
 
     const error = useError()
+
+    // Middleware returning a new location (e.g. via `navigateTo`) starts a new navigation, which
+    // re-runs middleware. A middleware that redirects on every navigation would loop forever —
+    // freezing the tab on the client or hanging the request on the server (#13565). vue-router
+    // only detects redirects to the _same_ location, and only in dev, so we track the chain here.
+    let middlewareRedirects = 0
+    const redirectChain: string[] = []
+    const resetRedirectChain = () => {
+      middlewareRedirects = 0
+      redirectChain.length = 0
+    }
+
     // we only skip redirect handlers for component islands, not page islands
     const isServerPage = import.meta.server && nuxtApp.ssrContext?.islandContext?.name?.startsWith('page_')
     if (import.meta.client || !nuxtApp.ssrContext?.islandContext || isServerPage) {
       router.afterEach(async (to, _from, failure) => {
         delete nuxtApp._processingMiddleware
+        resetRedirectChain()
         if (import.meta.server) {
           delete nuxtApp._middlewareTo
         }
@@ -301,6 +317,29 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
               if (isNuxtError(result) && result.fatal) {
                 await nuxtApp.runWithContext(() => showError(result))
                 pushErroredRoute(to)
+              } else if (!(result instanceof Error)) {
+                // the middleware is redirecting to a new location, which re-runs middleware
+                if (middlewareRedirects === 0) {
+                  if (from !== START_LOCATION) {
+                    redirectChain.push(from.fullPath)
+                  }
+                  redirectChain.push(to.fullPath)
+                }
+                middlewareRedirects++
+                try {
+                  redirectChain.push(router.resolve(result).fullPath)
+                } catch {
+                  redirectChain.push(String(result))
+                }
+                if (middlewareRedirects > MAX_MIDDLEWARE_REDIRECTS) {
+                  const chain = redirectChain.length > 12 ? `${redirectChain.slice(0, 12).join(' → ')} → …` : redirectChain.join(' → ')
+                  resetRedirectChain()
+                  navigationDiagnostics.NUXT_E2012({ chain })
+                  if (import.meta.server) {
+                    return createError({ status: 500, statusText: 'Too Many Redirects', message: `Detected an infinite redirect loop in route middleware: ${chain}` })
+                  }
+                  return false
+                }
               }
               return result
             }
@@ -334,6 +373,7 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
 
     router.onError(async () => {
       delete nuxtApp._processingMiddleware
+      resetRedirectChain()
       if (import.meta.server) {
         delete nuxtApp._middlewareTo
       }

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -310,9 +310,44 @@ describe('pages', () => {
     await serverPage.close()
   })
 
-  it.runIf(isDev)('returns 500 when there is an infinite redirect', async () => {
+  it('returns 500 when there is an infinite redirect', async () => {
     const { status } = await fetch('/catchall/redirect-infinite', { redirect: 'manual' })
     expect(status).toEqual(500)
+  })
+
+  it('returns 500 when middleware redirects in a cycle', async () => {
+    const { status } = await fetch('/catchall/redirect-cycle-a', { redirect: 'manual' })
+    expect(status).toEqual(500)
+  })
+
+  it('allows redirect chains below the loop threshold', async () => {
+    const html = await $fetch<string>('/catchall/redirect-chain')
+    expect(html).toContain('catchall at not-found')
+  })
+
+  it('warns and aborts navigation when middleware redirects in a cycle on client', async () => {
+    const { page, consoleLogs } = await renderPage('/')
+    await page.evaluate(() => {
+      void (window.useNuxtApp!() as unknown as { $router: { push: (to: string) => Promise<unknown> } }).$router.push('/catchall/redirect-cycle-a').catch(() => {})
+    })
+    await vi.waitFor(() => {
+      expect(consoleLogs.some(log => log.text.includes('NUXT_E2012'))).toBe(true)
+    }, { timeout: 10_000 })
+    if (isDev) {
+      const warning = consoleLogs.find(log => log.text.includes('NUXT_E2012'))
+      expect(warning!.text).toContain('/catchall/redirect-cycle-a')
+      expect(warning!.text).toContain('/catchall/redirect-cycle-b')
+    }
+    expect(new URL(page.url()).pathname).toBe('/')
+
+    // the redirect count resets afterwards, so a subsequent chain below the threshold still completes
+    await page.evaluate(() => {
+      void (window.useNuxtApp!() as unknown as { $router: { push: (to: string) => Promise<unknown> } }).$router.push('/catchall/redirect-chain').catch(() => {})
+    })
+    await vi.waitFor(() => {
+      expect(new URL(page.url()).pathname).toBe('/catchall/not-found')
+    }, { timeout: 10_000 })
+    await page.close()
   })
 
   it('render catchall page', async () => {

--- a/test/fixtures/basic/app/middleware/redirect.global.ts
+++ b/test/fixtures/basic/app/middleware/redirect.global.ts
@@ -10,8 +10,19 @@ export default defineNuxtRouteMiddleware(async (to) => {
     return navigateTo(to.path.slice('/redirect/'.length - 1))
   }
   if (to.path === '/catchall/redirect-infinite') {
-    // the path will be the same in this new route and vue-router should send a 500 response
+    // the path will be the same in this new route, so middleware will redirect in a
+    // loop and Nuxt should respond with a 500 error
     return navigateTo('/catchall/redirect-infinite?test=true')
+  }
+  if (to.path === '/catchall/redirect-cycle-a') {
+    return navigateTo('/catchall/redirect-cycle-b')
+  }
+  if (to.path === '/catchall/redirect-cycle-b') {
+    return navigateTo('/catchall/redirect-cycle-a')
+  }
+  if (to.path === '/catchall/redirect-chain') {
+    // two consecutive redirects (here and the `/redirect/` rule above), below the loop threshold
+    return navigateTo('/redirect/catchall/not-found')
   }
   if (to.path === '/navigate-to-external') {
     return navigateTo('/', { external: true })


### PR DESCRIPTION
### What

Implements the team plan from #13565: when route middleware redirects too many times in a row,

1. emit a verbose warning on the client in dev mode (via a new `NUXT_E2012` diagnostic, with the redirect chain and a docs page)
2. respond with a server error (`500 Too Many Redirects`) instead of hanging the request

### Why

A middleware that redirects on every navigation (e.g. `a → b → a`) loops forever. vue-router's own detection only covers redirects to the *same* location and is dev-only (`redirectedFrom._count > 30`), so redirect cycles and all production builds hang: the tab freezes on the client, and on the server `router.push(initialURL)` never settles so the request never responds.

### How

In the pages router plugin (`packages/nuxt/src/pages/runtime/plugins/router.ts`), each time a middleware returns a new location (a redirect) we count it and record the target in a trace, seeded with `from`/`to` of the first hop (skipping `START_LOCATION`). The count resets on every settled navigation (`afterEach`) and on navigation errors (`router.onError`); intermediate redirect hops don't trigger either, so the counter only accumulates within an unsettled chain. Past 30 redirects (matching vue-router's own threshold, but evaluated earlier within the same hop):

- server: report the diagnostic and return `createError({ status: 500, statusText: 'Too Many Redirects', ... })`, which surfaces through the existing guard-error → `_showErrorUnlessCrawler` path as a 500 error page (same mechanics as the current dev-only vue-router rejection)
- client: report the diagnostic (`NUXT_E2012`, with chain + fix + docs link in dev; `[NUXT_E2012]` via the prod reporter) and abort the navigation, leaving the current page intact

### Verification

- Fixture middleware gained a cycle (`/catchall/redirect-cycle-a` ↔ `b`) and a below-threshold two-hop chain.
- New/updated tests in `test/basic.test.ts`:
  - `returns 500 when there is an infinite redirect` — now runs in prod too (previously dev-only, since it relied on vue-router's dev check)
  - `returns 500 when middleware redirects in a cycle` — new; passes in dev **and** prod
  - `allows redirect chains below the loop threshold` — new; legitimate two-hop chains still complete
  - `warns and aborts navigation when middleware redirects in a cycle on client` — new; asserts the `NUXT_E2012` console message (and the chain text in dev), that the navigation is aborted, and that the counter resets (a follow-up navigation completes)
- Ran: `fixtures:vite-dev-default-manifest-on` and `fixtures:vite-built-default-manifest-on` projects for `test/basic.test.ts` with `-t 'redirect'` (31 passed) and `-t 'middleware|navigateTo'` (26 passed) — all green; `pnpm typecheck`, `eslint` on touched files, `markdownlint`/`case-police` on the new docs page — all clean.
- The diff was reviewed non-interactively by an LLM reviewer (kiro-cli, claude-opus-5) across three rounds; findings that were addressed: chain seeding, stale-counter resets, redirect-only counting with the 30 threshold, returning instead of throwing the server error, resolve-hardening, and the extra tests. Two rejected with evidence (a claimed `result === false` fall-through — it returns earlier; and deriving depth from `to.redirectedFrom`, which is not a linked list — vue-router keeps only the first origin, which is why it needs its own `_count` hack).

### Honest limitations / follow-ups

- The pages-less router (`packages/nuxt/src/app/plugins/router.ts`, used with `pages: false`) has the same defect — its `handleNavigation(result, true)` recurses without a depth bound (ending in a stack overflow caught by its error hooks). I left it out to keep this PR focused; happy to follow up.
- On the client, a loop during the *initial* SPA navigation (`ssr: false` boot) now aborts with a console warning but no error UI; surfacing an error page there could be a follow-up refinement.
- I tested the vite builder in dev and built modes only (not webpack/rspack), and did not exercise `redirectCode`/external-redirect interactions beyond the existing fixture suite.

Refs #13565