### PR TITLE
fix(nuxt): keep ref-initialised `useState` connected to payload state

### DIFF
--- a/packages/nuxt/src/app/composables/state.ts
+++ b/packages/nuxt/src/app/composables/state.ts
@@ -41,7 +41,7 @@ export function useState<T> (...args: any): Ref<T> {
     if (isRef(initialValue)) {
       // vue will unwrap the ref for us
       nuxtApp.payload.state[key] = initialValue
-      return initialValue as Ref<T>
+      return state
     }
     state.value = initialValue
   }

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -362,6 +362,21 @@ describe('clearNuxtState', () => {
     expect(state2.value).toBe('test')
   })
 
+  it('expect ref-initialised state to reset', () => {
+    const key = 'clearNuxtState-ref'
+    const state = useState(key, () => ref('test'))
+    state.value = 'test-2'
+    clearNuxtState(key, { reset: true })
+    expect(state.value).toBe('test')
+  })
+
+  it('expect ref-initialised state to clear', () => {
+    const key = 'clearNuxtState-ref-2'
+    const state = useState(key, () => ref('test'))
+    clearNuxtState(key, { reset: false })
+    expect(state.value).toBeUndefined()
+  })
+
   it('expect state in payload for function to reset', () => {
     const key = 'clearNuxtState-test'
     const state = useState(key, () => 'test')


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

previously:

```ts
const s = useState('k', () => ref('a'))
s.value = 'x'
clearNuxtState('k', { reset: true })
s.value // still 'x'
```

returning the state (which uses `toRef`) instead means we keep our ref connected to `payload.state` (though it won't be object-equal to the ref passed in)