### PR TITLE
refactor(kit,nitro)!: remove deprecated baseUrl handling

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -493,14 +493,6 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
 
   const aliases: Record<string, string> = nuxt.options.alias
 
-  // TODO: remove support for baseUrl in nuxt v5
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  const basePath = tsConfig.compilerOptions!.baseUrl
-    // TODO: remove support for baseUrl in nuxt v5
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    ? resolve(nuxt.options.buildDir, tsConfig.compilerOptions!.baseUrl)
-    : nuxt.options.buildDir
-
   tsConfig.compilerOptions ||= {}
   tsConfig.compilerOptions.paths ||= {}
   tsConfig.include ||= []
@@ -512,7 +504,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
     if (excludedAlias.some(re => re.test(alias))) {
       continue
     }
-    let absolutePath = resolve(basePath, aliases[alias]!)
+    let absolutePath = resolve(nuxt.options.buildDir, aliases[alias]!)
     let stats = await fsp.stat(absolutePath).catch(() => null /* file does not exist */)
     if (!stats) {
       const resolvedModule = resolveModulePath(aliases[alias]!, {
@@ -578,6 +570,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
     .filter(root => !rootDirWithSlash.startsWith(root))
 
   async function resolveConfig (tsConfig: TSConfig) {
+    Reflect.deleteProperty(tsConfig.compilerOptions!, 'baseUrl')
     for (const alias in tsConfig.compilerOptions!.paths) {
       const paths = tsConfig.compilerOptions!.paths[alias]
       tsConfig.compilerOptions!.paths[alias] = [...new Set(await Promise.all(paths.map(async (path: string) => {

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -52,6 +52,24 @@ describe('tsConfig generation', () => {
     `)
   })
 
+  it('should ignore baseUrl when resolving aliases', async () => {
+    const { tsConfig } = await _generateTypes(mockNuxtWithOptions({
+      alias: {
+        '#probe/base-url': './probe-target/',
+      },
+      typescript: {
+        tsConfig: {
+          compilerOptions: {
+            baseUrl: 'legacy-base',
+          },
+        },
+      },
+    }))
+
+    expect(tsConfig.compilerOptions?.paths?.['#probe/base-url']).toEqual(['./probe-target'])
+    expect(Reflect.get(tsConfig.compilerOptions ?? {}, 'baseUrl')).toBeUndefined()
+  })
+
   it('should add exclude for module paths', async () => {
     const { tsConfig } = await _generateTypes(mockNuxtWithOptions({
       modulesDir: ['/my-app/modules/test/node_modules', '/my-app/modules/node_modules', '/my-app/node_modules/@some/module/node_modules'],

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -788,13 +788,11 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
 
   // TODO: extract to shared utility?
   const excludedAlias = [/^@vue\/.*$/, 'vue', /vue-router/, 'vite/client', '#imports', 'vue-demi', /^#app/, '~', '@', '~~', '@@']
-  // TODO: remove support for baseUrl in nuxt v5
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  const basePath = nitroConfig.typescript!.tsConfig!.compilerOptions?.baseUrl ? resolve(nuxt.options.buildDir, nitroConfig.typescript!.tsConfig!.compilerOptions?.baseUrl) : nuxt.options.buildDir
   const aliases = nitroConfig.alias!
   const importPaths = nuxt.options.modulesDir.map(d => pathToFileURL(withTrailingSlash(d)))
   const tsConfig = nitroConfig.typescript!.tsConfig!
   tsConfig.compilerOptions ||= {}
+  Reflect.deleteProperty(tsConfig.compilerOptions, 'baseUrl')
   tsConfig.compilerOptions.paths ||= {}
   for (const _alias in aliases) {
     const alias = _alias as keyof typeof aliases
@@ -805,7 +803,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
       continue
     }
 
-    let absolutePath = resolve(basePath, aliases[alias]!)
+    let absolutePath = resolve(nuxt.options.buildDir, aliases[alias]!)
     let stats = await fsp.stat(absolutePath).catch(() => null /* file does not exist */)
     if (!stats) {
       const resolvedModule = resolveModulePath(aliases[alias]!, {

--- a/packages/nuxt/test/load-nuxt.test.ts
+++ b/packages/nuxt/test/load-nuxt.test.ts
@@ -1,12 +1,13 @@
 import { fileURLToPath } from 'node:url'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { normalize } from 'pathe'
+import { normalize, resolve } from 'pathe'
 import { withoutTrailingSlash } from 'ufo'
 import { defu } from 'defu'
 import { logger, tryUseNuxt, useNuxt } from '@nuxt/kit'
 import { findWorkspaceDir } from 'pkg-types'
 import { loadNuxt } from '../src/index.ts'
 import type { NuxtConfig } from '../schema.ts'
+import type { Nitro } from 'nitro/types'
 
 const repoRoot = await findWorkspaceDir()
 
@@ -209,6 +210,37 @@ describe('loadNuxt', () => {
     expect(tsConfigPaths['#probe/defu']?.[0]?.replace(/\\/g, '/')).toMatch(/node_modules\/defu\//)
 
     await nuxt.close()
+  })
+
+  it('ignores baseUrl when resolving nitro aliases', async () => {
+    const nuxt = await loadNuxt({
+      cwd: repoRoot,
+      ready: true,
+      overrides: {
+        nitro: {
+          alias: {
+            '#probe/base-url': './probe-target',
+          },
+          typescript: {
+            tsConfig: {
+              compilerOptions: {
+                baseUrl: 'legacy-base',
+              },
+            },
+          },
+        },
+      },
+    })
+
+    // Nitro attaches its instance to Nuxt during the ready hook.
+    const nitro = (nuxt as typeof nuxt & { _nitro?: Nitro })._nitro
+    const compilerOptions = nitro?.options.typescript?.tsConfig?.compilerOptions ?? {}
+    const tsConfigPaths = compilerOptions.paths ?? {}
+    const aliasPath = tsConfigPaths['#probe/base-url']?.[0]
+    await nuxt.close()
+
+    expect(aliasPath).toBe(resolve(nuxt.options.buildDir, 'probe-target'))
+    expect(Reflect.get(compilerOptions, 'baseUrl')).toBeUndefined()
   })
 
   it('applies global typescript.tsConfig compiler options to the nitro tsconfig', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

Nuxt 5 still carried special `compilerOptions.baseUrl` handling even though TypeScript 6 deprecated the option. That compatibility no longer belongs on `main`: this removes `baseUrl` from generated Kit and Nitro configs and keeps generated aliases rooted at `buildDir`. This is intentionally breaking for configs or modules that still set `baseUrl`.