### PR TITLE
fix(nuxt): avoid blank lazy hydration remounts

### DIFF
--- a/packages/nuxt/src/components/runtime/lazy-hydrated-component.ts
+++ b/packages/nuxt/src/components/runtime/lazy-hydrated-component.ts
@@ -10,38 +10,40 @@ type LazyHydrationEmits = {
 type LazyComponentFactory<Props extends Record<string, any>> = (id: string, loader: AsyncComponentLoader) => DefineSetupFnComponent<Props, LazyHydrationEmits>
 
 function defineLazyComponent<P extends ComponentObjectPropsOptions, Props extends Record<string, any> = ExtractPropTypes<P>> (props: P, defineStrategy: (props: ExtractPropTypes<P>) => HydrationStrategy | undefined, never = false): LazyComponentFactory<Props> {
-  return (id: string, loader: AsyncComponentLoader) => defineComponent({
-    inheritAttrs: false,
-    props,
-    emits: ['hydrated'],
-    setup (props, ctx) {
-      if (import.meta.server) {
-        if (never) {
-          provide(neverHydratedSymbol, true)
-        }
-        const nuxtApp = useNuxtApp()
-        nuxtApp.hook('app:rendered', ({ ssrContext }) => {
-          // track lazy hydrated components so prefetch/preload tags are not rendered for them
-          // but keep them in modules so CSS links are still rendered
-          ssrContext!['~lazyHydratedModules'] ||= new Set()
-          ssrContext!['~lazyHydratedModules'].add(id)
+  return (id: string, loader: AsyncComponentLoader) => {
+    const child = defineAsyncComponent({ loader })
+    return defineComponent({
+      inheritAttrs: false,
+      props,
+      emits: ['hydrated'],
+      setup (props, ctx) {
+        if (import.meta.server) {
           if (never) {
-            // never-hydrated chunks are also excluded from prefetch hints, as they can never be needed
-            ssrContext!['~neverHydratedModules'] ||= new Set()
-            ssrContext!['~neverHydratedModules'].add(id)
+            provide(neverHydratedSymbol, true)
           }
+          const nuxtApp = useNuxtApp()
+          nuxtApp.hook('app:rendered', ({ ssrContext }) => {
+            // track lazy hydrated components so prefetch/preload tags are not rendered for them
+            // but keep them in modules so CSS links are still rendered
+            ssrContext!['~lazyHydratedModules'] ||= new Set()
+            ssrContext!['~lazyHydratedModules'].add(id)
+            if (never) {
+              // never-hydrated chunks are also excluded from prefetch hints, as they can never be needed
+              ssrContext!['~neverHydratedModules'] ||= new Set()
+              ssrContext!['~neverHydratedModules'].add(id)
+            }
+          })
+        }
+        // wrap the async component in a second component to avoid loading the chunk too soon
+        const comp = defineAsyncComponent({
+          hydrate: defineStrategy(props as ExtractPropTypes<P>),
+          loader: () => Promise.resolve(child),
         })
-      }
-      // wrap the async component in a second component to avoid loading the chunk too soon
-      const child = defineAsyncComponent({ loader })
-      const comp = defineAsyncComponent({
-        hydrate: defineStrategy(props as ExtractPropTypes<P>),
-        loader: () => Promise.resolve(child),
-      })
-      const onVnodeMounted = () => { ctx.emit('hydrated') }
-      return () => h(comp, mergeProps(ctx.attrs, { onVnodeMounted }), ctx.slots)
-    },
-  }) as unknown as DefineSetupFnComponent<Props, LazyHydrationEmits>
+        const onVnodeMounted = () => { ctx.emit('hydrated') }
+        return () => h(comp, mergeProps(ctx.attrs, { onVnodeMounted }), ctx.slots)
+      },
+    }) as unknown as DefineSetupFnComponent<Props, LazyHydrationEmits>
+  }
 }
 
 interface LazyVisibleProps { hydrateOnVisible?: true | IntersectionObserverInit }

--- a/test/e2e/lazy-hydration.test.ts
+++ b/test/e2e/lazy-hydration.test.ts
@@ -59,6 +59,17 @@ test.describe('lazy hydration styles', () => {
   })
 })
 
+test('renders a previously loaded lazy hydration component on the first frame after remount', async ({ page, goto }) => {
+  await goto('/remount')
+  await page.locator('[data-testid="plain-remounted-component"]', { hasText: 'This is mounted.' }).first().waitFor()
+  await page.locator('[data-testid="hydrated-remounted-component"]', { hasText: 'This is mounted.' }).first().waitFor()
+
+  await page.getByTestId('remount').click()
+
+  await expect(page.getByTestId('plain-count-on-first-frame')).toHaveText('12')
+  await expect(page.getByTestId('hydrated-count-on-first-frame')).toHaveText('12')
+})
+
 const hydrationTests = {
   'in template': '',
   'with vue macros': '/macro',

--- a/test/fixtures/lazy-hydration/pages/remount.vue
+++ b/test/fixtures/lazy-hydration/pages/remount.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+const show = ref(true)
+const plainCountOnFirstFrame = ref<number>()
+const hydratedCountOnFirstFrame = ref<number>()
+
+async function remount () {
+  show.value = false
+  await nextTick()
+  show.value = true
+  await new Promise<void>((resolve) => {
+    requestAnimationFrame(() => {
+      plainCountOnFirstFrame.value = document.querySelectorAll('[data-testid="plain-remounted-component"]').length
+      hydratedCountOnFirstFrame.value = document.querySelectorAll('[data-testid="hydrated-remounted-component"]').length
+      resolve()
+    })
+  })
+}
+</script>
+
+<template>
+  <button
+    data-testid="remount"
+    @click="remount"
+  >
+    Remount
+  </button>
+  <output data-testid="plain-count-on-first-frame">
+    {{ plainCountOnFirstFrame }}
+  </output>
+  <output data-testid="hydrated-count-on-first-frame">
+    {{ hydratedCountOnFirstFrame }}
+  </output>
+  <template v-if="show">
+    <LazyDelayedComponent
+      v-for="n in 12"
+      :key="`plain-${n}`"
+      data-testid="plain-remounted-component"
+    />
+    <LazyDelayedComponent
+      v-for="n in 12"
+      :key="`hydrated-${n}`"
+      data-testid="hydrated-remounted-component"
+      hydrate-on-visible
+    />
+  </template>
+</template>


### PR DESCRIPTION
### 🔗 Linked issue

resolves #36017

### 📚 Description

Lazy hydration components recreated their inner async wrapper on every mount, dropping Vue's resolved component cache and leaving remounted content blank even after the chunk was loaded. The wrapper is now shared by instances of the generated component, so remounts render in the same frame as a plain lazy component.