### PR TITLE
fix(vite): drop duplicate CSS links for fully inlined shared chunks

### DIFF
--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -106,7 +106,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
 
   const isDroppableCSSFile = (file: string) => {
     const sources = cssSourcesByCSSFile.get(basename(file))
-    if (!sources) { return true }
+    if (!sources?.size) { return false }
     for (const cssId of sources) {
       if (!isInlinedForEveryImporter(cssId)) { return false }
     }
@@ -286,7 +286,12 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
               }
               if (cssSources.size) {
                 for (const file of chunk.viteMetadata?.importedCss ?? []) {
-                  cssSourcesByCSSFile.set(basename(file), cssSources)
+                  const cssFile = basename(file)
+                  const sources = cssSourcesByCSSFile.get(cssFile) ?? new Set<string>()
+                  cssSourcesByCSSFile.set(cssFile, sources)
+                  for (const cssId of cssSources) {
+                    sources.add(cssId)
+                  }
                 }
               }
             }

--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -134,7 +134,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
     // prevents duplicate styles when `inlineStyles` is enabled. (#30435)
     for (const chunk of Object.values(manifest)) {
       if (!chunk.css?.length) { continue }
-      const cssSources = (chunk.src && cssSourcesByChunkSrc.get(chunk.src)) || (chunk.file && cssSourcesByChunkFile.get(basename(chunk.file)))
+      const cssSources = (chunk.src ? cssSourcesByChunkSrc.get(chunk.src) : undefined) ?? (chunk.file ? cssSourcesByChunkFile.get(basename(chunk.file)) : undefined)
       if (!cssSources?.size) { continue }
       let allInlined = true
       for (const cssId of cssSources) {

--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -51,16 +51,12 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
   const envApi = nuxt.options.experimental.nitroViteEnvironment
 
   const chunksWithInlinedCSS = new Set<string>()
-  // For each output chunk that originates from a source file, the set of CSS
-  // source module ids (no query) vite/rolldown bundled into that chunk's CSS
-  // asset. Keyed by the manifest source path (`chunk.src`).
-  const cssSourcesByChunkSrc = new Map<string, Set<string>>()
-  // Same, but keyed by output file name, so shared chunks (which have no
-  // `src` in the manifest because they have no facade module) can be resolved.
-  const cssSourcesByChunkFile = new Map<string, Set<string>>()
-  // For each CSS source module id (no query), the source paths (relative to
-  // `srcDir`) of the modules importing it in the client graph.
-  const cssImporters = new Map<string, Set<string>>()
+  // Client module graph (ids and importers with any query stripped), used to
+  // check which components a CSS source can be reached from.
+  const clientImporters = new Map<string, Set<string>>()
+  // For each emitted CSS asset (base file name), the CSS source module ids
+  // bundled into it.
+  const cssSourcesByCSSFile = new Map<string, Set<string>>()
   const clientCSSMap: Record<string, Set<string>> = {}
 
   const stripQuery = (id: string) => id.replace(QUERY_RE, '')
@@ -78,24 +74,41 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
     return id + (id.includes('?') ? '&' : '?') + 'inline&used'
   }
 
-  // CSS source module ids (with `?...` query stripped) whose styles will be
-  // inlined into the SSR response. Built up in `build:manifest` from the
-  // components whose styles are actually emitted as inline `<style>` tags
-  // (i.e. those with `inBundle && files.length`). We can't populate this set
-  // during `transform` because at that point we don't yet know which
-  // components will actually have inline styles emitted.
-  const inlinedCSSModuleIds = new Set<string>()
-  // For each inlined CSS source module id, the `cssMap` keys of the modules it
-  // was inlined for. A CSS source can only be dropped from a chunk if every
-  // module importing it inlines it; with a function-valued `inlineStyles` one
-  // importer may inline a shared CSS source while another relies on the link.
+  // For each CSS source module id (with `?...` query stripped) whose styles are
+  // inlined into the SSR response, the `cssMap` keys of the components it is
+  // inlined for. Built up in `build:manifest` from the components whose styles
+  // are actually emitted as inline `<style>` tags (i.e. those with
+  // `inBundle && files.length`). We can't populate this during `transform`
+  // because at that point we don't yet know which components will actually have
+  // inline styles emitted.
   const inlinedCSSConsumers = new Map<string, Set<string>>()
 
+  // A CSS source is only safe to drop when every path from it up through the
+  // client module graph reaches a component that inlines it. With a
+  // function-valued `inlineStyles` (the default is one) a shared CSS source can
+  // be inlined for one importer while another still relies on the link.
   const isInlinedForEveryImporter = (cssId: string) => {
     const consumers = inlinedCSSConsumers.get(cssId)
     if (!consumers) { return false }
-    for (const importer of cssImporters.get(cssId) ?? []) {
-      if (!consumers.has(importer)) { return false }
+    const seen = new Set<string>()
+    const queue = [cssId]
+    while (queue.length) {
+      const importer = queue.shift()!
+      if (seen.has(importer)) { continue }
+      seen.add(importer)
+      if (consumers.has(relativeToSrcDir(importer))) { continue }
+      const parents = clientImporters.get(importer)
+      if (!parents?.size) { return false }
+      queue.push(...parents)
+    }
+    return true
+  }
+
+  const isDroppableCSSFile = (file: string) => {
+    const sources = cssSourcesByCSSFile.get(basename(file))
+    if (!sources) { return true }
+    for (const cssId of sources) {
+      if (!isInlinedForEveryImporter(cssId)) { return false }
     }
     return true
   }
@@ -113,7 +126,6 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
       chunksWithInlinedCSS.add(id)
       if (!cssIds) { continue }
       for (const cssId of cssIds) {
-        inlinedCSSModuleIds.add(cssId)
         const consumers = inlinedCSSConsumers.get(cssId) ?? new Set()
         inlinedCSSConsumers.set(cssId, consumers)
         consumers.add(id)
@@ -128,7 +140,10 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
       if (chunk.isEntry && chunk.src) {
         entryIds.add(chunk.src)
       } else {
-        chunk.css &&= []
+        // A chunk's CSS also covers the CSS of the chunks it imports, which can
+        // include sources this component does not inline (for example CSS pulled
+        // in by a non-Vue module elsewhere in the graph). Keep those links.
+        chunk.css &&= chunk.css.filter(file => !isDroppableCSSFile(file))
       }
       // Rolldown may split a component into a facade chunk (with no CSS) and
       // a shared code chunk (with CSS). Also clear CSS from directly imported
@@ -149,23 +164,12 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
       }
     }
 
-    // Drop a chunk's bundled CSS link when every CSS source module bundled into
-    // that chunk has already been inlined as a `<style>` tag during SSR. This
-    // prevents duplicate styles when `inlineStyles` is enabled. (#30435)
+    // Drop a CSS link when every CSS source module bundled into that asset has
+    // already been inlined as a `<style>` tag during SSR. This prevents
+    // duplicate styles when `inlineStyles` is enabled. (#30435)
     for (const chunk of Object.values(manifest)) {
       if (!chunk.css?.length) { continue }
-      const cssSources = (chunk.src ? cssSourcesByChunkSrc.get(chunk.src) : undefined) ?? (chunk.file ? cssSourcesByChunkFile.get(basename(chunk.file)) : undefined)
-      if (!cssSources?.size) { continue }
-      let allInlined = true
-      for (const cssId of cssSources) {
-        if (!inlinedCSSModuleIds.has(cssId) || !isInlinedForEveryImporter(cssId)) {
-          allInlined = false
-          break
-        }
-      }
-      if (allInlined) {
-        chunk.css = []
-      }
+      chunk.css = chunk.css.filter(file => !isDroppableCSSFile(file))
     }
 
     setBuildOutput('entryIds', () => `export default ${JSON.stringify(Array.from(entryIds))}`, nuxt)
@@ -263,21 +267,27 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
           if (environment.name === 'client') {
             for (const chunk of Object.values(bundle)) {
               if (chunk.type !== 'chunk') { continue }
-              let cssSources: Set<string> | undefined
               for (const moduleId of chunk.moduleIds) {
-                if (!isCSS(moduleId)) { continue }
-                const cssId = stripQuery(moduleId)
-                cssSources ||= cssSourcesByChunkFile.get(basename(chunk.fileName)) ?? new Set()
-                cssSources.add(cssId)
-                const importers = cssImporters.get(cssId) ?? new Set()
-                cssImporters.set(cssId, importers)
+                const id = stripQuery(moduleId)
+                const importers = clientImporters.get(id) ?? new Set()
+                clientImporters.set(id, importers)
                 for (const importer of this.getModuleInfo(moduleId)?.importers ?? []) {
-                  if (isCSS(importer)) { continue }
-                  importers.add(relativeToSrcDir(stripQuery(importer)))
+                  const importerId = stripQuery(importer)
+                  if (importerId !== id) {
+                    importers.add(importerId)
+                  }
                 }
               }
-              if (cssSources) {
-                cssSourcesByChunkFile.set(basename(chunk.fileName), cssSources)
+              const cssSources = new Set<string>()
+              for (const moduleId of chunk.moduleIds) {
+                if (isCSS(moduleId)) {
+                  cssSources.add(stripQuery(moduleId))
+                }
+              }
+              if (cssSources.size) {
+                for (const file of chunk.viteMetadata?.importedCss ?? []) {
+                  cssSourcesByCSSFile.set(basename(file), cssSources)
+                }
               }
             }
             return
@@ -360,24 +370,12 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
           if (isEntry) {
             clientCSSMap[chunk.facadeModuleId!] ||= new Set()
           }
-          let chunkCSSSources: Set<string> | undefined
-          if (environment.name === 'client' && chunk.facadeModuleId) {
-            const chunkSrc = relativeToSrcDir(chunk.facadeModuleId)
-            if (chunkSrc) {
-              chunkCSSSources = cssSourcesByChunkSrc.get(chunkSrc)
-              if (!chunkCSSSources) {
-                chunkCSSSources = new Set()
-                cssSourcesByChunkSrc.set(chunkSrc, chunkCSSSources)
-              }
-            }
-          }
           for (const moduleId of [chunk.facadeModuleId, ...chunk.moduleIds].filter(Boolean) as string[]) {
             // 'Teleport' CSS chunks that made it into the bundle on the client side
             // to be inlined on server rendering
             if (environment.name === 'client') {
               const moduleMap = clientCSSMap[moduleId] ||= new Set()
               if (isCSS(moduleId)) {
-                chunkCSSSources?.add(stripQuery(moduleId))
                 // Vue files can (also) be their own entrypoints as they are tracked separately
                 if (isVue(moduleId)) {
                   moduleMap.add(moduleId)

--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -55,6 +55,9 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
   // source module ids (no query) vite/rolldown bundled into that chunk's CSS
   // asset. Keyed by the manifest source path (`chunk.src`).
   const cssSourcesByChunkSrc = new Map<string, Set<string>>()
+  // Same, but keyed by output file name, so shared chunks (which have no
+  // `src` in the manifest because they have no facade module) can be resolved.
+  const cssSourcesByChunkFile = new Map<string, Set<string>>()
   const clientCSSMap: Record<string, Set<string>> = {}
 
   const stripQuery = (id: string) => id.replace(QUERY_RE, '')
@@ -130,8 +133,8 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
     // that chunk has already been inlined as a `<style>` tag during SSR. This
     // prevents duplicate styles when `inlineStyles` is enabled. (#30435)
     for (const chunk of Object.values(manifest)) {
-      if (!chunk.css?.length || !chunk.src) { continue }
-      const cssSources = cssSourcesByChunkSrc.get(chunk.src)
+      if (!chunk.css?.length) { continue }
+      const cssSources = (chunk.src && cssSourcesByChunkSrc.get(chunk.src)) || (chunk.file && cssSourcesByChunkFile.get(basename(chunk.file)))
       if (!cssSources?.size) { continue }
       let allInlined = true
       for (const cssId of cssSources) {
@@ -236,8 +239,22 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
             }
           },
         },
-        generateBundle (outputOptions) {
-          if (environment.name === 'client') { return }
+        generateBundle (outputOptions, bundle) {
+          if (environment.name === 'client') {
+            for (const chunk of Object.values(bundle)) {
+              if (chunk.type !== 'chunk') { continue }
+              let cssSources: Set<string> | undefined
+              for (const moduleId of chunk.moduleIds) {
+                if (!isCSS(moduleId)) { continue }
+                cssSources ||= cssSourcesByChunkFile.get(basename(chunk.fileName)) ?? new Set()
+                cssSources.add(stripQuery(moduleId))
+              }
+              if (cssSources) {
+                cssSourcesByChunkFile.set(basename(chunk.fileName), cssSources)
+              }
+            }
+            return
+          }
 
           const emitted: Record<string, string> = {}
           const usedNames = new Set<string>()

--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -58,6 +58,9 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
   // Same, but keyed by output file name, so shared chunks (which have no
   // `src` in the manifest because they have no facade module) can be resolved.
   const cssSourcesByChunkFile = new Map<string, Set<string>>()
+  // For each CSS source module id (no query), the source paths (relative to
+  // `srcDir`) of the modules importing it in the client graph.
+  const cssImporters = new Map<string, Set<string>>()
   const clientCSSMap: Record<string, Set<string>> = {}
 
   const stripQuery = (id: string) => id.replace(QUERY_RE, '')
@@ -82,6 +85,20 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
   // during `transform` because at that point we don't yet know which
   // components will actually have inline styles emitted.
   const inlinedCSSModuleIds = new Set<string>()
+  // For each inlined CSS source module id, the `cssMap` keys of the modules it
+  // was inlined for. A CSS source can only be dropped from a chunk if every
+  // module importing it inlines it; with a function-valued `inlineStyles` one
+  // importer may inline a shared CSS source while another relies on the link.
+  const inlinedCSSConsumers = new Map<string, Set<string>>()
+
+  const isInlinedForEveryImporter = (cssId: string) => {
+    const consumers = inlinedCSSConsumers.get(cssId)
+    if (!consumers) { return false }
+    for (const importer of cssImporters.get(cssId) ?? []) {
+      if (!consumers.has(importer)) { return false }
+    }
+    return true
+  }
 
   // Remove CSS entries for files that will have inlined styles
   nuxt.hook('build:manifest', (manifest) => {
@@ -97,6 +114,9 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
       if (!cssIds) { continue }
       for (const cssId of cssIds) {
         inlinedCSSModuleIds.add(cssId)
+        const consumers = inlinedCSSConsumers.get(cssId) ?? new Set()
+        inlinedCSSConsumers.set(cssId, consumers)
+        consumers.add(id)
       }
     }
 
@@ -138,7 +158,7 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
       if (!cssSources?.size) { continue }
       let allInlined = true
       for (const cssId of cssSources) {
-        if (!inlinedCSSModuleIds.has(cssId)) {
+        if (!inlinedCSSModuleIds.has(cssId) || !isInlinedForEveryImporter(cssId)) {
           allInlined = false
           break
         }
@@ -246,8 +266,15 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
               let cssSources: Set<string> | undefined
               for (const moduleId of chunk.moduleIds) {
                 if (!isCSS(moduleId)) { continue }
+                const cssId = stripQuery(moduleId)
                 cssSources ||= cssSourcesByChunkFile.get(basename(chunk.fileName)) ?? new Set()
-                cssSources.add(stripQuery(moduleId))
+                cssSources.add(cssId)
+                const importers = cssImporters.get(cssId) ?? new Set()
+                cssImporters.set(cssId, importers)
+                for (const importer of this.getModuleInfo(moduleId)?.importers ?? []) {
+                  if (isCSS(importer)) { continue }
+                  importers.add(relativeToSrcDir(stripQuery(importer)))
+                }
               }
               if (cssSources) {
                 cssSourcesByChunkFile.set(basename(chunk.fileName), cssSources)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1948,6 +1948,12 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/nuxt
 
+  test/fixtures/inline-styles-predicate:
+    dependencies:
+      nuxt:
+        specifier: workspace:*
+        version: link:../../../packages/nuxt
+
   test/fixtures/lazy-hydration:
     dependencies:
       nuxt:

--- a/test/fixtures/inline-styles-predicate/app.vue
+++ b/test/fixtures/inline-styles-predicate/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <NuxtPage />
+</template>

--- a/test/fixtures/inline-styles-predicate/assets/shared.css
+++ b/test/fixtures/inline-styles-predicate/assets/shared.css
@@ -1,0 +1,3 @@
+.shared-box {
+  --inline-predicate-shared-token: predicate-shared;
+}

--- a/test/fixtures/inline-styles-predicate/components/SharedBox.vue
+++ b/test/fixtures/inline-styles-predicate/components/SharedBox.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="predicate-shared-box" />
+</template>
+
+<style>
+.predicate-shared-box {
+  --inline-predicate-box-token: predicate-box;
+}
+</style>

--- a/test/fixtures/inline-styles-predicate/nuxt.config.ts
+++ b/test/fixtures/inline-styles-predicate/nuxt.config.ts
@@ -1,0 +1,17 @@
+import { isNuxtPrepare, projectSuffix, withMatrix } from '../../matrix.ts'
+
+// Regression for a `features.inlineStyles` predicate that inlines a shared CSS
+// source for one page but not another: the page that does not inline it must
+// keep its stylesheet link.
+export default withMatrix({
+  ...(isNuxtPrepare ? {} : { buildDir: `.nuxt-${projectSuffix}` }),
+  sourcemap: false,
+  features: {
+    inlineStyles: (id?: string) => !!id && id.includes('.vue') && !id.includes('not-inlined'),
+  },
+  nitro: {
+    output: {
+      dir: `.output-${projectSuffix}`,
+    },
+  },
+})

--- a/test/fixtures/inline-styles-predicate/package.json
+++ b/test/fixtures/inline-styles-predicate/package.json
@@ -1,0 +1,14 @@
+{
+  "private": true,
+  "type": "module",
+  "name": "fixture-inline-styles-predicate",
+  "scripts": {
+    "build": "nuxt build"
+  },
+  "dependencies": {
+    "nuxt": "workspace:*"
+  },
+  "engines": {
+    "node": "^22.19.0 || ^24.11.0 || >=26.0.0"
+  }
+}

--- a/test/fixtures/inline-styles-predicate/pages/inlined.vue
+++ b/test/fixtures/inline-styles-predicate/pages/inlined.vue
@@ -1,0 +1,16 @@
+<script setup>
+import '~/assets/shared.css'
+</script>
+
+<template>
+  <main class="shared-box">
+    inlined
+    <SharedBox />
+  </main>
+</template>
+
+<style>
+.page-inlined {
+  --inline-predicate-page-inlined-token: inlined;
+}
+</style>

--- a/test/fixtures/inline-styles-predicate/pages/not-inlined.vue
+++ b/test/fixtures/inline-styles-predicate/pages/not-inlined.vue
@@ -1,0 +1,16 @@
+<script setup>
+import '~/assets/shared.css'
+</script>
+
+<template>
+  <main class="shared-box">
+    not-inlined
+    <SharedBox />
+  </main>
+</template>
+
+<style>
+.page-not-inlined {
+  --inline-predicate-page-not-inlined-token: not-inlined;
+}
+</style>

--- a/test/fixtures/inline-styles-predicate/tsconfig.json
+++ b/test/fixtures/inline-styles-predicate/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./.nuxt/tsconfig.app.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.server.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.node.json"
+    }
+  ]
+}

--- a/test/fixtures/inline-styles/assets/shared-with-js-module.css
+++ b/test/fixtures/inline-styles/assets/shared-with-js-module.css
@@ -1,0 +1,3 @@
+.shared-with-js-module {
+  --inline-shared-with-js-module-token: shared-with-js-module;
+}

--- a/test/fixtures/inline-styles/components/shared-css-module.js
+++ b/test/fixtures/inline-styles/components/shared-css-module.js
@@ -1,0 +1,8 @@
+import '~/assets/shared-with-js-module.css'
+
+import { h } from 'vue'
+
+export default {
+  name: 'SharedCssModule',
+  render: () => h('span', { class: 'shared-with-js-module' }),
+}

--- a/test/fixtures/inline-styles/pages/shared-css-direct.vue
+++ b/test/fixtures/inline-styles/pages/shared-css-direct.vue
@@ -1,0 +1,9 @@
+<script setup>
+import '~/assets/shared-with-js-module.css'
+</script>
+
+<template>
+  <main class="shared-with-js-module">
+    shared css direct
+  </main>
+</template>

--- a/test/fixtures/inline-styles/pages/shared-css-via-js.vue
+++ b/test/fixtures/inline-styles/pages/shared-css-via-js.vue
@@ -1,0 +1,15 @@
+<script setup>
+import SharedCssModule from '../components/shared-css-module.js'
+</script>
+
+<template>
+  <main class="shared-css-via-js">
+    <SharedCssModule />
+  </main>
+</template>
+
+<style>
+.shared-css-via-js {
+  --inline-shared-css-via-js-token: shared-css-via-js;
+}
+</style>

--- a/test/inline-styles.test.ts
+++ b/test/inline-styles.test.ts
@@ -41,7 +41,7 @@ describe.skipIf(!runsOnceInMatrix)('inline styles', () => {
   })
 
   // https://github.com/nuxt/nuxt/issues/35255
-  it.fails('drops duplicate stylesheet links for fully inlined CSS in a shared chunk', async () => {
+  it('drops duplicate stylesheet links for fully inlined CSS in a shared chunk', async () => {
     for (const page of ['shared-a', 'shared-b']) {
       const html = await readFile(join(outputDir, 'public', page, 'index.html'), 'utf-8')
       expect(html, page).toContain('--inline-shared-box-token:shared-box')

--- a/test/inline-styles.test.ts
+++ b/test/inline-styles.test.ts
@@ -51,6 +51,15 @@ describe.skipIf(!runsOnceInMatrix)('inline styles', () => {
     }
   })
 
+  it('keeps a stylesheet link for CSS a page does not inline itself', async () => {
+    const html = await readFile(join(outputDir, 'public', 'shared-css-via-js', 'index.html'), 'utf-8')
+    expect(html).toContain('--inline-shared-css-via-js-token:shared-css-via-js')
+
+    const cssLinks = [...html.matchAll(/<link [^>]*rel="stylesheet"[^>]*href="([^"]+)"/g)].map(m => m[1]!)
+    const linked = await Promise.all(cssLinks.map(href => readFile(join(outputDir, 'public', href.replace(/^\//, '')), 'utf-8')))
+    expect([html, ...linked].join('\n')).toContain('--inline-shared-with-js-module-token:shared-with-js-module')
+  })
+
   // https://github.com/nuxt/nuxt/issues/31558
   it('inlines CSS for a non-island child of a server component', async () => {
     const html = await readFile(join(outputDir, 'public', 'index.html'), 'utf-8')
@@ -111,5 +120,34 @@ describe.skipIf(!runsOnceInMatrix)('inline styles', () => {
     const inlinedStyles = [...html.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)].map(m => m[1]!).join('\n')
     expect(inlinedStyles).toContain('--inline-custom-layout-token:custom-layout')
     expect(inlinedStyles).toMatch(/\.xs\s*(?:\{\s*)?\.layout-container/)
+  })
+})
+
+describe.skipIf(!runsOnceInMatrix)('inline styles with an `inlineStyles` predicate', () => {
+  const rootDir = fileURLToPath(new URL('./fixtures/inline-styles-predicate', import.meta.url))
+
+  beforeAll(async () => {
+    const result = await exec('pnpm', ['nuxt', 'generate', rootDir])
+    if (result.exitCode !== 0) {
+      throw new Error(`nuxt generate failed:\n${result.stderr}\n${result.stdout}`)
+    }
+  }, 120 * 1000)
+
+  const outputDir = join(rootDir, `.output-${projectSuffix}`)
+
+  it('inlines shared CSS for the page the predicate opts in', async () => {
+    const html = await readFile(join(outputDir, 'public', 'inlined', 'index.html'), 'utf-8')
+    const inlinedStyles = [...html.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)].map(m => m[1]!).join('\n')
+    expect(inlinedStyles).toContain('--inline-predicate-shared-token:predicate-shared')
+  })
+
+  it('keeps the stylesheet link for the page the predicate opts out', async () => {
+    const html = await readFile(join(outputDir, 'public', 'not-inlined', 'index.html'), 'utf-8')
+    const inlinedStyles = [...html.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)].map(m => m[1]!).join('\n')
+    expect(inlinedStyles).not.toContain('--inline-predicate-shared-token:predicate-shared')
+
+    const cssLinks = [...html.matchAll(/<link [^>]*rel="stylesheet"[^>]*href="([^"]+)"/g)].map(m => m[1]!)
+    const linked = await Promise.all(cssLinks.map(href => readFile(join(outputDir, 'public', href.replace(/^\//, '')), 'utf-8')))
+    expect(linked.join('\n')).toContain('--inline-predicate-shared-token:predicate-shared')
   })
 })

--- a/test/inline-styles.test.ts
+++ b/test/inline-styles.test.ts
@@ -56,8 +56,10 @@ describe.skipIf(!runsOnceInMatrix)('inline styles', () => {
     expect(html).toContain('--inline-shared-css-via-js-token:shared-css-via-js')
 
     const cssLinks = [...html.matchAll(/<link [^>]*rel="stylesheet"[^>]*href="([^"]+)"/g)].map(m => m[1]!)
+    expect(cssLinks.length).toBeGreaterThan(0)
+
     const linked = await Promise.all(cssLinks.map(href => readFile(join(outputDir, 'public', href.replace(/^\//, '')), 'utf-8')))
-    expect([html, ...linked].join('\n')).toContain('--inline-shared-with-js-module-token:shared-with-js-module')
+    expect(linked.join('\n')).toContain('--inline-shared-with-js-module-token:shared-with-js-module')
   })
 
   // https://github.com/nuxt/nuxt/issues/31558


### PR DESCRIPTION
### 🔗 Linked issue

resolves #35255
related #30435, #34950, #34008, #35649

### 📚 Description

this allows shared chunks to be stripped (issue is that shared rolldown chunks have no `facadeModuleId`).