### PR TITLE
refactor(nuxt): remove reverse trace indexing

### DIFF
--- a/packages/nuxt/src/app/utils.ts
+++ b/packages/nuxt/src/app/utils.ts
@@ -21,11 +21,11 @@ export function getUserTrace (): Trace[] {
 
   const trace = captureStackTrace()
   const start = trace.findIndex(entry => !entry.source.startsWith(distURL))
-  const end = trace.toReversed().findIndex(entry => !entry.source.includes('node_modules') && !entry.source.startsWith(distURL))
+  const end = trace.findLastIndex(entry => !entry.source.includes('node_modules') && !entry.source.startsWith(distURL))
   if (start === -1 || end === -1) {
     return []
   }
-  return trace.slice(start, end > 0 ? -end : undefined).map(i => ({
+  return trace.slice(start, end + 1).map(i => ({
     ...i,
     source: i.source.replace(/^file:\/\//, ''),
   }))

--- a/packages/nuxt/test/app-utils.test.ts
+++ b/packages/nuxt/test/app-utils.test.ts
@@ -1,0 +1,58 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { getUserTrace as GetUserTrace } from '../src/app/utils.ts'
+
+const captureStackTrace = vi.hoisted(() => vi.fn())
+
+vi.mock('errx', () => ({ captureStackTrace }))
+
+let getUserTrace: typeof GetUserTrace
+
+beforeAll(async () => {
+  vi.stubGlobal('__TEST_DEV__', true)
+  // Import after stubbing because `distURL` is initialized from `import.meta.dev`.
+  ;({ getUserTrace } = await import('../src/app/utils.ts'))
+})
+
+beforeEach(() => {
+  captureStackTrace.mockReset()
+})
+
+afterAll(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('getUserTrace', () => {
+  it('includes a user frame at the end of the trace', () => {
+    captureStackTrace.mockReturnValue([
+      { source: 'file:///project/node_modules/nuxt/runtime.js' },
+      { source: 'file:///project/app/page.vue', line: 2, column: 3 },
+    ])
+
+    expect(getUserTrace()).toEqual([
+      { source: '/project/node_modules/nuxt/runtime.js' },
+      { source: '/project/app/page.vue', line: 2, column: 3 },
+    ])
+  })
+
+  it('excludes trailing dependency frames', () => {
+    captureStackTrace.mockReturnValue([
+      { source: 'file:///project/app/page.vue' },
+      { source: 'file:///project/app/middleware.ts' },
+      { source: 'file:///project/node_modules/router/runtime.js' },
+    ])
+
+    expect(getUserTrace()).toEqual([
+      { source: '/project/app/page.vue' },
+      { source: '/project/app/middleware.ts' },
+    ])
+  })
+
+  it('returns an empty trace when no user frame exists', () => {
+    captureStackTrace.mockReturnValue([
+      { source: 'file:///project/node_modules/nuxt/runtime.js' },
+      { source: 'file:///project/node_modules/router/runtime.js' },
+    ])
+
+    expect(getUserTrace()).toEqual([])
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

No issue - small refactor.

### 📚 Description

`getUserTrace()` still converts an index from a reversed trace back into `slice()` coordinates. That already needed the negative zero fix in #34524, and #34980 only changed `reverse()` to `toReversed()` without removing the awkward index math. `findLastIndex()` gives the actual boundary directly - no copied trace and no special case. Focused tests cover the three boundary shapes.