### PR TITLE
fix(nuxt): avoid mutating options when stripping never-hydrated data

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -393,6 +393,10 @@ export const createUseAsyncData: CreateUseAsyncData = defineKeyedFunctionFactory
         }
       }
 
+      if (import.meta.server && stripNeverHydratedData && opts.serialize === undefined && getCurrentInstance() && inject(neverHydratedSymbol, false)) {
+        opts = { ...opts, serialize: false }
+      }
+
       opts.server ??= true
       opts.default ??= getDefault as () => DefaultT
       opts.getCachedData ??= getDefaultCachedData
@@ -402,10 +406,6 @@ export const createUseAsyncData: CreateUseAsyncData = defineKeyedFunctionFactory
       opts.deep ??= asyncDataDefaults.deep
       opts.dedupe ??= 'cancel'
       opts.enabled ??= true
-
-      if (import.meta.server && stripNeverHydratedData && opts.serialize === undefined && getCurrentInstance() && inject(neverHydratedSymbol, false)) {
-        opts.serialize = false
-      }
 
       // assign overrides from factory
       if (shouldFactoryOptionsOverride) {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this keeps `serialize: false` scoped locally rather than potentially affecting a shared options object. it's context dependent (based on whether it's called inside a `hydrate-never` boundary) so this is unsafe