### PR TITLE
fix(nuxt): expose root node on server component refs

### DIFF
--- a/docs/3.guide/1.concepts/6.server-components.md
+++ b/docs/3.guide/1.concepts/6.server-components.md
@@ -182,7 +182,6 @@ Server components are experimental, and some rough edges are tracked in open iss
 - Global styles of your application are sent with each island response, and island assets can be loaded twice in some setups ([#29591](https://github.com/nuxt/nuxt/issues/29591)).
 - Using islands can significantly increase the number of chunks generated at build time ([#34855](https://github.com/nuxt/nuxt/issues/34855)).
 - `:slotted()` styles are ignored in server component slots ([#31510](https://github.com/nuxt/nuxt/issues/31510)).
-- Template refs cannot reference elements inside a server component from the parent ([#31512](https://github.com/nuxt/nuxt/issues/31512)).
 - `inject`/`provide` does not cross the island boundary, so injecting from the page into a standalone server component does not work ([#22751](https://github.com/nuxt/nuxt/issues/22751)).
 - Server components rendered via the auto-generated wrapper do not expose load and error events; use `<NuxtIsland>` directly if you need its `error` event and `refresh()` method ([#25744](https://github.com/nuxt/nuxt/issues/25744)).
 - [`useId`](https://vuejs.org/api/composition-api-helpers#useid) has known limitations inside islands; see the [`<NuxtIsland>` documentation](/docs/4.x/api/components/nuxt-island#known-limitations).

--- a/docs/3.guide/1.concepts/6.server-components.md
+++ b/docs/3.guide/1.concepts/6.server-components.md
@@ -182,7 +182,7 @@ Server components are experimental, and some rough edges are tracked in open iss
 - Global styles of your application are sent with each island response, and island assets can be loaded twice in some setups ([#29591](https://github.com/nuxt/nuxt/issues/29591)).
 - Using islands can significantly increase the number of chunks generated at build time ([#34855](https://github.com/nuxt/nuxt/issues/34855)).
 - `:slotted()` styles are ignored in server component slots ([#31510](https://github.com/nuxt/nuxt/issues/31510)).
-- Template refs cannot reference elements inside a server component from the parent ([#31512](https://github.com/nuxt/nuxt/issues/31512)).
+- A template ref on a server component exposes its rendered root element as `$el`, but cannot reference elements inside the server component from the parent.
 - `inject`/`provide` does not cross the island boundary, so injecting from the page into a standalone server component does not work ([#22751](https://github.com/nuxt/nuxt/issues/22751)).
 - Server components rendered via the auto-generated wrapper do not expose load and error events; use `<NuxtIsland>` directly if you need its `error` event and `refresh()` method ([#25744](https://github.com/nuxt/nuxt/issues/25744)).
 - [`useId`](https://vuejs.org/api/composition-api-helpers#useid) has known limitations inside islands; see the [`<NuxtIsland>` documentation](/docs/4.x/api/components/nuxt-island#known-limitations).

--- a/docs/3.guide/1.concepts/6.server-components.md
+++ b/docs/3.guide/1.concepts/6.server-components.md
@@ -182,6 +182,7 @@ Server components are experimental, and some rough edges are tracked in open iss
 - Global styles of your application are sent with each island response, and island assets can be loaded twice in some setups ([#29591](https://github.com/nuxt/nuxt/issues/29591)).
 - Using islands can significantly increase the number of chunks generated at build time ([#34855](https://github.com/nuxt/nuxt/issues/34855)).
 - `:slotted()` styles are ignored in server component slots ([#31510](https://github.com/nuxt/nuxt/issues/31510)).
+- Template refs cannot reference elements inside a server component from the parent ([#31512](https://github.com/nuxt/nuxt/issues/31512)).
 - `inject`/`provide` does not cross the island boundary, so injecting from the page into a standalone server component does not work ([#22751](https://github.com/nuxt/nuxt/issues/22751)).
 - Server components rendered via the auto-generated wrapper do not expose load and error events; use `<NuxtIsland>` directly if you need its `error` event and `refresh()` method ([#25744](https://github.com/nuxt/nuxt/issues/25744)).
 - [`useId`](https://vuejs.org/api/composition-api-helpers#useid) has known limitations inside islands; see the [`<NuxtIsland>` documentation](/docs/4.x/api/components/nuxt-island#known-limitations).

--- a/packages/nuxt/src/components/runtime/server-component.ts
+++ b/packages/nuxt/src/components/runtime/server-component.ts
@@ -1,5 +1,5 @@
-import { defineComponent, getCurrentInstance, h, ref } from 'vue'
-import type { DefineSetupFnComponent } from 'vue'
+import { Fragment, defineComponent, getCurrentInstance, h, isVNode, ref } from 'vue'
+import type { DefineSetupFnComponent, RendererNode, VNode } from 'vue'
 import NuxtIsland from '#app/components/nuxt-island'
 import { useRoute } from '#app/composables/router'
 import { isPrerendered, shouldLoadPayload } from '#app/composables/payload'
@@ -10,6 +10,29 @@ import { getIslandHash } from '#app/island-hash'
 import type { NuxtIslandResponse } from '#app/types'
 import { $fetch } from '#build/fetch'
 import { payloadExtraction } from '#build/nuxt.config.mjs'
+
+function getVNodeRootNode (vnode: VNode | null): RendererNode | null {
+  if (!vnode) {
+    return null
+  }
+  if (vnode.component) {
+    return getVNodeRootNode(vnode.component.subTree)
+  }
+  if (vnode.type !== Fragment) {
+    return vnode.el
+  }
+  if (Array.isArray(vnode.children)) {
+    for (const child of vnode.children) {
+      if (isVNode(child)) {
+        const node = getVNodeRootNode(child)
+        if (node) {
+          return node
+        }
+      }
+    }
+  }
+  return null
+}
 
 interface ServerComponentProps {
   lazy?: boolean
@@ -34,6 +57,9 @@ export const createServerComponent = (name: string): ServerComponentType => {
       const islandRef = ref<{ refresh: () => Promise<void> } | null>(null)
 
       expose({
+        get $el () {
+          return vm ? getVNodeRootNode(vm.subTree) : undefined
+        },
         refresh: () => islandRef.value?.refresh(),
       })
 

--- a/packages/nuxt/src/components/runtime/server-component.ts
+++ b/packages/nuxt/src/components/runtime/server-component.ts
@@ -11,29 +11,6 @@ import type { NuxtIslandResponse } from '#app/types'
 import { $fetch } from '#build/fetch'
 import { payloadExtraction } from '#build/nuxt.config.mjs'
 
-function getVNodeRootNode (vnode: VNode | null): RendererNode | null {
-  if (!vnode) {
-    return null
-  }
-  if (vnode.component) {
-    return getVNodeRootNode(vnode.component.subTree)
-  }
-  if (vnode.type !== Fragment) {
-    return vnode.el
-  }
-  if (Array.isArray(vnode.children)) {
-    for (const child of vnode.children) {
-      if (isVNode(child)) {
-        const node = getVNodeRootNode(child)
-        if (node) {
-          return node
-        }
-      }
-    }
-  }
-  return null
-}
-
 interface ServerComponentProps {
   lazy?: boolean
 }
@@ -124,6 +101,29 @@ export const createIslandPage = (name: string, islandKey?: string): IslandPageTy
     (component as any).__nuxt_prefetch = (nuxtApp: NuxtApp, route: { path: string, fullPath: string }) => prefetchIslandPage(nuxtApp, name, route)
   }
   return component as unknown as IslandPageType
+}
+
+function getVNodeRootNode (vnode: VNode | null): RendererNode | null {
+  if (!vnode) {
+    return null
+  }
+  if (vnode.component) {
+    return getVNodeRootNode(vnode.component.subTree)
+  }
+  if (vnode.type !== Fragment) {
+    return vnode.el
+  }
+  if (Array.isArray(vnode.children)) {
+    for (const child of vnode.children) {
+      if (isVNode(child)) {
+        const node = getVNodeRootNode(child)
+        if (node) {
+          return node
+        }
+      }
+    }
+  }
+  return null
 }
 
 const inflightIslandPrefetches = import.meta.client ? new Set<string>() : undefined

--- a/test/fixtures/server-components/app/pages/islands.vue
+++ b/test/fixtures/server-components/app/pages/islands.vue
@@ -10,6 +10,7 @@ const showIslandSlot = ref(false)
 const routeIslandVisible = ref(false)
 const testCount = ref(0)
 const count = ref(0)
+const serverComponentRef = ref<InstanceType<typeof AsyncServerComponent>>()
 </script>
 
 <template>
@@ -55,11 +56,15 @@ const count = ref(0)
     </button>
 
     <p>async .server component</p>
-    <AsyncServerComponent :count="count">
+    <AsyncServerComponent
+      ref="serverComponentRef"
+      :count="count"
+    >
       <div id="slot-in-server">
         Slot with in .server component
       </div>
     </AsyncServerComponent>
+    <output id="server-component-ref">{{ serverComponentRef?.$el.nodeName }}</output>
     <div>
       Async component (1000ms):
       <div>

--- a/test/server-components.test.ts
+++ b/test/server-components.test.ts
@@ -44,6 +44,8 @@ await setup({
 describe('server components/islands', () => {
   it('/islands', async () => {
     const { page } = await renderPage('/islands')
+    await page.waitForFunction(() => document.querySelector('#server-component-ref')?.textContent)
+    expect(await page.locator('#server-component-ref').textContent()).toBe('DIV')
     const islandRequest = page.waitForResponse(response => response.url().includes('/__nuxt_island/') && response.status() === 200)
     await page.locator('#increase-pure-component').click()
     await islandRequest


### PR DESCRIPTION
### 🔗 Linked issue

resolves #31512

### 📚 Description

`$el` on a server component ref resolves to NuxtIsland's fragment anchor instead of the component's single rendered root. It now follows the current island VNode tree without adding a wrapper. Refs to elements inside the server component are still not available from the parent, and the docs now make this distinction clear.
