### PR TITLE
docs: mention Valibot for server-side validation

### DIFF
--- a/docs/2.directory-structure/1.server.md
+++ b/docs/2.directory-structure/1.server.md
@@ -201,7 +201,7 @@ export default defineEventHandler((event) => {
 ```
 
 ::tip{to="https://h3.dev/examples/validate-data#validate-params"}
-Alternatively, use `getValidatedRouterParams` with a schema validator such as Zod for runtime and type safety.
+Alternatively, use `getValidatedRouterParams` with a schema validator such as Zod or Valibot for runtime and type safety.
 ::
 
 You can now universally call this API on `/api/hello/nuxt` and get `Hello, nuxt!`.
@@ -277,7 +277,7 @@ export default defineEventHandler(async (event) => {
 ```
 
 ::tip{to="https://unjs.io/blog/2023-08-15-h3-towards-the-edge-of-the-web/#runtime-type-safe-request-utils"}
-Alternatively, use `readValidatedBody` with a schema validator such as Zod for runtime and type safety.
+Alternatively, use `readValidatedBody` with a schema validator such as Zod or Valibot for runtime and type safety.
 ::
 
 You can now universally call this API using:
@@ -310,7 +310,7 @@ export default defineEventHandler((event) => {
 ```
 
 ::tip{to="https://unjs.io/blog/2023-08-15-h3-towards-the-edge-of-the-web#runtime-type-safe-request-utils"}
-Alternatively, use `getValidatedQuery` with a schema validator such as Zod for runtime and type safety.
+Alternatively, use `getValidatedQuery` with a schema validator such as Zod or Valibot for runtime and type safety.
 ::
 
 ### Error Handling


### PR DESCRIPTION
H3 v2 accepts any Standard Schema library in its validation utilities and Nuxt UI already documents Valibot. This updates the server docs wording so Nuxt users discover that Valibot works too. I'm the author of Valibot.