### PR TITLE
fix(nitro): in dev, only add css for islands actually rendered

### DIFF
--- a/packages/nitro-server/src/runtime/handlers/island.ts
+++ b/packages/nitro-server/src/runtime/handlers/island.ts
@@ -17,7 +17,7 @@ import { createSSRContext, rethrowWithResponseHeaders, returnRenderResponse } fr
 import { getSSRRenderer } from '../utils/renderer/build-files'
 import { renderInlineStyles } from '../utils/renderer/inline-styles'
 import { getClientIslandResponse, getServerComponentHTML, getSlotIslandResponse } from '../utils/renderer/islands'
-import { patchDevClientCss } from '../utils/renderer/dev-css'
+import { isStyleOfModule, patchDevClientCss } from '../utils/renderer/dev-css'
 import { recordDevClientCss } from '../utils/renderer/dev-client-css'
 import { prerenderRenderingURLs } from '../utils/cache'
 import { useStorage } from 'nitro/storage'
@@ -167,14 +167,15 @@ async function renderIsland (event: H3Event): Promise<IslandRenderResult> {
     const { styles } = getRequestDependencies(ssrContext, renderer.rendererContext)
 
     const link: Link[] = []
+    const modules = ssrContext.modules ?? []
     for (const resource of Object.values(styles)) {
       // Do not add links to resources that are inlined (vite v5+)
       if ('inline' in getURLQuery(resource.file)) {
         continue
       }
-      // Add CSS links in <head> for CSS files
-      // - in dev mode when rendering an island and the file has scoped styles and is not a page
-      if (resource.file.includes('scoped') && !resource.file.includes('pages/')) {
+      // The dev CSS set covers the whole module graph, so restrict it to the styles of the
+      // components this island rendered.
+      if (isStyleOfModule(resource.file, modules)) {
         link.push({ rel: 'stylesheet', href: renderer.rendererContext.buildAssetsURL(resource.file), crossorigin: '' })
       }
     }

--- a/packages/nitro-server/src/runtime/utils/renderer/dev-css.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/dev-css.ts
@@ -22,3 +22,24 @@ export function patchDevClientCss (event: H3Event, rendererContext: RendererCont
 
   rendererContext.updateManifest(normalizeViteManifest({ ...current, '@vite/client': { ...entry, css } }))
 }
+
+const QUERY_RE = /\?.*$/
+const LEADING_RELATIVE_RE = /^(?:\.\.?\/)+/
+
+/**
+ * Whether a dev stylesheet belongs to one of the modules a render actually used.
+ *
+ * The dev CSS set is the builder's whole module graph, not a per-request subset, so
+ * consumers that must not leak unrelated styles (islands) narrow it with the modules
+ * Vue registered during their own render.
+ */
+export function isStyleOfModule (file: string, modules: Set<string> | string[]): boolean {
+  const path = file.replace(QUERY_RE, '')
+  for (const mod of modules) {
+    const normalized = mod.replace(LEADING_RELATIVE_RE, '')
+    if (normalized && (path === normalized || path.endsWith('/' + normalized))) {
+      return true
+    }
+  }
+  return false
+}

--- a/test/server-components.test.ts
+++ b/test/server-components.test.ts
@@ -262,10 +262,6 @@ describe('component islands', () => {
     const result = await $fetch<NuxtIslandResponse>(islandURL('RouteComponent', { context: { url: '/foo' } }))
 
     result.html = result.html.replace(/ data-island-uid="[^"]*"/g, '')
-    if (isDev) {
-      result.head.link = result.head.link?.filter(l => typeof l.href !== 'string' || (!l.href.includes('_nuxt/components/islands/RouteComponent') && !l.href.includes('PureComponent') /* TODO: fix dev bug triggered by previous fetch of /islands */))
-    }
-
     result.head.link ||= []
     result.head.style ||= []
     delete result.id
@@ -284,10 +280,6 @@ describe('component islands', () => {
 
   it('render async component', async () => {
     const result = await $fetch<NuxtIslandResponse>(islandURL('LongAsyncComponent', { props: { count: 3 } }))
-    if (isDev) {
-      result.head.link = result.head.link?.filter(l => typeof l.href !== 'string' || (!l.href.includes('_nuxt/components/islands/LongAsyncComponent') && !l.href.includes('PureComponent') /* TODO: fix dev bug triggered by previous fetch of /islands */))
-    }
-
     result.head.link ||= []
     result.head.style ||= []
     result.html = result.html.replaceAll(/ (?:data-island-uid|data-island-component)="[^"]*"/g, '')
@@ -342,10 +334,6 @@ describe('component islands', () => {
 
   it('render .server async component', async () => {
     const result = await $fetch<NuxtIslandResponse>(islandURL('AsyncServerComponent', { props: { count: 2 } }))
-    if (isDev) {
-      result.head.link = result.head.link?.filter(l => typeof l.href === 'string' && !l.href.includes('PureComponent') /* TODO: fix dev bug triggered by previous fetch of /islands */ && (!l.href.startsWith('_nuxt/components/islands/') || l.href.includes('AsyncServerComponent')))
-    }
-
     result.head.link ||= []
     result.head.style ||= []
     result.props = {}
@@ -371,13 +359,6 @@ describe('component islands', () => {
   if (!isWebpack) {
     it('render server component with selective client hydration', async () => {
       const result = await $fetch<NuxtIslandResponse>(islandURL('ServerWithClient'))
-      if (isDev) {
-        result.head.link = result.head.link?.filter(l => typeof l.href !== 'string' || (!l.href.includes('_nuxt/components/islands/LongAsyncComponent') && !l.href.includes('PureComponent') /* TODO: fix dev bug triggered by previous fetch of /islands */))
-
-        if (!result.head.link) {
-          delete result.head.link
-        }
-      }
       const { components } = result
       result.components = {}
       result.slots = {}
@@ -449,9 +430,6 @@ describe('component islands', () => {
       expect(result.head.link).toBeUndefined()
       expect(result.head.style).toBeUndefined()
     } else {
-      // TODO: resolve dev bug triggered by earlier fetch of /vueuse-head page
-      // https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/core/runtime/nitro/handlers/renderer.ts#L139
-      result.head.link = result.head.link?.filter(l => typeof l.href !== 'string' || !l.href.includes('SharedComponent'))
       if (result.head.link?.[0]?.href) {
         result.head.link[0].href = result.head.link[0].href.replace(/scoped=[^?&]+/, 'scoped=xxxxx')
       }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this was a small pain (reminded of it in https://github.com/nuxt/nuxt/pull/36047!) - and longstanding. islands gradually accrued inline styles in development, from other vue pages which were rendered at some point.

cc: @huang-julien 