### PR TITLE
fix(nuxt): match vue-router path encoding in `navigateTo`

### DIFF
--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -1,7 +1,7 @@
 import { getCurrentInstance, getCurrentScope, hasInjectionContext, inject, onScopeDispose } from 'vue'
 import type { ComponentInternalInstance, EffectScope } from 'vue'
 import type { NavigationFailure, NavigationGuard, RouteLocationNormalized, RouteLocationRaw, Router, useRoute as _useRoute, useRouter as _useRouter } from 'vue-router'
-import { decodePath, encodePath, hasProtocol, isScriptProtocol, joinURL, parseQuery, parseURL, withQuery } from 'ufo'
+import { decodePath, hasProtocol, isScriptProtocol, joinURL, parseQuery, parseURL, withQuery } from 'ufo'
 
 import type { NuxtLayouts } from '../../pages/runtime/composables'
 
@@ -282,8 +282,8 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
     return Promise.resolve()
   }
 
-  // Encode the path portion of string locations to match vue-router's
-  // percent-encoded route records.
+  // Encode the path portion of string locations so that decoded paths like
+  // `/café` match vue-router's encoded route records.
   const encodedTo = typeof to === 'string' ? encodeRoutePath(to) : to
   return options?.replace ? router.replace(encodedTo) : router.push(encodedTo)
 }
@@ -386,5 +386,27 @@ export function encodeURL (location: string, isExternalHost = false): string {
  */
 export function encodeRoutePath (url: string): string {
   const parsed = parseURL(url)
-  return encodePath(decodePath(parsed.pathname)) + parsed.search + parsed.hash
+  return encodeVueRouterPath(decodePath(parsed.pathname)) + parsed.search + parsed.hash
+}
+
+const ENC_PIPE_RE = /%7C/g
+const ENC_BRACKET_OPEN_RE = /%5B/g
+const ENC_BRACKET_CLOSE_RE = /%5D/g
+const ENC_ENC_SLASH_RE = /%252F/gi
+const HASH_RE = /#/g
+const QUESTION_MARK_RE = /\?/g
+
+/**
+ * Apply vue-router's own path encoding, which leaves sub-delimiters like `&`
+ * and `+` literal. This must stay in sync with `encodeVueRouterPath` in
+ * `unrouting`, which encodes the route records we need to match against.
+ */
+function encodeVueRouterPath (value: string): string {
+  return encodeURI(value)
+    .replace(ENC_PIPE_RE, '|')
+    .replace(ENC_BRACKET_OPEN_RE, '[')
+    .replace(ENC_BRACKET_CLOSE_RE, ']')
+    .replace(HASH_RE, '%23')
+    .replace(QUESTION_MARK_RE, '%3F')
+    .replace(ENC_ENC_SLASH_RE, '%2F')
 }

--- a/packages/nuxt/test/__snapshots__/pages-override-meta-disabled.test.ts.snap
+++ b/packages/nuxt/test/__snapshots__/pages-override-meta-disabled.test.ts.snap
@@ -137,7 +137,7 @@
       "component": "() => import("pages/a&b.vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "a&b"",
-      "path": "mockMeta?.path ?? "/a%26b"",
+      "path": "mockMeta?.path ?? "/a&b"",
       "props": "mockMeta?.props ?? false",
       "redirect": "mockMeta?.redirect",
     },

--- a/packages/nuxt/test/__snapshots__/pages-override-meta-enabled.test.ts.snap
+++ b/packages/nuxt/test/__snapshots__/pages-override-meta-enabled.test.ts.snap
@@ -91,7 +91,7 @@
     {
       "component": "() => import("pages/a&b.vue")",
       "name": ""a&b"",
-      "path": ""/a%26b"",
+      "path": ""/a&b"",
     },
     {
       "component": "() => import("pages/a/b.vue")",

--- a/packages/nuxt/test/nitro-ssr-routes.test.ts
+++ b/packages/nuxt/test/nitro-ssr-routes.test.ts
@@ -47,7 +47,7 @@ describe('nitro-ssr-routes', () => {
         "/%E6%96%87%E6%A1%A3",
         "/%E6%96%87%E6%A1%A3/%E4%BB%8B%E7%BB%8D",
         "/%D8%AE%D8%A7%D8%B5\\:_D8_AC_D8_AF_D9_8A_D8_AF",
-        "/a%26b",
+        "/a&b",
         "/a%5Cb",
         "/:foo",
         "/:foo",

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -870,7 +870,7 @@ export const pageTests: Array<{
       { path: `${pagesDir}/a\\b.vue` },
     ],
     output: [
-      { name: 'a&b', path: `/a${encodeURIComponent('&')}b`, file: `${pagesDir}/a&b.vue`, children: [] },
+      { name: 'a&b', path: '/a&b', file: `${pagesDir}/a&b.vue`, children: [] },
       { name: 'a\\b', path: `/a${encodeURIComponent('\\')}b`, file: `${pagesDir}/a\\b.vue`, children: [] },
     ],
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,8 +242,8 @@ catalogs:
       specifier: ^3.3.0
       version: 3.3.0
     unrouting:
-      specifier: ^0.2.2
-      version: 0.2.2
+      specifier: ^0.2.3
+      version: 0.2.3
     untyped:
       specifier: ^2.0.0
       version: 2.0.0
@@ -981,7 +981,7 @@ importers:
         version: 3.0.0(magic-string@1.1.0)(oxc-parser@0.143.0)(rolldown@1.2.3)(unplugin@3.3.0(@rspack/core@2.1.7(@swc/helpers@0.5.23))(esbuild@0.28.1)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1)(webpack@5.109.2(cssnano@8.0.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)))
       unrouting:
         specifier: catalog:build
-        version: 0.2.2
+        version: 0.2.3
       unstorage:
         specifier: catalog:nitro-runtime
         version: 2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4)(ioredis@5.10.1(supports-color@10.2.2))(lru-cache@11.5.2)(ofetch@2.0.0-alpha.3)
@@ -1177,7 +1177,7 @@ importers:
         version: 3.3.0(@rspack/core@2.1.7(@swc/helpers@0.5.23))(esbuild@0.28.1)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1)(webpack@5.109.2(cssnano@8.0.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25))
       unrouting:
         specifier: catalog:build
-        version: 0.2.2
+        version: 0.2.3
       untyped:
         specifier: catalog:build
         version: 2.0.0
@@ -9651,8 +9651,8 @@ packages:
       webpack:
         optional: true
 
-  unrouting@0.2.2:
-    resolution: {integrity: sha512-EoCab68s1o9AWFq9fjKsMEsmjKrPO11SAsvopikks2eEm/KLXgZMCof4cgpVgdy0Vz71OFBJw6DoDqu1oOSFGw==}
+  unrouting@0.2.3:
+    resolution: {integrity: sha512-8wOFT/fBh8YeeDr1aVmkXCqYVTMbQ6vzfNzwzybKmSfXdRhGCq1Y2B1e9YeB0JEf85gbvSwJHAMu3D2IEcLGKA==}
 
   unrs-resolver@1.12.2:
     resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
@@ -18581,7 +18581,7 @@ snapshots:
       vite: 8.2.1(@types/node@24.13.3)(@vitejs/devtools@0.4.12)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
       webpack: 5.109.2(cssnano@8.0.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)
 
-  unrouting@0.2.2:
+  unrouting@0.2.3:
     dependencies:
       escape-string-regexp: 5.0.0
       ufo: 1.6.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -200,7 +200,7 @@ catalogs:
     unenv: 2.0.0-rc.24 # intentionally pinned to match nitro's dependency
     unimport: ^6.4.0
     unplugin: ^3.3.0
-    unrouting: ^0.2.2
+    unrouting: ^0.2.3
     untyped: ^2.0.0
     verkit: ^0.3.1
     vue-bundle-renderer: ^2.3.1

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -675,6 +675,30 @@ describe('pages', () => {
     expect(html).toContain('Extended layout from foo')
   })
 
+  it('renders pages with sub-delimiters in route', async () => {
+    expect(await $fetch<string>('/non-ascii/a&b')).toContain('sub-delimiter page: a&amp;b')
+    expect(await $fetch<string>('/non-ascii/a+b')).toContain('sub-delimiter page: a+b')
+  })
+
+  it('navigates to pages with sub-delimiters in route', async () => {
+    const { page } = await renderPage('/non-ascii/navigate')
+
+    for (const [id, path, content] of [
+      ['#navigate-ampersand', '/non-ascii/a&b', 'sub-delimiter page: a&b'],
+      ['#navigate-plus', '/non-ascii/a+b', 'sub-delimiter page: a+b'],
+    ] as const) {
+      await page.locator(id).click()
+      await page.waitForFunction(p => window.useNuxtApp?.()._route.path === p, path)
+      expect(await page.evaluate(() => window.useNuxtApp?.()._route.matched.length)).toBe(1)
+      expect(await page.evaluate(() => window.location.pathname)).toBe(path)
+      expect(await page.innerText('body')).toContain(content)
+      await page.goBack()
+      await page.waitForFunction(() => window.useNuxtApp?.()._route.path === '/non-ascii/navigate')
+    }
+
+    await page.close()
+  })
+
   it.skipIf(isDev)('prerenders pages with special characters', async () => {
     const html = await $fetch('/prerender/ç')
     expect(html).toContain('should be prerendered: true')

--- a/test/fixtures/basic/app/pages/non-ascii/a&b.vue
+++ b/test/fixtures/basic/app/pages/non-ascii/a&b.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>sub-delimiter page: a&amp;b</div>
+</template>

--- a/test/fixtures/basic/app/pages/non-ascii/a+b.vue
+++ b/test/fixtures/basic/app/pages/non-ascii/a+b.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>sub-delimiter page: a+b</div>
+</template>

--- a/test/fixtures/basic/app/pages/non-ascii/navigate.vue
+++ b/test/fixtures/basic/app/pages/non-ascii/navigate.vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    <button
+      id="navigate-ampersand"
+      @click="navigateTo('/non-ascii/a&b')"
+    >
+      navigate to a&amp;b
+    </button>
+    <button
+      id="navigate-plus"
+      @click="navigateTo('/non-ascii/a+b')"
+    >
+      navigate to a+b
+    </button>
+  </div>
+</template>

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -948,9 +948,15 @@ describe('routing utilities: `encodeRoutePath`', () => {
     expect(encodeRoutePath('/café?q=foo#bar')).toBe(`/${encodeURIComponent('café')}?q=foo#bar`)
   })
 
-  it('should encode special characters in path segments', () => {
-    expect(encodeRoutePath('/a&b')).toBe(`/a${encodeURIComponent('&')}b`)
+  it('should leave sub-delimiters literal, as vue-router does', () => {
+    expect(encodeRoutePath('/a&b')).toBe('/a&b')
+    expect(encodeRoutePath('/a+b')).toBe('/a+b')
+    expect(encodeRoutePath('/a[b]')).toBe('/a[b]')
     expect(encodeRoutePath('/normal')).toBe('/normal')
+  })
+
+  it('should preserve encoded slashes', () => {
+    expect(encodeRoutePath('/a%2Fb')).toBe('/a%2Fb')
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/unjs/unrouting/pull/182

### 📚 Description

`encodePath` in `ufo` doesn't match `vue-router` behaviour so we can end up with mismatches.

(discovered thanks to 🐰 on https://github.com/nuxt/nuxt/pull/36050)
