### PR TITLE
fix(nuxt): don't defer hydration route for trailing-slash-only diffs

### DIFF
--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -2,7 +2,7 @@ import { isReadonly, reactive, shallowReactive, shallowRef } from 'vue'
 import type { Ref, VNode } from 'vue'
 import type { RouteLocationNormalizedLoadedGeneric, Router, RouterScrollBehavior } from 'vue-router'
 import { START_LOCATION, createMemoryHistory, createRouter, createWebHashHistory, createWebHistory } from 'vue-router'
-import { isSamePath, withoutBase, withoutTrailingSlash } from 'ufo'
+import { isSamePath, withoutBase } from 'ufo'
 
 import type { NuxtApp, Plugin } from '#app/nuxt'
 import type { RouteMiddleware } from '#app/composables/router'
@@ -20,6 +20,9 @@ import _routeRulesMatcher from '#build/route-rules.mjs'
 import routerOptions, { hashMode } from '#build/router.options.mjs'
 import { globalMiddleware, namedMiddleware } from '#build/middleware'
 import { pageIslandRoutes } from '#build/components.islands.mjs'
+
+// matches a trailing slash on the path only, leaving query and hash significant
+const PATH_TRAILING_SLASH_RE = /\/(?=$|[?#])/
 
 // https://github.com/vuejs/router/blob/4a0cc8b9c1e642cdf47cc007fa5bbebde70afc66/packages/router/src/history/html5.ts#L37
 function createCurrentLocation (
@@ -201,7 +204,7 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
       && nuxtApp.isHydrating
       && nuxtApp.payload.prerenderedAt
       && nuxtApp.payload.path
-      && withoutTrailingSlash(initialURL, true) !== withoutTrailingSlash(nuxtApp.payload.path, true)
+      && initialURL.replace(PATH_TRAILING_SLASH_RE, '') !== nuxtApp.payload.path.replace(PATH_TRAILING_SLASH_RE, '')
       && isSamePath(router.currentRoute.value.path, nuxtApp.payload.path)
 
     syncCurrentRoute()

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -2,7 +2,7 @@ import { isReadonly, reactive, shallowReactive, shallowRef } from 'vue'
 import type { Ref, VNode } from 'vue'
 import type { RouteLocationNormalizedLoadedGeneric, Router, RouterScrollBehavior } from 'vue-router'
 import { START_LOCATION, createMemoryHistory, createRouter, createWebHashHistory, createWebHistory } from 'vue-router'
-import { isSamePath, withoutBase } from 'ufo'
+import { isSamePath, withoutBase, withoutTrailingSlash } from 'ufo'
 
 import type { NuxtApp, Plugin } from '#app/nuxt'
 import type { RouteMiddleware } from '#app/composables/router'
@@ -201,7 +201,7 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
       && nuxtApp.isHydrating
       && nuxtApp.payload.prerenderedAt
       && nuxtApp.payload.path
-      && initialURL !== nuxtApp.payload.path
+      && withoutTrailingSlash(initialURL, true) !== withoutTrailingSlash(nuxtApp.payload.path, true)
       && isSamePath(router.currentRoute.value.path, nuxtApp.payload.path)
 
     syncCurrentRoute()

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -722,7 +722,10 @@ describe('pages', () => {
     await page.close()
   })
 
-  it.skipIf(isDev)('does not rewrite the URL when hydrating a prerendered page requested with a trailing slash', async () => {
+  it.skipIf(isDev).each([
+    ['/prerender/query-reactivity'],
+    ['/prerender/%C3%A7'],
+  ])('does not rewrite the URL when hydrating prerendered %s requested with a trailing slash', async (path) => {
     const page = await createPage()
     await page.addInitScript(() => {
       const paths: string[] = []
@@ -735,12 +738,12 @@ describe('pages', () => {
       }
     })
 
-    await page.goto(url('/prerender/query-reactivity/'))
+    await page.goto(url(path + '/'))
     await page.waitForFunction(() => window.useNuxtApp?.() && !window.useNuxtApp!().isHydrating)
 
     const paths = await page.evaluate(() => (window as unknown as { __historyPaths: string[] }).__historyPaths)
-    expect(paths).not.toContain('/prerender/query-reactivity')
-    expect(new URL(page.url()).pathname).toBe('/prerender/query-reactivity/')
+    expect(paths).not.toContain(path)
+    expect(new URL(page.url()).pathname).toBe(path + '/')
 
     await page.close()
   })

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -722,6 +722,29 @@ describe('pages', () => {
     await page.close()
   })
 
+  it.skipIf(isDev)('does not rewrite the URL when hydrating a prerendered page requested with a trailing slash', async () => {
+    const page = await createPage()
+    await page.addInitScript(() => {
+      const paths: string[] = []
+      Object.assign(window, { __historyPaths: paths })
+      const replaceState = history.replaceState.bind(history)
+      history.replaceState = (...args: Parameters<History['replaceState']>) => {
+        const result = replaceState(...args)
+        paths.push(window.location.pathname)
+        return result
+      }
+    })
+
+    await page.goto(url('/prerender/query-reactivity/'))
+    await page.waitForFunction(() => window.useNuxtApp?.() && !window.useNuxtApp!().isHydrating)
+
+    const paths = await page.evaluate(() => (window as unknown as { __historyPaths: string[] }).__historyPaths)
+    expect(paths).not.toContain('/prerender/query-reactivity')
+    expect(new URL(page.url()).pathname).toBe('/prerender/query-reactivity/')
+
+    await page.close()
+  })
+
   it.skipIf(isDev)('enables preview mode on prerendered pages', async () => {
     const { page } = await renderPage('/prerender/preview-mode?preview=true&token=hehe')
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

we push a route after hydration for generate routes, in case it's different. we shouldn't take trailing slashes into account for this change (it's meant to capture queries only)