### PR TITLE
fix(nuxt): only compute `distURL` in development

### DIFF
--- a/packages/nuxt/src/app/utils.ts
+++ b/packages/nuxt/src/app/utils.ts
@@ -11,7 +11,6 @@ export function isBotUserAgent (userAgent: string): boolean {
   return BOT_RE.test(userAgent)
 }
 
-const distURL = import.meta.url.replace(/\/app\/.*$/, '/')
 type Trace = { source: string, line?: number, column?: number }
 
 export function getUserTrace (): Trace[] {
@@ -20,6 +19,7 @@ export function getUserTrace (): Trace[] {
   }
 
   const trace = captureStackTrace()
+  const distURL = import.meta.url.replace(/\/app\/.*$/, '/')
   const start = trace.findIndex(entry => !entry.source.startsWith(distURL))
   const end = trace.toReversed().findIndex(entry => !entry.source.includes('node_modules') && !entry.source.startsWith(distURL))
   if (start === -1 || end === -1) {
@@ -36,6 +36,7 @@ export function getUserCaller (): Trace | null {
     return null
   }
 
+  const distURL = import.meta.url.replace(/\/app\/.*$/, '/')
   const { source, line, column } = captureStackTrace().find(entry => !entry.source.startsWith(distURL)) ?? {}
 
   if (!source) {

--- a/packages/nuxt/src/app/utils.ts
+++ b/packages/nuxt/src/app/utils.ts
@@ -11,6 +11,7 @@ export function isBotUserAgent (userAgent: string): boolean {
   return BOT_RE.test(userAgent)
 }
 
+const distURL = import.meta.dev ? import.meta.url.replace(/\/app\/.*$/, '/') : ''
 type Trace = { source: string, line?: number, column?: number }
 
 export function getUserTrace (): Trace[] {
@@ -19,7 +20,6 @@ export function getUserTrace (): Trace[] {
   }
 
   const trace = captureStackTrace()
-  const distURL = import.meta.url.replace(/\/app\/.*$/, '/')
   const start = trace.findIndex(entry => !entry.source.startsWith(distURL))
   const end = trace.toReversed().findIndex(entry => !entry.source.includes('node_modules') && !entry.source.startsWith(distURL))
   if (start === -1 || end === -1) {
@@ -36,7 +36,6 @@ export function getUserCaller (): Trace | null {
     return null
   }
 
-  const distURL = import.meta.url.replace(/\/app\/.*$/, '/')
   const { source, line, column } = captureStackTrace().find(entry => !entry.source.startsWith(distURL)) ?? {}
 
   if (!source) {

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -103,7 +103,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs'], serverDir, pagesRootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"313k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"314k"`)
 
     const packages = getVendorPackages(await glob(['_libs/**/*'], { cwd: serverDir }))
     expect(packages).toMatchInlineSnapshot(`


### PR DESCRIPTION
### 🔗 Linked issue

Resolves https://github.com/nuxt/nuxt/issues/36022 
Resolves https://github.com/nuxt/nuxt/issues/36031

### 📚 Description

Compute `distURL` lazily in its `import.meta.dev` gated consumers instead of doing it in the module scope.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
