### PR TITLE
refactor(webpack): replace pify with node promisify

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -136,7 +136,6 @@
         "mini-css-extract-plugin",
         "ohash",
         "pathe",
-        "pify",
         "postcss",
         "postcss-import",
         "postcss-import-resolver",

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -45,7 +45,6 @@
     "mini-css-extract-plugin": "catalog:webpack",
     "ohash": "catalog:build",
     "pathe": "catalog:build",
-    "pify": "catalog:webpack",
     "postcss": "catalog:build",
     "postcss-import": "catalog:build",
     "postcss-import-resolver": "catalog:build",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -46,7 +46,6 @@
     "mini-css-extract-plugin": "catalog:webpack",
     "ohash": "catalog:build",
     "pathe": "catalog:build",
-    "pify": "catalog:webpack",
     "postcss": "catalog:build",
     "postcss-import": "catalog:build",
     "postcss-import-resolver": "catalog:build",

--- a/packages/webpack/src/utils/mfs.ts
+++ b/packages/webpack/src/utils/mfs.ts
@@ -1,5 +1,5 @@
 import { join } from 'pathe'
-import pify from 'pify'
+import { promisify } from 'node:util'
 import { Volume, createFsFromVolume } from 'memfs'
 
 import type { IFs } from 'memfs'
@@ -17,8 +17,7 @@ export function createMFS () {
 
   // Used by vue-renderer
   _fs.exists = p => Promise.resolve(_fs.existsSync(p))
-  // @ts-expect-error need better types for `pify`
-  _fs.readFile = pify(_fs.readFile)
+  _fs.readFile = promisify(_fs.readFile)
 
   return _fs as IFs & { join?(...paths: string[]): string }
 }

--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -1,4 +1,4 @@
-import pify from 'pify'
+import { promisify } from 'node:util'
 import type { H3Event as H3V1Event } from 'h3'
 import type { H3Event as H3V2Event } from 'h3-next'
 import type webpackDevMiddleware from 'webpack-dev-middleware'
@@ -280,8 +280,7 @@ async function createDevMiddleware (compiler: Compiler) {
     ...nuxt.options.webpack.devMiddleware,
   })
 
-  // @ts-expect-error need better types for `pify`
-  nuxt.hook('close', () => pify(devMiddleware.close.bind(devMiddleware))())
+  nuxt.hook('close', () => promisify(devMiddleware.close.bind(devMiddleware))())
 
   const { client: _client, ...hotMiddlewareOptions } = nuxt.options.webpack.hotMiddleware || {}
   const hotMiddleware = webpackHotMiddleware(compiler, {
@@ -355,7 +354,7 @@ async function compile (compiler: Compiler) {
     const compilersWatching: Array<Watching | MultiWatching> = []
 
     nuxt.hook('close', async () => {
-      await Promise.all(compilersWatching.map(watching => watching && pify(watching.close.bind(watching))()))
+      await Promise.all(compilersWatching.map(watching => watching && promisify(watching.close.bind(watching))()))
     })
 
     // Client build

--- a/packages/webpack/test/mfs.test.ts
+++ b/packages/webpack/test/mfs.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { createMFS } from '../src/utils/mfs'
+
+describe('createMFS', () => {
+  it('reads files asynchronously', async () => {
+    const fs = createMFS()
+    fs.writeFileSync('/test.txt', 'hello')
+
+    const contents = await (fs.readFile as unknown as (path: string, encoding: BufferEncoding) => Promise<string>)('/test.txt', 'utf8')
+
+    expect(contents).toBe('hello')
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -543,9 +543,6 @@ catalogs:
     mini-css-extract-plugin:
       specifier: ^2.10.2
       version: 2.10.2
-    pify:
-      specifier: ^6.1.0
-      version: 6.1.0
     pug-plain-loader:
       specifier: ^1.1.0
       version: 1.1.0
@@ -1302,9 +1299,6 @@ importers:
       pathe:
         specifier: catalog:build
         version: 2.0.3
-      pify:
-        specifier: catalog:webpack
-        version: 6.1.0
       postcss:
         specifier: catalog:build
         version: 8.5.25
@@ -1746,9 +1740,6 @@ importers:
       pathe:
         specifier: catalog:build
         version: 2.0.3
-      pify:
-        specifier: catalog:webpack
-        version: 6.1.0
       postcss:
         specifier: catalog:build
         version: 8.5.25
@@ -8100,10 +8091,6 @@ packages:
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
-
-  pify@6.1.0:
-    resolution: {integrity: sha512-KocF8ve28eFjjuBKKGvzOBGzG8ew2OqOOSxTTZhirkzH7h3BI1vyzqlR0qbfcDBve1Yzo3FVlWUAtCRrbVN8Fw==}
-    engines: {node: '>=14.16'}
 
   pkg-pr-new@0.0.86:
     resolution: {integrity: sha512-BwPsw/e1Be7F0SfpxhNc2VSxX7uHgCy46Ck+2Z/vqCwXoePhUBrX/VbcawpAlZgMvQe2iwGbZIQ6HSj9bmCk8A==}
@@ -16933,8 +16920,6 @@ snapshots:
   picomatch@4.0.5: {}
 
   pify@2.3.0: {}
-
-  pify@6.1.0: {}
 
   pkg-pr-new@0.0.86: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -130,7 +130,6 @@ catalogs:
     hash-sum: ^2.0.0
     memfs: ^4.67.0
     mini-css-extract-plugin: ^2.10.2
-    pify: ^6.1.0
     pug-plain-loader: ^1.1.0
     raw-loader: ^4.0.2
     time-fix-plugin: ^2.0.7


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### 📚 Description

The webpack builder still used `pify` for three callback APIs even though all supported Node versions provide `promisify`. This replaces that dependency with `node:util`, including the shared Rspack path, and keeps the async `memfs` contract covered directly.
