### PR TITLE
fix(kit,nitro): ignore baseUrl with compatibilityVersion 5

### DIFF
--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -68,6 +68,7 @@ When you set your `future.compatibilityVersion` to `5`, defaults throughout your
 - **Vue Options API disabled**: The [Options API is compiled out of the client bundle](/docs/4.x/getting-started/upgrade#vue-options-api-disabled-by-default) to reduce its size
 - **`process.*` type augmentation removed**: TypeScript no longer exposes [deprecated `process.*` flags](/docs/4.x/getting-started/upgrade#process-type-augmentation-removed) on `NodeJS.Process`
 - **Typed pages**: [`experimental.typedPages`](/docs/4.x/getting-started/upgrade#typed-pages-enabled-by-default) is enabled by default for type-checked routing
+- **TypeScript `baseUrl` ignored**: Generated TypeScript configurations [no longer use `compilerOptions.baseUrl`](/docs/4.x/getting-started/upgrade#typescript-baseurl-is-ignored) to resolve Nuxt aliases
 - Other Nuxt 5 improvements and changes as they become available
 
 ::note
@@ -899,4 +900,38 @@ export default defineNuxtConfig({
     typedPages: false,
   },
 })
+```
+
+### TypeScript `baseUrl` Is Ignored
+
+🚦 **Impact Level**: Minimal
+
+#### What Changed
+
+With `compatibilityVersion: 5`, Nuxt removes `compilerOptions.baseUrl` from its generated TypeScript configurations. Relative Nuxt and Nitro aliases are resolved from Nuxt's build directory instead of a custom `baseUrl`.
+
+#### Reasons for Change
+
+TypeScript 6 deprecates `baseUrl`, and it is no longer required when using `paths`. Removing the option also keeps Nuxt's generated aliases anchored consistently to the generated configuration that contains them.
+
+#### Migration Steps
+
+Remove `baseUrl` from your Nuxt TypeScript configuration. If you used it to anchor a relative Nuxt or Nitro alias, make that alias absolute instead:
+
+```diff [nuxt.config.ts]
++ import { fileURLToPath } from 'node:url'
++
+  export default defineNuxtConfig({
+    alias: {
+-     images: './assets/images',
++     images: fileURLToPath(new URL('./assets/images', import.meta.url)),
+    },
+-   typescript: {
+-     tsConfig: {
+-       compilerOptions: {
+-         baseUrl: '..',
+-       },
+-     },
+-   },
+  })
 ```

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -494,12 +494,11 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
   const aliases: Record<string, string> = nuxt.options.alias
 
   // TODO: remove support for baseUrl in nuxt v5
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  const basePath = tsConfig.compilerOptions!.baseUrl
-    // TODO: remove support for baseUrl in nuxt v5
+  const baseUrl = isV5OrHigher
+    ? undefined
     // eslint-disable-next-line @typescript-eslint/no-deprecated
-    ? resolve(nuxt.options.buildDir, tsConfig.compilerOptions!.baseUrl)
-    : nuxt.options.buildDir
+    : tsConfig.compilerOptions!.baseUrl
+  const basePath = baseUrl ? resolve(nuxt.options.buildDir, baseUrl) : nuxt.options.buildDir
 
   tsConfig.compilerOptions ||= {}
   tsConfig.compilerOptions.paths ||= {}
@@ -578,6 +577,10 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
     .filter(root => !rootDirWithSlash.startsWith(root))
 
   async function resolveConfig (tsConfig: TSConfig) {
+    if (isV5OrHigher) {
+      Reflect.deleteProperty(tsConfig.compilerOptions!, 'baseUrl')
+    }
+
     for (const alias in tsConfig.compilerOptions!.paths) {
       const paths = tsConfig.compilerOptions!.paths[alias]
       tsConfig.compilerOptions!.paths[alias] = [...new Set(await Promise.all(paths.map(async (path: string) => {

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -52,6 +52,40 @@ describe('tsConfig generation', () => {
     `)
   })
 
+  it.each([
+    {
+      compatibilityVersion: 4,
+      expectedAlias: './legacy-base/probe-target',
+      expectedBaseUrl: 'legacy-base',
+    },
+    {
+      compatibilityVersion: 5,
+      expectedAlias: './probe-target',
+      expectedBaseUrl: undefined,
+    },
+  ] as const)('should resolve aliases with compatibilityVersion $compatibilityVersion', async ({ compatibilityVersion, expectedAlias, expectedBaseUrl }) => {
+    const generatedTypes = await _generateTypes(mockNuxtWithOptions({
+      alias: {
+        '#probe/base-url': './probe-target/',
+      },
+      future: {
+        compatibilityVersion,
+      },
+      typescript: {
+        tsConfig: {
+          compilerOptions: {
+            baseUrl: 'legacy-base',
+          },
+        },
+      },
+    }))
+
+    expect(generatedTypes.tsConfig.compilerOptions?.paths?.['#probe/base-url']).toEqual([expectedAlias])
+    for (const tsConfig of [generatedTypes.tsConfig, generatedTypes.nodeTsConfig, generatedTypes.sharedTsConfig, generatedTypes.legacyTsConfig]) {
+      expect(Reflect.get(tsConfig.compilerOptions ?? {}, 'baseUrl')).toBe(expectedBaseUrl)
+    }
+  })
+
   it('should add exclude for module paths', async () => {
     const { tsConfig } = await _generateTypes(mockNuxtWithOptions({
       modulesDir: ['/my-app/modules/test/node_modules', '/my-app/modules/node_modules', '/my-app/node_modules/@some/module/node_modules'],

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -789,12 +789,17 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
   // TODO: extract to shared utility?
   const excludedAlias = [/^@vue\/.*$/, 'vue', /vue-router/, 'vite/client', '#imports', 'vue-demi', /^#app/, '~', '@', '~~', '@@']
   // TODO: remove support for baseUrl in nuxt v5
+  const isV5OrHigher = nuxt.options.future.compatibilityVersion >= 5
   // eslint-disable-next-line @typescript-eslint/no-deprecated
-  const basePath = nitroConfig.typescript!.tsConfig!.compilerOptions?.baseUrl ? resolve(nuxt.options.buildDir, nitroConfig.typescript!.tsConfig!.compilerOptions?.baseUrl) : nuxt.options.buildDir
+  const baseUrl = isV5OrHigher ? undefined : nitroConfig.typescript!.tsConfig!.compilerOptions?.baseUrl
+  const basePath = baseUrl ? resolve(nuxt.options.buildDir, baseUrl) : nuxt.options.buildDir
   const aliases = nitroConfig.alias!
   const importPaths = nuxt.options.modulesDir.map(d => pathToFileURL(withTrailingSlash(d)))
   const tsConfig = nitroConfig.typescript!.tsConfig!
   tsConfig.compilerOptions ||= {}
+  if (isV5OrHigher) {
+    Reflect.deleteProperty(tsConfig.compilerOptions, 'baseUrl')
+  }
   tsConfig.compilerOptions.paths ||= {}
   for (const _alias in aliases) {
     const alias = _alias as keyof typeof aliases

--- a/packages/nuxt/test/load-nuxt.test.ts
+++ b/packages/nuxt/test/load-nuxt.test.ts
@@ -1,12 +1,13 @@
 import { fileURLToPath } from 'node:url'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { normalize } from 'pathe'
+import { normalize, resolve } from 'pathe'
 import { withoutTrailingSlash } from 'ufo'
 import { defu } from 'defu'
 import { logger, tryUseNuxt, useNuxt } from '@nuxt/kit'
 import { findWorkspaceDir } from 'pkg-types'
 import { loadNuxt } from '../src/index.ts'
 import type { NuxtConfig } from '../schema.ts'
+import type { Nitro } from 'nitro/types'
 
 const repoRoot = await findWorkspaceDir()
 
@@ -209,6 +210,49 @@ describe('loadNuxt', () => {
     expect(tsConfigPaths['#probe/defu']?.[0]?.replace(/\\/g, '/')).toMatch(/node_modules\/defu\//)
 
     await nuxt.close()
+  })
+
+  it.each([
+    {
+      compatibilityVersion: 4,
+      expectedAlias: 'legacy-base/probe-target',
+      expectedBaseUrl: 'legacy-base',
+    },
+    {
+      compatibilityVersion: 5,
+      expectedAlias: 'probe-target',
+      expectedBaseUrl: undefined,
+    },
+  ] as const)('resolves nitro aliases with compatibilityVersion $compatibilityVersion', async ({ compatibilityVersion, expectedAlias, expectedBaseUrl }) => {
+    const nuxt = await loadNuxt({
+      cwd: repoRoot,
+      ready: true,
+      overrides: {
+        future: {
+          compatibilityVersion,
+        },
+        nitro: {
+          alias: {
+            '#probe/base-url': './probe-target',
+          },
+          typescript: {
+            tsConfig: {
+              compilerOptions: {
+                baseUrl: 'legacy-base',
+              },
+            },
+          },
+        },
+      },
+    })
+
+    const nitro = (nuxt as typeof nuxt & { _nitro?: Nitro })._nitro
+    const compilerOptions = nitro?.options.typescript?.tsConfig?.compilerOptions ?? {}
+    const aliasPath = compilerOptions.paths?.['#probe/base-url']?.[0]
+    await nuxt.close()
+
+    expect(aliasPath).toBe(resolve(nuxt.options.buildDir, expectedAlias))
+    expect(Reflect.get(compilerOptions, 'baseUrl')).toBe(expectedBaseUrl)
   })
 
   it('applies global typescript.tsConfig compiler options to the nitro tsconfig', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

This splits the backportable change from #36036.

With `compatibilityVersion: 5`, generated Kit and Nitro TypeScript configurations ignore deprecated `compilerOptions.baseUrl`. Earlier compatibility versions keep their current behavior, and the migration guide covers moving relative aliases to absolute paths.