### PR TITLE
fix(nitro): expose server auto-imports as `#imports/server`

### DIFF
--- a/docs/3.guide/1.concepts/3.auto-imports.md
+++ b/docs/3.guide/1.concepts/3.auto-imports.md
@@ -127,6 +127,18 @@ const double = computed(() => count.value * 2)
 </script>
 ```
 
+In the [`server`](/docs/4.x/directory-structure/server) directory, `#imports` exposes the server auto-imports instead, including those added by modules with [`addServerImports`](/docs/4.x/api/kit/nitro#addserverimports). Nuxt exposes the same auto-imports with the `#imports/server` alias, which keeps working in server files that are also type-checked in the app context, like server routes:
+
+```ts [server/api/session.ts]
+import { useServerSession } from '#imports/server'
+
+export default defineEventHandler(() => useServerSession())
+```
+
+::note
+The `#imports/server` alias is only available in your server code. Importing it in your app is an error, as server utilities must not be bundled into the client.
+::
+
 ### Disabling Auto-imports
 
 If you want to disable auto-importing composables and utilities, you can set `imports.autoImport` to `false` in the `nuxt.config` file.

--- a/docs/3.guide/4.modules/5.recipes-advanced.md
+++ b/docs/3.guide/4.modules/5.recipes-advanced.md
@@ -239,3 +239,5 @@ This is required because Nuxt infers the return types of your server endpoints t
 ::warning
 This can cause issues when using **server-only types** in your route files. For example, if a module creates a server-only virtual file using [`addServerTemplate`](/docs/4.x/api/kit/templates#addservertemplate) and you declare types for it in `tsconfig.server.json`, those type declarations will only be available in the server context. When the app context type-checks your server routes, it won't recognize these server-only types and will report errors.  To resolve this, you unfortunately need to declare such types in the app context as well.
 ::
+
+Server auto-imports are an exception. Utilities registered with [`addServerImports`](/docs/4.x/api/kit/nitro#addserverimports) or [`addServerImportsDir`](/docs/4.x/api/kit/nitro#addserverimportsdir) are declared in both contexts, so you can import them explicitly from `#imports/server` and they will type-check in your route files.

--- a/docs/4.api/5.kit/12.nitro.md
+++ b/docs/4.api/5.kit/12.nitro.md
@@ -301,6 +301,8 @@ function addPrerenderRoutes (routes: string | string[]): void
 
 Add imports to the server. It makes your imports available in Nitro without the need to import them manually.
 
+These imports are also available explicitly from the `#imports/server` alias, which resolves in every type context, including [server routes type-checked in the app context](/docs/4.x/guide/modules/recipes-advanced#type-checking-server-routes-in-app-context).
+
 ::warning
 If you want to provide a utility that works in both server and client contexts and is usable in the [`shared/`](/docs/4.x/directory-structure/shared) directory, the function must be imported from the same source file for both [`addImports`](/docs/4.x/api/kit/autoimports#addimports) and `addServerImports` and should have identical signature. That source file should not import anything context-specific (i.e., Nitro context, Nuxt app context) or else it might cause errors during type-checking.
 ::
@@ -350,7 +352,7 @@ function addServerImports (dirs: Import | Import[]): void
 
 ## `addServerImportsDir`
 
-Add a directory to be scanned for auto-imports by Nitro.
+Add a directory to be scanned for auto-imports by Nitro. These imports are also available explicitly from the `#imports/server` alias.
 
 ### Usage
 

--- a/docs/4.api/5.kit/12.nitro.md
+++ b/docs/4.api/5.kit/12.nitro.md
@@ -301,7 +301,7 @@ function addPrerenderRoutes (routes: string | string[]): void
 
 Add imports to the server. It makes your imports available in Nitro without the need to import them manually.
 
-These imports are also available explicitly from the `#imports/server` alias, which resolves in every type context, including [server routes type-checked in the app context](/docs/4.x/guide/modules/recipes-advanced#type-checking-server-routes-in-app-context).
+These imports are also available explicitly from the `#imports/server` alias, which is mapped in both the server and app type contexts, so they also resolve in [server routes type-checked in the app context](/docs/4.x/guide/modules/recipes-advanced#type-checking-server-routes-in-app-context). The alias is for server code only, and importing it in your app is an error.
 
 ::warning
 If you want to provide a utility that works in both server and client contexts and is usable in the [`shared/`](/docs/4.x/directory-structure/shared) directory, the function must be imported from the same source file for both [`addImports`](/docs/4.x/api/kit/autoimports#addimports) and `addServerImports` and should have identical signature. That source file should not import anything context-specific (i.e., Nitro context, Nuxt app context) or else it might cause errors during type-checking.

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -192,6 +192,33 @@ describe('tsConfig generation', () => {
     expect(legacyTsConfig.exclude).toContain('my-app-exclude')
   })
 
+  it('should propagate paths added in the `prepare:types` hook to the legacy tsconfig', async () => {
+    // the legacy config shares the app config's `compilerOptions`, which is how modules
+    // (nitro, for one) can add a single paths entry and have both contexts resolve it
+    const nuxt = mockNuxtWithOptions({})
+    nuxt.callHook = ((name: string, ctx: unknown) => {
+      if (name === 'prepare:types') {
+        const { tsConfig } = ctx as { tsConfig: { compilerOptions: { paths: Record<string, string[]> } } }
+        tsConfig.compilerOptions.paths['#hooked-alias'] = ['/my-app/.nuxt/types/hooked']
+      }
+      return Promise.resolve()
+    }) as Nuxt['callHook']
+
+    const { tsConfig, legacyTsConfig } = await _generateTypes(nuxt)
+    expect(tsConfig.compilerOptions?.paths).toHaveProperty('#hooked-alias')
+    expect(legacyTsConfig.compilerOptions?.paths).toHaveProperty('#hooked-alias')
+  })
+
+  it('should not emit a wildcard for an alias pointing at a single declaration file', async () => {
+    // `#imports` resolves to an extensionless file rather than a directory, so no `#imports/*`
+    // entry is emitted and more specific specifiers under it stay resolvable
+    const { tsConfig } = await _generateTypes(mockNuxtWithOptions({
+      alias: { '#imports': `${typesFixtureDir}/util.ts` },
+    }))
+    expect(tsConfig.compilerOptions?.paths).toHaveProperty('#imports')
+    expect(tsConfig.compilerOptions?.paths).not.toHaveProperty('#imports/*')
+  })
+
   it('should rewrite `paths` substitutions so TS resolves them to declarations', async () => {
     const fixtureAliases = {
       'nitro/h3': `${typesFixtureDir}/h3.d.mts`,

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -144,6 +144,11 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
   delete globalCompilerOptions.paths
   delete globalCompilerOptions.noEmit
 
+  // Nitro writes server auto-imports (including anything registered with `addServerImports`)
+  // to `nitro-imports.d.ts` here, and maps `#imports` to it in `tsconfig.server.json`.
+  const nitroGeneratedTypesDir = join(nuxt.options.buildDir, 'types/nitro')
+  const serverImportsDeclaration = join(nitroGeneratedTypesDir, 'nitro-imports')
+
   const nitroConfig: NitroConfig = defu(nuxt.options.nitro, {
     typescript: {
       tsConfig: { compilerOptions: globalCompilerOptions } as NitroTSConfig,
@@ -200,6 +205,9 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     },
     baseURL: nuxt.options.app.baseURL,
     virtual: {
+      // server auto-imports under a specifier that is unambiguous outside the server
+      // context; nitro re-exports `#imports` as `#nitro` in the same way
+      '#imports/server': 'export * from "#imports"',
       '#internal/nuxt.config.mjs': () => nuxt.vfs['#build/nuxt.config.mjs'] || '',
       '#internal/nuxt/app-config': () => nuxt.vfs['#build/app.config.mjs']?.replace(/\/\*\* client \*\*\/[\s\S]*\/\*\* client-end \*\*\//, '') || '',
       '#spa-template': async () => `export const template = ${JSON.stringify(await spaLoadingTemplate(nuxt))}`,
@@ -260,7 +268,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     typescript: {
       generateTsConfig: true,
       tsconfigPath: join(nuxt.options.buildDir, 'tsconfig.server.json'),
-      generatedTypesDir: join(nuxt.options.buildDir, 'types/nitro'),
+      generatedTypesDir: nitroGeneratedTypesDir,
       tsConfig: {
         compilerOptions: {
           lib: ['esnext', 'webworker', 'dom.iterable'],
@@ -269,6 +277,10 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
           moduleResolution: 'bundler',
           noUncheckedIndexedAccess: true,
           allowArbitraryExtensions: true,
+          paths: {
+            // same target nitro maps `#imports` to, under a server-unambiguous specifier
+            '#imports/server': [serverImportsDeclaration],
+          },
         },
         include: [
           join(nuxt.options.buildDir, 'types/nitro-nuxt.d.ts'),
@@ -1078,6 +1090,13 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     opts.tsConfig.exclude.push(relative(nuxt.options.buildDir, resolve(nuxt.options.rootDir, nitro.options.output.dir)))
     opts.tsConfig.exclude.push(relative(nuxt.options.buildDir, resolve(nuxt.options.rootDir, nuxt.options.serverDir)))
     opts.references.push({ path: resolve(nuxt.options.rootDir, nitroConfig.typescript!.generatedTypesDir!, 'nitro.d.ts') })
+
+    // Server files are also checked in the app context, where `#imports` resolves to the Vue
+    // app's auto-imports and server-only utils are missing. Deliberately not a
+    // `nuxt.options.alias` entry: importing server utils in app code must remain an error.
+    opts.tsConfig.compilerOptions ||= {}
+    opts.tsConfig.compilerOptions.paths ||= {}
+    opts.tsConfig.compilerOptions.paths['#imports/server'] ||= [serverImportsDeclaration]
 
     // ensure aliases shared between nuxt + nitro are included in shared tsconfig
     opts.sharedTsConfig.compilerOptions ||= {}

--- a/packages/nuxt/test/load-nuxt.test.ts
+++ b/packages/nuxt/test/load-nuxt.test.ts
@@ -190,6 +190,21 @@ describe('loadNuxt', () => {
     await nuxt.close()
   })
 
+  it('exposes server auto-imports as #imports/server', async () => {
+    const nuxt = await loadNuxt({ cwd: repoRoot, ready: true })
+
+    const nitroOptions = (nuxt as any)._nitro?.options
+    const tsConfigPaths = nitroOptions?.typescript?.tsConfig?.compilerOptions?.paths ?? {}
+
+    expect(tsConfigPaths['#imports/server']?.[0]).toMatch(/types[/\\]nitro[/\\]nitro-imports$/)
+    // resolved at runtime through a virtual module rather than an alias, so that importing
+    // it from app code stays a build error instead of bundling server code into the client
+    expect(nitroOptions?.virtual?.['#imports/server']).toBe('export * from "#imports"')
+    expect(nuxt.options.alias).not.toHaveProperty('#imports/server')
+
+    await nuxt.close()
+  })
+
   it('resolves nitro aliases pointing at bare module specifiers', async () => {
     const nuxt = await loadNuxt({
       cwd: repoRoot,

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -64,6 +64,16 @@ describe.skipIf(!runsOnceInMatrix)('server api', () => {
       }
     `)
   })
+
+  it('should resolve server auto-imports named explicitly from #imports/server', async () => {
+    const res = await $fetch('/api/server-imports')
+    expect(res).toMatchInlineSnapshot(`
+      {
+        "fromServerDir": "test-utils",
+        "thisIs": "serverAutoImported",
+      }
+    `)
+  })
 })
 
 describe('route rules', () => {

--- a/test/fixtures/basic-types/modules/auto-registered/index.ts
+++ b/test/fixtures/basic-types/modules/auto-registered/index.ts
@@ -1,4 +1,4 @@
-import { addServerHandler, createResolver, defineNuxtModule } from 'nuxt/kit'
+import { addServerHandler, addServerImportsDir, createResolver, defineNuxtModule } from 'nuxt/kit'
 
 export default defineNuxtModule({
   meta: {
@@ -11,5 +11,7 @@ export default defineNuxtModule({
       handler: resolver.resolve('./runtime/handler'),
       route: '/auto-registered-module',
     })
+
+    addServerImportsDir(resolver.resolve('./runtime/server/utils'))
   },
 })

--- a/test/fixtures/basic-types/modules/auto-registered/runtime/server/utils/session.ts
+++ b/test/fixtures/basic-types/modules/auto-registered/runtime/server/utils/session.ts
@@ -1,0 +1,3 @@
+export function useAutoRegisteredSession () {
+  return { id: 'auto-registered-session' as const }
+}

--- a/test/fixtures/basic-types/server/api/server-imports.ts
+++ b/test/fixtures/basic-types/server/api/server-imports.ts
@@ -1,0 +1,10 @@
+import { expectTypeOf } from 'vitest'
+import { useAutoRegisteredSession } from '#imports/server'
+
+// route handlers are pulled into the app tsconfig by `nitro-routes.d.ts`, where `#imports` is
+// the Vue app's auto-imports; `#imports/server` resolves in both contexts
+// https://github.com/nuxt/nuxt/issues/33979
+const session = useAutoRegisteredSession()
+expectTypeOf(session.id).toEqualTypeOf<'auto-registered-session'>()
+
+export default defineEventHandler(() => session)

--- a/test/fixtures/basic-types/server/utils/server-imports.ts
+++ b/test/fixtures/basic-types/server/utils/server-imports.ts
@@ -1,0 +1,9 @@
+import { expectTypeOf } from 'vitest'
+import { useAutoRegisteredSession } from '#imports/server'
+
+// the issue covers the whole server directory, not only route handlers
+export function getAutoRegisteredSessionId () {
+  const id = useAutoRegisteredSession().id
+  expectTypeOf(id).toEqualTypeOf<'auto-registered-session'>()
+  return id
+}

--- a/test/fixtures/basic/server/api/server-imports.ts
+++ b/test/fixtures/basic/server/api/server-imports.ts
@@ -1,0 +1,10 @@
+// the same server auto-imports the handler could use implicitly, named explicitly
+// https://github.com/nuxt/nuxt/issues/33979
+import { autoimportedFunction, testUtils } from '#imports/server'
+
+export default defineEventHandler(() => {
+  return {
+    thisIs: autoimportedFunction(),
+    fromServerDir: testUtils,
+  }
+})


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #33979

### 📚 Description

Nitro now registers a `#imports/server` alias pointing at the `nitro-imports.d.ts` it already generates, so server auto-imports can be imported explicitly from a specifier that resolves in every type context. It's mapped in `tsconfig.server.json` and, through the `prepare:types` hook, in `tsconfig.app.json`, which the legacy `.nuxt/tsconfig.json` inherits; at runtime it's a Nitro `virtual` entry re-exporting `#imports`, the same way Nitro already exposes `#nitro`. Deliberately not a `nuxt.options.alias` entry, so importing it from app code still fails the build instead of bundling server code into the client.

It needs a second name because `nitro-routes.d.ts` imports route handlers for `$fetch` return-type inference, which pulls server files into the app program, and there `#imports` is the app's auto-imports with nothing from `addServerImports` declared. Since #35938 the server imports run regardless of `experimental.nitroAutoImports`, so this hits default v5 apps. Plain `#imports` in a server file stays broken in the app program and this PR doesn't change that: one specifier can't resolve to two different sets in two programs that both include the file.

On naming, I said I'd wait for your confirmation before opening this. I went with `#imports/server` since it's the wording in the issue, but it's trivial to rename and the `#imports/nuxt` + `#imports/nitro` pair is still on the table.

Tests cover the tsconfig paths, the runtime virtual and the absence of an app alias, plus type-level fixtures for a route handler and a non-route server file and a runtime `$fetch` assertion; docs updated in the auto-imports guide, the module recipes page and the Kit Nitro reference.