### PR TITLE
refactor(nuxt): iterate over fragment children

### DIFF
--- a/packages/nuxt/src/app/components/utils.ts
+++ b/packages/nuxt/src/app/components/utils.ts
@@ -145,18 +145,16 @@ export function getFragmentHTML (element: RendererNode | null, withoutSlots = fa
 }
 
 function getFragmentChildren (element: RendererNode | null, blocks: string[] = [], withoutSlots = false) {
-  if (element && element.nodeName) {
-    if (isEndFragment(element)) {
-      return blocks
-    } else if (!isStartFragment(element)) {
-      const clone = element.cloneNode(true) as Element
+  let current = element
+  while (current?.nodeName && !isEndFragment(current)) {
+    if (!isStartFragment(current)) {
+      const clone = current.cloneNode(true) as Element
       if (withoutSlots) {
         clone.querySelectorAll?.('[data-island-slot]').forEach((n) => { n.innerHTML = '' })
       }
       blocks.push(clone.outerHTML)
     }
-
-    getFragmentChildren(element.nextSibling, blocks, withoutSlots)
+    current = current.nextSibling
   }
   return blocks
 }

--- a/test/nuxt/component-utils.test.ts
+++ b/test/nuxt/component-utils.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { getFragmentHTML } from '../../packages/nuxt/src/app/components/utils'
+
+describe('getFragmentHTML', () => {
+  it('walks large fragments without overflowing the call stack', () => {
+    const fragment = document.createDocumentFragment()
+    const start = document.createComment('[')
+    fragment.append(start)
+
+    for (let i = 0; i < 20_000; i++) {
+      const element = document.createElement('span')
+      element.textContent = String(i)
+      fragment.append(element)
+    }
+
+    fragment.append(document.createComment(']'))
+
+    const html = getFragmentHTML(start)
+    expect(html).toHaveLength(20_000)
+    expect(html?.[0]).toBe('<span>0</span>')
+    expect(html?.[19_999]).toBe('<span>19999</span>')
+  })
+
+  it('stops at the fragment boundary and clears island slot contents', () => {
+    const fragment = document.createDocumentFragment()
+    const start = document.createComment('[')
+    const element = document.createElement('div')
+    const slot = document.createElement('span')
+    const ignored = document.createElement('p')
+
+    slot.dataset.islandSlot = 'default'
+    slot.textContent = 'slot content'
+    element.append('before', slot, 'after')
+    ignored.textContent = 'outside fragment'
+    fragment.append(start, element, document.createComment(']'), ignored)
+
+    expect(getFragmentHTML(start, true)).toEqual([
+      '<div>before<span data-island-slot="default"></span>after</div>',
+    ])
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

Large Vue fragments currently traverse sibling nodes recursively, so enough nodes can overflow the call stack. This switches the traversal to a loop while keeping fragment boundaries and island slot stripping unchanged.