### PR TITLE
fix(kit): add vite plugins at top level instead of wrapping them

### DIFF
--- a/packages/kit/src/build.ts
+++ b/packages/kit/src/build.ts
@@ -1,5 +1,5 @@
 import type { Configuration as WebpackConfig, WebpackPluginInstance } from 'webpack'
-import type { ConfigEnv, UserConfig as ViteConfig, Plugin as VitePlugin } from 'vite'
+import type { UserConfig as ViteConfig, Plugin as VitePlugin } from 'vite'
 import type { Nuxt, NuxtBuildOutputs } from '@nuxt/schema'
 import { useNuxt } from './context.ts'
 import { toArray } from './utils.ts'
@@ -175,37 +175,34 @@ export function addVitePlugin (pluginOrGetter: Arrayable<VitePlugin> | (() => Th
     config.plugins ||= []
 
     const plugin = toArray(typeof pluginOrGetter === 'function' ? await pluginOrGetter() : pluginOrGetter)
+    const method: 'push' | 'unshift' = options?.prepend ? 'unshift' : 'push'
+
+    // Isomorphic plugins apply to every environment Nuxt builds, so they only need
+    // scoping once Nitro contributes environments of its own.
     if (isIsomorphic && !nuxt.options.experimental.nitroViteEnvironment) {
-      const method: 'push' | 'unshift' = options?.prepend ? 'unshift' : 'push'
       config.plugins[method](...plugin)
       return
     }
 
+    // Without the environment API `applyToEnvironment` is ignored, so a plugin that
+    // is not isomorphic has to be added to each environment's config separately.
     if (!config.environments?.ssr || !config.environments.client) {
-      needsEnvInjection = true
+      if (isIsomorphic) {
+        config.plugins[method](...plugin)
+      } else {
+        needsEnvInjection = true
+      }
       return
     }
 
     const environmentName = options.server === false ? 'client' : 'ssr'
+    const isAllowed = isIsomorphic
+      ? (name: string) => name === 'client' || name === 'ssr'
+      : (name: string) => name === environmentName
     // isomorphic plugins are normally just added to plugins, so only force when `prepend` is set
     const defaultEnforce = isIsomorphic ? (options?.prepend ? 'pre' : undefined) : (options?.prepend ? 'pre' : 'post')
 
-    // Vite only sorts by `enforce` at the top level, and inserts the plugins returned from
-    // `applyToEnvironment` at the wrapper's own position, so plugins declaring different
-    // `enforce` values need a wrapper each to keep their requested ordering.
-    const method: 'push' | 'unshift' = options?.prepend ? 'unshift' : 'push'
-    for (const [enforce, plugins] of groupByEnforce(plugin, defaultEnforce)) {
-      const pluginName = plugins.map(p => p.name).join('|')
-      config.plugins[method]({
-        name: `${pluginName}:wrapper`,
-        enforce,
-        applyToEnvironment (environment) {
-          if (isIsomorphic ? environment.name === 'client' || environment.name === 'ssr' : environment.name === environmentName) {
-            return resolveNestedPlugins(plugins, config, environment, nuxt)
-          }
-        },
-      })
-    }
+    config.plugins[method](...plugin.map(p => scopeToEnvironments(p, defaultEnforce, isAllowed)))
   })
 
   nuxt.hook('vite:extendConfig', async (config, env) => {
@@ -223,67 +220,28 @@ export function addVitePlugin (pluginOrGetter: Arrayable<VitePlugin> | (() => Th
   })
 }
 
-type VitePluginEnvironment = Parameters<NonNullable<VitePlugin['applyToEnvironment']>>[0]
-
-function groupByEnforce (plugins: VitePlugin[], defaultEnforce: VitePlugin['enforce']) {
-  const groups = new Map<VitePlugin['enforce'], VitePlugin[]>()
-  for (const plugin of plugins) {
-    const enforce = plugin.enforce ?? defaultEnforce
-    const group = groups.get(enforce)
-    if (group) {
-      group.push(plugin)
-    } else {
-      groups.set(enforce, [plugin])
-    }
-  }
-  return groups
-}
-
 /**
- * Vite only honours `apply` and `applyToEnvironment` for plugins it finds in the
- * top-level plugin array, so plugins nested behind a wrapper have to be resolved
- * by hand or (for example) dev-only plugins would leak into production builds.
+ * `addVitePlugin` has always scoped plugins to the app builds. Nitro contributes
+ * further environments (`nitro`, and one per service), so a plugin registered here
+ * has to opt out of any environment it wasn't registered for.
+ *
+ * The plugin is returned as a top-level plugin rather than nested behind a wrapper
+ * so that Vite still applies `apply`, sorts by `enforce`, calls server-level hooks
+ * like `configureServer`, and exposes any extra properties the plugin declares
+ * (`api`, and whatever tooling scanning `config.plugins` looks for) as usual.
  */
-async function resolveNestedPlugins (plugins: VitePlugin[], config: ViteConfig, environment: VitePluginEnvironment, nuxt: Nuxt): Promise<VitePlugin[]> {
-  const configEnv = resolveConfigEnv(environment, config, nuxt)
-
-  const resolved: VitePlugin[] = []
-  for (const plugin of plugins) {
-    const { apply, applyToEnvironment } = plugin
-    if (apply && (typeof apply === 'function' ? !apply(config, configEnv) : apply !== configEnv.command)) {
-      continue
-    }
-    const applied = applyToEnvironment ? await applyToEnvironment(environment) : true
-    if (applied === true) {
-      resolved.push(plugin)
-      continue
-    }
-    resolved.push(...await flattenPlugins(applied))
-  }
-  return resolved
-}
-
-/**
- * `getTopLevelConfig` is only available from Vite 6, and kit is used with older
- * versions of nuxt (and therefore vite), so fall back to what we can infer.
- */
-function resolveConfigEnv (environment: VitePluginEnvironment, config: ViteConfig, nuxt: Nuxt): ConfigEnv {
-  const topLevelConfig = (environment as Partial<VitePluginEnvironment>).getTopLevelConfig?.() ?? environment.config as Partial<VitePluginEnvironment['config']> | undefined
+function scopeToEnvironments (plugin: VitePlugin, defaultEnforce: VitePlugin['enforce'], isAllowed: (name: string) => boolean): VitePlugin {
+  const { applyToEnvironment } = plugin
   return {
-    command: topLevelConfig?.command ?? (nuxt.options.dev ? 'serve' : 'build'),
-    mode: topLevelConfig?.mode ?? config.mode ?? nuxt.options.vite?.mode ?? (nuxt.options.dev ? 'development' : 'production'),
+    ...plugin,
+    enforce: plugin.enforce ?? defaultEnforce,
+    applyToEnvironment (environment) {
+      if (!isAllowed(environment.name)) {
+        return false
+      }
+      return applyToEnvironment ? applyToEnvironment(environment) : true
+    },
   }
-}
-
-async function flattenPlugins (option: unknown): Promise<VitePlugin[]> {
-  const resolved = await option
-  if (!resolved) {
-    return []
-  }
-  if (Array.isArray(resolved)) {
-    return (await Promise.all(resolved.map(flattenPlugins))).flat()
-  }
-  return [resolved as VitePlugin]
 }
 
 interface AddBuildPluginFactory {

--- a/packages/kit/src/build.ts
+++ b/packages/kit/src/build.ts
@@ -177,15 +177,8 @@ export function addVitePlugin (pluginOrGetter: Arrayable<VitePlugin> | (() => Th
     const plugin = toArray(typeof pluginOrGetter === 'function' ? await pluginOrGetter() : pluginOrGetter)
     const method: 'push' | 'unshift' = options?.prepend ? 'unshift' : 'push'
 
-    // Isomorphic plugins apply to every environment Nuxt builds, so they only need
-    // scoping once Nitro contributes environments of its own.
-    if (isIsomorphic && !nuxt.options.experimental.nitroViteEnvironment) {
-      config.plugins[method](...plugin)
-      return
-    }
-
-    // Without the environment API `applyToEnvironment` is ignored, so a plugin that
-    // is not isomorphic has to be added to each environment's config separately.
+    // Without the environment API `applyToEnvironment` is ignored, so an isomorphic
+    // plugin can be added as-is and anything else has to be injected per environment.
     if (!config.environments?.ssr || !config.environments.client) {
       if (isIsomorphic) {
         config.plugins[method](...plugin)
@@ -221,9 +214,11 @@ export function addVitePlugin (pluginOrGetter: Arrayable<VitePlugin> | (() => Th
 }
 
 /**
- * `addVitePlugin` has always scoped plugins to the app builds. Nitro contributes
- * further environments (`nitro`, and one per service), so a plugin registered here
- * has to opt out of any environment it wasn't registered for.
+ * `addVitePlugin` has always scoped plugins to the app builds. Builders can contribute
+ * further environments (Nitro adds `nitro`, and one per service), so a plugin registered
+ * here has to opt out of any environment it wasn't registered for. The check runs per
+ * environment as Vite resolves them, so environments added after the plugin was
+ * registered are still excluded.
  *
  * The plugin is returned as a top-level plugin rather than nested behind a wrapper
  * so that Vite still applies `apply`, sorts by `enforce`, calls server-level hooks

--- a/packages/kit/test/build.test.ts
+++ b/packages/kit/test/build.test.ts
@@ -1,5 +1,5 @@
 import { createHooks } from 'hookable'
-import type { Nuxt } from 'nuxt/schema'
+import type { Nuxt, ViteConfig as NuxtViteConfig } from 'nuxt/schema'
 import { createServer } from 'vite'
 import type { UserConfig as ViteConfig, Plugin as VitePlugin } from 'vite'
 import { describe, expect, it, vi } from 'vitest'
@@ -7,7 +7,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { addVitePlugin } from '../src/build.ts'
 import { runWithNuxtContext } from '../src/context.ts'
 
-function createMockNuxt (dev: boolean, nitroViteEnvironment = true) {
+function createMockNuxt (dev: boolean) {
   const hooks = createHooks()
   return {
     hooks,
@@ -16,7 +16,6 @@ function createMockNuxt (dev: boolean, nitroViteEnvironment = true) {
     options: {
       dev,
       build: false,
-      experimental: { nitroViteEnvironment },
       vite: { mode: dev ? 'development' : 'production' },
     },
   } as unknown as Nuxt
@@ -134,17 +133,7 @@ describe('addVitePlugin', () => {
   })
 
   describe('without the environment API', () => {
-    it('should add isomorphic plugins directly', async () => {
-      const nuxt = createMockNuxt(true, false)
-      const plugin: VitePlugin = { name: 'a' }
-      const plugins = await addPlugins(nuxt, [plugin])
-
-      expect(plugins).toHaveLength(1)
-      expect(plugins[0]).toBe(plugin)
-      expect(plugins[0]!.applyToEnvironment).toBeUndefined()
-    })
-
-    it('should add isomorphic plugins directly when vite has no environments', async () => {
+    it('should add isomorphic plugins as-is', async () => {
       const nuxt = createMockNuxt(true)
       const config: ViteConfig = { plugins: [] }
       const plugin: VitePlugin = { name: 'a' }
@@ -152,7 +141,8 @@ describe('addVitePlugin', () => {
       runWithNuxtContext(nuxt, () => addVitePlugin([plugin]))
       await nuxt.callHook('vite:extend', { config } as any)
 
-      expect(config.plugins).toEqual([plugin])
+      expect(config.plugins).toHaveLength(1)
+      expect(config.plugins![0]).toBe(plugin)
     })
 
     it('should inject single-environment plugins per environment', async () => {
@@ -164,12 +154,12 @@ describe('addVitePlugin', () => {
       await nuxt.callHook('vite:extend', { config } as any)
       expect(config.plugins).toEqual([])
 
-      const ssrConfig: ViteConfig = { plugins: [] }
-      await nuxt.callHook('vite:extendConfig', ssrConfig, { isServer: true, isClient: false } as any)
+      const ssrConfig: NuxtViteConfig = { plugins: [] }
+      await nuxt.callHook('vite:extendConfig', ssrConfig, { isServer: true, isClient: false })
       expect(ssrConfig.plugins).toEqual([])
 
-      const clientConfig: ViteConfig = { plugins: [] }
-      await nuxt.callHook('vite:extendConfig', clientConfig, { isServer: false, isClient: true } as any)
+      const clientConfig: NuxtViteConfig = { plugins: [] }
+      await nuxt.callHook('vite:extendConfig', clientConfig, { isServer: false, isClient: true })
       expect(clientConfig.plugins).toEqual([clientOnly])
     })
   })

--- a/packages/kit/test/build.test.ts
+++ b/packages/kit/test/build.test.ts
@@ -1,12 +1,13 @@
 import { createHooks } from 'hookable'
 import type { Nuxt } from 'nuxt/schema'
+import { createServer } from 'vite'
 import type { UserConfig as ViteConfig, Plugin as VitePlugin } from 'vite'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { addVitePlugin } from '../src/build.ts'
 import { runWithNuxtContext } from '../src/context.ts'
 
-function createMockNuxt (dev: boolean) {
+function createMockNuxt (dev: boolean, nitroViteEnvironment = true) {
   const hooks = createHooks()
   return {
     hooks,
@@ -15,120 +16,98 @@ function createMockNuxt (dev: boolean) {
     options: {
       dev,
       build: false,
-      experimental: { nitroViteEnvironment: true },
+      experimental: { nitroViteEnvironment },
       vite: { mode: dev ? 'development' : 'production' },
     },
   } as unknown as Nuxt
 }
 
-async function resolveClientPlugins (nuxt: Nuxt, plugins: VitePlugin[], environment: Record<string, unknown> = {
-  name: 'client',
-  getTopLevelConfig: () => ({
-    command: nuxt.options.dev ? 'serve' : 'build',
-    mode: nuxt.options.dev ? 'development' : 'production',
-  }),
-}) {
-  const config: ViteConfig = { plugins: [], environments: { client: {}, ssr: {} } }
-  runWithNuxtContext(nuxt, () => addVitePlugin(plugins))
-  await nuxt.callHook('vite:extend', { config } as any)
-
-  const wrapper = config.plugins![0] as VitePlugin
-  const applied = await wrapper.applyToEnvironment!(environment as any)
-  return (Array.isArray(applied) ? applied : []).map(p => (p as VitePlugin).name)
-}
-
-async function resolveWrappers (nuxt: Nuxt, plugins: VitePlugin[], options?: Parameters<typeof addVitePlugin>[1]) {
+async function addPlugins (nuxt: Nuxt, plugins: VitePlugin[], options?: Parameters<typeof addVitePlugin>[1]) {
   const config: ViteConfig = { plugins: [], environments: { client: {}, ssr: {} } }
   runWithNuxtContext(nuxt, () => addVitePlugin(plugins, options))
   await nuxt.callHook('vite:extend', { config } as any)
+  return config.plugins as VitePlugin[]
+}
 
-  const environment = { name: 'client', getTopLevelConfig: () => ({ command: 'build', mode: 'production' }) }
-  return Promise.all((config.plugins as VitePlugin[]).map(async wrapper => ({
-    enforce: wrapper.enforce,
-    plugins: ((await wrapper.applyToEnvironment!(environment as any)) as VitePlugin[]).map(p => p.name),
-  })))
+function environment (name: string) {
+  return { name, getTopLevelConfig: () => ({ command: 'build', mode: 'production' }) } as any
+}
+
+function appliesTo (plugin: VitePlugin, name: string) {
+  return plugin.applyToEnvironment!(environment(name))
 }
 
 describe('addVitePlugin', () => {
-  it('should filter nested dev-only plugins out of production builds', async () => {
-    const nuxt = createMockNuxt(false)
-    const names = await resolveClientPlugins(nuxt, [
-      { name: 'always' },
-      { name: 'serve-only', apply: 'serve' },
-      { name: 'build-only', apply: 'build' },
-      { name: 'fn-apply', apply: (_config, env) => env.command === 'build' },
-    ])
-    expect(names).toEqual(['always', 'build-only', 'fn-apply'])
+  it('should add plugins to the top-level plugin array', async () => {
+    const plugins = await addPlugins(createMockNuxt(true), [{ name: 'a' }, { name: 'b' }])
+    expect(plugins.map(p => p.name)).toEqual(['a', 'b'])
   })
 
-  it('should filter nested build-only plugins out of dev', async () => {
-    const nuxt = createMockNuxt(true)
-    const names = await resolveClientPlugins(nuxt, [
-      { name: 'always' },
-      { name: 'serve-only', apply: 'serve' },
-      { name: 'build-only', apply: 'build' },
-    ])
-    expect(names).toEqual(['always', 'serve-only'])
+  it('should scope isomorphic plugins to the app environments', async () => {
+    const [plugin] = await addPlugins(createMockNuxt(true), [{ name: 'a' }])
+    expect(await appliesTo(plugin!, 'client')).toBe(true)
+    expect(await appliesTo(plugin!, 'ssr')).toBe(true)
+    expect(await appliesTo(plugin!, 'nitro')).toBe(false)
   })
 
-  it('should respect a nested plugin own applyToEnvironment', async () => {
-    const nuxt = createMockNuxt(false)
-    const names = await resolveClientPlugins(nuxt, [
+  it('should scope single-environment plugins to their environment', async () => {
+    const [clientOnly] = await addPlugins(createMockNuxt(true), [{ name: 'a' }], { server: false })
+    expect(await appliesTo(clientOnly!, 'client')).toBe(true)
+    expect(await appliesTo(clientOnly!, 'ssr')).toBe(false)
+
+    const [serverOnly] = await addPlugins(createMockNuxt(true), [{ name: 'b' }], { client: false })
+    expect(await appliesTo(serverOnly!, 'ssr')).toBe(true)
+    expect(await appliesTo(serverOnly!, 'client')).toBe(false)
+    expect(await appliesTo(serverOnly!, 'nitro')).toBe(false)
+  })
+
+  it('should respect a plugin own applyToEnvironment within the allowed environments', async () => {
+    const plugins = await addPlugins(createMockNuxt(true), [
       { name: 'ssr-only', applyToEnvironment: env => env.name === 'ssr' },
-      { name: 'client-only', applyToEnvironment: env => env.name === 'client' },
       { name: 'replaced', applyToEnvironment: () => [{ name: 'replacement' }] },
     ])
-    expect(names).toEqual(['client-only', 'replacement'])
+    expect(await appliesTo(plugins[0]!, 'client')).toBe(false)
+    expect(await appliesTo(plugins[0]!, 'ssr')).toBe(true)
+    expect(await appliesTo(plugins[0]!, 'nitro')).toBe(false)
+    expect(await appliesTo(plugins[1]!, 'client')).toEqual([{ name: 'replacement' }])
+    expect(await appliesTo(plugins[1]!, 'nitro')).toBe(false)
   })
 
-  it('should infer the command when the environment predates `getTopLevelConfig`', async () => {
-    const nuxt = createMockNuxt(true)
-    const names = await resolveClientPlugins(nuxt, [
-      { name: 'always' },
-      { name: 'serve-only', apply: 'serve' },
-      { name: 'build-only', apply: 'build' },
-    ], { name: 'client' })
-    expect(names).toEqual(['always', 'serve-only'])
+  it('should preserve plugin hooks, metadata and apply', async () => {
+    const configureServer = vi.fn()
+    const transform = vi.fn()
+    const plugins = await addPlugins(createMockNuxt(true), [
+      { name: 'a', apply: 'serve', configureServer, transform, devtools: { dock: 'yes' }, api: { hello: 'world' } } as VitePlugin,
+    ])
+
+    const plugin = plugins[0] as VitePlugin & { devtools?: unknown }
+    expect(plugin.name).toBe('a')
+    expect(plugin.apply).toBe('serve')
+    expect(plugin.configureServer).toBe(configureServer)
+    expect(plugin.transform).toBe(transform)
+    expect(plugin.devtools).toEqual({ dock: 'yes' })
+    expect(plugin.api).toEqual({ hello: 'world' })
   })
 
-  it('should honour the enforce of wrapped plugins', async () => {
-    const nuxt = createMockNuxt(false)
-    const wrappers = await resolveWrappers(nuxt, [
+  it('should preserve the enforce of added plugins', async () => {
+    const plugins = await addPlugins(createMockNuxt(false), [
       { name: 'normal' },
       { name: 'first', enforce: 'pre' },
       { name: 'last', enforce: 'post' },
-      { name: 'also-first', enforce: 'pre' },
     ])
-    expect(wrappers).toEqual([
-      { enforce: undefined, plugins: ['normal'] },
-      { enforce: 'pre', plugins: ['first', 'also-first'] },
-      { enforce: 'post', plugins: ['last'] },
+    expect(plugins.map(p => [p.name, p.enforce])).toEqual([
+      ['normal', undefined],
+      ['first', 'pre'],
+      ['last', 'post'],
     ])
   })
 
   it('should fall back to the default enforce for plugins that declare none', async () => {
-    // With prepend: true, wrappers are unshifted so they appear in reverse order
-    // (last enforce group first). Vite sorts by enforce at the top level anyway.
-    expect(await resolveWrappers(createMockNuxt(false), [{ name: 'a' }, { name: 'b', enforce: 'post' }], { prepend: true })).toEqual([
-      { enforce: 'post', plugins: ['b'] },
-      { enforce: 'pre', plugins: ['a'] },
-    ])
-    expect(await resolveWrappers(createMockNuxt(false), [{ name: 'a' }, { name: 'b', enforce: 'pre' }], { server: false })).toEqual([
-      { enforce: 'post', plugins: ['a'] },
-      { enforce: 'pre', plugins: ['b'] },
-    ])
+    expect((await addPlugins(createMockNuxt(false), [{ name: 'a' }, { name: 'b', enforce: 'post' }], { prepend: true })).map(p => p.enforce)).toEqual(['pre', 'post'])
+    expect((await addPlugins(createMockNuxt(false), [{ name: 'a' }, { name: 'b', enforce: 'pre' }], { server: false })).map(p => p.enforce)).toEqual(['post', 'pre'])
   })
 
-  it('should resolve nested and async replacement plugins', async () => {
-    const nuxt = createMockNuxt(false)
-    const names = await resolveClientPlugins(nuxt, [
-      { name: 'deep', applyToEnvironment: () => [[{ name: 'nested' }], Promise.resolve({ name: 'async' })] as any },
-      { name: 'empty', applyToEnvironment: () => [null, undefined, false] as any },
-    ])
-    expect(names).toEqual(['nested', 'async'])
-  })
-
-  it('should prepend wrapper plugins when prepend: true', async () => {
+  it('should prepend plugins when prepend: true', async () => {
     const nuxt = createMockNuxt(false)
     const config: ViteConfig = { plugins: [], environments: { client: {}, ssr: {} } }
 
@@ -138,16 +117,10 @@ describe('addVitePlugin', () => {
     })
     await nuxt.callHook('vite:extend', { config } as any)
 
-    const wrapperNames = (config.plugins as VitePlugin[]).map(p => p.name)
-    const firstIndex = wrapperNames.findIndex(n => n === 'first:wrapper')
-    const secondIndex = wrapperNames.findIndex(n => n === 'second:wrapper')
-
-    expect(firstIndex).toBeGreaterThan(-1)
-    expect(secondIndex).toBeGreaterThan(-1)
-    expect(secondIndex).toBeLessThan(firstIndex)
+    expect((config.plugins as VitePlugin[]).map(p => p.name)).toEqual(['second', 'first'])
   })
 
-  it('should append wrapper plugins when prepend is not set', async () => {
+  it('should append plugins when prepend is not set', async () => {
     const nuxt = createMockNuxt(false)
     const config: ViteConfig = { plugins: [], environments: { client: {}, ssr: {} } }
 
@@ -157,12 +130,76 @@ describe('addVitePlugin', () => {
     })
     await nuxt.callHook('vite:extend', { config } as any)
 
-    const wrapperNames = (config.plugins as VitePlugin[]).map(p => p.name)
-    const firstIndex = wrapperNames.findIndex(n => n === 'first:wrapper')
-    const secondIndex = wrapperNames.findIndex(n => n === 'second:wrapper')
+    expect((config.plugins as VitePlugin[]).map(p => p.name)).toEqual(['first', 'second'])
+  })
 
-    expect(firstIndex).toBeGreaterThan(-1)
-    expect(secondIndex).toBeGreaterThan(-1)
-    expect(secondIndex).toBeGreaterThan(firstIndex)
+  describe('without the environment API', () => {
+    it('should add isomorphic plugins directly', async () => {
+      const nuxt = createMockNuxt(true, false)
+      const plugin: VitePlugin = { name: 'a' }
+      const plugins = await addPlugins(nuxt, [plugin])
+
+      expect(plugins).toHaveLength(1)
+      expect(plugins[0]).toBe(plugin)
+      expect(plugins[0]!.applyToEnvironment).toBeUndefined()
+    })
+
+    it('should add isomorphic plugins directly when vite has no environments', async () => {
+      const nuxt = createMockNuxt(true)
+      const config: ViteConfig = { plugins: [] }
+      const plugin: VitePlugin = { name: 'a' }
+
+      runWithNuxtContext(nuxt, () => addVitePlugin([plugin]))
+      await nuxt.callHook('vite:extend', { config } as any)
+
+      expect(config.plugins).toEqual([plugin])
+    })
+
+    it('should inject single-environment plugins per environment', async () => {
+      const nuxt = createMockNuxt(true)
+      const config: ViteConfig = { plugins: [] }
+      const clientOnly: VitePlugin = { name: 'client-only' }
+
+      runWithNuxtContext(nuxt, () => addVitePlugin([clientOnly], { server: false }))
+      await nuxt.callHook('vite:extend', { config } as any)
+      expect(config.plugins).toEqual([])
+
+      const ssrConfig: ViteConfig = { plugins: [] }
+      await nuxt.callHook('vite:extendConfig', ssrConfig, { isServer: true, isClient: false } as any)
+      expect(ssrConfig.plugins).toEqual([])
+
+      const clientConfig: ViteConfig = { plugins: [] }
+      await nuxt.callHook('vite:extendConfig', clientConfig, { isServer: false, isClient: true } as any)
+      expect(clientConfig.plugins).toEqual([clientOnly])
+    })
+  })
+
+  it('should run server-level hooks and expose metadata on a real vite server', async () => {
+    const nuxt = createMockNuxt(true)
+    let mounted = false
+    const plugins = await addPlugins(nuxt, [
+      {
+        name: 'hub',
+        devtools: { dock: 'yes' },
+        configureServer (server) {
+          mounted = true
+          server.middlewares.use('/__devtools/', (_req, res) => res.end('{"ok":true}'))
+        },
+      } as VitePlugin,
+      { name: 'build-only', apply: 'build' },
+    ])
+
+    const server = await createServer({ logLevel: 'silent', configFile: false, server: { middlewareMode: true }, plugins })
+    const names = server.config.plugins.map(p => p.name)
+    const body = await new Promise((resolve) => {
+      const res = { end: resolve, setHeader () {}, getHeader () {}, writeHead () {} }
+      server.middlewares({ url: '/__devtools/', method: 'GET', headers: {} } as any, res as any, () => resolve('<not mounted>'))
+    })
+    await server.close()
+
+    expect(mounted).toBe(true)
+    expect(body).toBe('{"ok":true}')
+    expect((server.config.plugins.find(p => p.name === 'hub') as any)?.devtools).toEqual({ dock: 'yes' })
+    expect(names).not.toContain('build-only')
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this aims to simplify/refactor the logic for adding vite plugins, given that vite environment api is the default going forward.

resolves an issue with https://github.com/nuxt/devtools whereby the new `devtools` property in vite plugin was being stripped which I noted when creating https://github.com/nuxt/devtools/pull/1063