### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -503,6 +503,15 @@ declare module '@nuxt/schema' {
 // This declaration must not import user `app.config` files: their import graph
 // can rely on app auto-imports, which do not exist in the shared, node and
 // server programs (https://github.com/nuxt/nuxt/issues/34140).
+//
+// It also must not augment the `AppConfig` interface: `app.config.d.ts` already
+// declares it with the user's app-config values merged in, and a second
+// declaration of the same interface in the same module is a TS2717 conflict that
+// `skipLibCheck` hides and TypeScript then resolves by load order — silently
+// dropping user-declared app-config keys such as component variants
+// (https://github.com/nuxt/nuxt/issues/35996). Shared, node and server programs
+// that cannot import user `app.config` files can still reference the
+// framework-default shape via `SharedAppConfig`.
 export const sharedAppConfigDeclarationTemplate: NuxtTemplate = {
   filename: 'types/shared-app.config.d.ts',
   dependsOn: [],
@@ -514,10 +523,10 @@ declare const inlineConfig = ${JSON.stringify(nuxt.options.appConfig, null, 2)}
 ${APP_CONFIG_MERGE_TYPES}
 
 declare module 'nuxt/schema' {
-  interface AppConfig extends MergedAppConfig<typeof inlineConfig, CustomAppConfig> { }
+  interface SharedAppConfig extends MergedAppConfig<typeof inlineConfig, CustomAppConfig> { }
 }
 declare module '@nuxt/schema' {
-  interface AppConfig extends MergedAppConfig<typeof inlineConfig, CustomAppConfig> { }
+  interface SharedAppConfig extends MergedAppConfig<typeof inlineConfig, CustomAppConfig> { }
 }
 `
   },

--- a/packages/nuxt/test/templates.test.ts
+++ b/packages/nuxt/test/templates.test.ts
@@ -7,7 +7,7 @@ import { resolve } from 'pathe'
 // it does in production; otherwise the test would see partially-initialised
 // exports and crash before any assertions run.
 import '../src/core/app.ts'
-import { appConfigTemplate, publicPathTemplate } from '../src/core/templates.ts'
+import { appConfigDeclarationTemplate, appConfigTemplate, publicPathTemplate, sharedAppConfigDeclarationTemplate } from '../src/core/templates.ts'
 
 import type { Nuxt, NuxtApp } from 'nuxt/schema'
 
@@ -51,5 +51,22 @@ describe('publicPathTemplate', () => {
 
     expect(contents).not.toMatch(/runtime-config/)
     expect(contents).toMatch(/getAppConfig = \(\) => \(/)
+  })
+})
+
+describe('app config declarations', () => {
+  it('declares `AppConfig` exactly once per module across the app and shared declaration templates', async () => {
+    const nuxt = makeNuxt({ buildDir: '.nuxt' })
+    const appConfig = await appConfigDeclarationTemplate.getContents!({ nuxt, app: makeApp(['./app.config']), options: {} })
+    const sharedAppConfig = await sharedAppConfigDeclarationTemplate.getContents!({ nuxt, app: makeApp(), options: {} })
+
+    // The full app-config declaration augments `AppConfig` in both `nuxt/schema` and `@nuxt/schema`.
+    expect(appConfig.match(/interface AppConfig/g)).toHaveLength(2)
+
+    // The shared declaration must not restate `AppConfig`: a second declaration of the same
+    // interface in the same module is a TS2717 conflict that `skipLibCheck` hides, so TypeScript
+    // resolves the properties by load order and user-declared app-config keys (e.g. component
+    // variants) silently disappear from `AppConfig`. See https://github.com/nuxt/nuxt/issues/35996.
+    expect(sharedAppConfig.match(/interface AppConfig/g)).toBeNull()
   })
 })

--- a/test/fixtures/basic-types/server/type-context.ts
+++ b/test/fixtures/basic-types/server/type-context.ts
@@ -5,7 +5,10 @@ const _fake: Fromage = 'babybel'
 
 const _fromage: Fromage = 'cheese'
 
+// `AppConfig` is intentionally untyped in server/node programs: user `app.config` files are not
+// importable there (#34140), and restating `AppConfig` with a narrower type would conflict with the
+// full declaration in `app.config.d.ts` and silently drop user-declared app-config keys (#35996).
 const appConfig = useAppConfig()
-expectTypeOf(appConfig.fromNuxtConfig).toEqualTypeOf<boolean>()
-expectTypeOf(appConfig.userConfig).toEqualTypeOf<123 | 456 | undefined>()
+expectTypeOf(appConfig.fromNuxtConfig).toEqualTypeOf<unknown>()
+expectTypeOf(appConfig.userConfig).toEqualTypeOf<unknown>()
 expectTypeOf(appConfig.fromLayer).toEqualTypeOf<unknown>()

--- a/test/fixtures/basic-types/shared/shared-types.ts
+++ b/test/fixtures/basic-types/shared/shared-types.ts
@@ -23,10 +23,15 @@ describe('shared folder', () => {
     expectTypeOf(config).not.toBeAny()
   })
 
-  it('types inline and schema app config but not app-context `app.config` files', () => {
+  // `AppConfig` is intentionally untyped in shared programs: user `app.config` files are not
+  // importable there (#34140), and the shared declaration must not restate `AppConfig` with a
+  // narrower type — a second declaration of the same interface in the same module is a TS2717
+  // conflict that `skipLibCheck` hides and resolves by load order, silently dropping user-declared
+  // app-config keys (#35996). The framework-default shape remains available as `SharedAppConfig`.
+  it('does not type app-context `app.config` files in shared programs', () => {
     const config = useAppConfig()
-    expectTypeOf(config.fromNuxtConfig).toEqualTypeOf<boolean>()
-    expectTypeOf(config.userConfig).toEqualTypeOf<123 | 456 | undefined>()
+    expectTypeOf(config.fromNuxtConfig).toEqualTypeOf<unknown>()
+    expectTypeOf(config.userConfig).toEqualTypeOf<unknown>()
     expectTypeOf(config.fromLayer).toEqualTypeOf<unknown>()
   })
 })


### PR DESCRIPTION
## Problem

On `nuxt@4.5.1` (and `4.5.2`) an app-config-declared component variant stops type-checking. With a custom Nuxt UI variant in `app.config.ts`:

```ts
export default defineAppConfig({
  ui: {
    formField: {
      variants: {
        orientation: {
          action: 'flex items-center justify-between gap-4',
        },
      },
    },
  },
})
```

`<UFormField orientation="action">` fails `vue-tsc` with:

```
error TS2322: Type '"action"' is not assignable to type '"vertical" | "horizontal" | undefined'.
```

Runtime is unaffected. The same config type-checks on `4.5.0` and, per the reporter, is still broken on `4.5.2`. The bug is declaration-order dependent: it appears or vanishes depending on which generated `.d.ts` TypeScript loads first.

## Root cause

#35673 split the generated app-config declaration into two files that both augment the same `AppConfig` interface in the same modules (`nuxt/schema` and `@nuxt/schema`):

- `.nuxt/types/app.config.d.ts` — imports the user's `app.config.ts` (`cfg0`), so `AppConfig` includes user-declared variants.
- `.nuxt/types/shared-app.config.d.ts` — deliberately does not import it (see #34140), so `AppConfig` carries framework defaults only.

```ts
// types/app.config.d.ts
declare module 'nuxt/schema' {
  interface AppConfig extends MergedAppConfig<ResolvedAppConfig, CustomAppConfig> { }
}

// types/shared-app.config.d.ts
declare module 'nuxt/schema' {
  interface AppConfig extends MergedAppConfig<typeof inlineConfig, CustomAppConfig> { }
}
```

Both are reachable from one program: `nuxt.d.ts` references the first while `nuxt.shared.d.ts` / `nuxt.node.d.ts` reference the second, and the app program includes all of them. Two declarations of the same interface with different property types is a `TS2717` conflict — but Nuxt's generated tsconfig sets `skipLibCheck: true`, so it is never reported. TypeScript then resolves each property to whichever declaration it loaded **first**, silently dropping user-declared keys such as the custom variant.

## Fix

`sharedAppConfigDeclarationTemplate` now augments a distinct `SharedAppConfig` interface (mirroring the existing `SharedRuntimeConfig` pattern in `types/runtime-config.d.ts`) instead of restating `AppConfig`. `AppConfig` is then declared exactly once per module — by `app.config.d.ts` — so its shape is deterministic and no longer load-order dependent. Shared, node and server programs that cannot import user `app.config` files can still reference the framework-default shape via `SharedAppConfig`.

In shared/node/server programs `AppConfig` now resolves to the untyped fallback (`{ [key: string]: unknown }`), so the `basic-types` fixture assertions in `shared/shared-types.ts` and `server/type-context.ts` are updated accordingly.

## Test

Adds a unit test in `packages/nuxt/test/templates.test.ts` asserting that the app + shared declaration templates declare `interface AppConfig` exactly once per module (the app declaration once in each of `nuxt/schema` and `@nuxt/schema`, the shared declaration zero times). On the broken code the shared template still contains `interface AppConfig`, so the test fails (RED); with the fix it passes (GREEN).

Refs #35996