### PR TITLE
docs: fix typos and grammar issues

### DIFF
--- a/docs/1.getting-started/06.styling.md
+++ b/docs/1.getting-started/06.styling.md
@@ -288,7 +288,7 @@ This is an experimental option and you should refer to the Vite documentation an
 
 ## Single File Components (SFC) Styling
 
-One of the best things about Vue and SFC is how great it is at naturally dealing with styling. You can directly write CSS or preprocessor code in the style block of your components file, therefore you will have fantastic developer experience without having to use something like CSS-in-JS. However if you wish to use CSS-in-JS, you can find 3rd party libraries and modules that support it, such as [pinceau](https://github.com/Tahul/pinceau).
+One of the best things about Vue and SFC is how great it is at naturally dealing with styling. You can directly write CSS or preprocessor code in the style block of your components file, therefore you will have a fantastic developer experience without having to use something like CSS-in-JS. However if you wish to use CSS-in-JS, you can find 3rd party libraries and modules that support it, such as [pinceau](https://github.com/Tahul/pinceau).
 
 You can refer to the [Vue docs](https://vuejs.org/api/sfc-css-features) for a comprehensive reference about styling components in SFC.
 
@@ -364,7 +364,7 @@ Refer to the [Vue docs](https://vuejs.org/guide/essentials/class-and-style) for 
 
 ### Dynamic Styles With `v-bind`
 
-You can reference JavaScript variable and expression within your style blocks with the v-bind function.
+You can reference JavaScript variables and expressions within your style blocks with the v-bind function.
 The binding will be dynamic, meaning that if the variable value changes, the style will be updated.
 
 ```vue

--- a/docs/1.getting-started/08.seo-meta.md
+++ b/docs/1.getting-started/08.seo-meta.md
@@ -147,7 +147,7 @@ const title = ref('Hello World')
 </template>
 ```
 
-It's suggested to wrap your components in either a `<Head>` or `<Html>` components as tags will be deduped more intuitively.
+It's suggested to wrap your components in either a `<Head>` or `<Html>` component as tags will be deduped more intuitively.
 
 ::warning
 If you need to duplicate tags across client-server boundaries, apply a `key` attribute on the `<Head>` component.

--- a/docs/1.getting-started/09.transitions.md
+++ b/docs/1.getting-started/09.transitions.md
@@ -25,7 +25,7 @@ export default defineNuxtConfig({
 ```
 
 ::note
-If you are changing layouts as well as page, the page transition you set here will not run. Instead, you should set a [layout transition](/docs/4.x/getting-started/transitions#layout-transitions).
+If you are changing layouts as well as pages, the page transition you set here will not run. Instead, you should set a [layout transition](/docs/4.x/getting-started/transitions#layout-transitions).
 ::
 
 To start adding transition between your pages, add the following CSS to your [`app.vue`](/docs/4.x/directory-structure/app/app):
@@ -389,7 +389,7 @@ const next = computed(() => '/' + (id.value + 1))
 
 ::
 
-The page now applies the `slide-left` transition when going to the next id and `slide-right` for the previous:
+The page now applies the `slide-left` transition when going to the next id and `slide-right` for the previous one:
 
 <video controls class="rounded" poster="https://res.cloudinary.com/nuxt/video/upload/v1665069410/nuxt3/nuxt-dynamic-page-transitions.jpg">
   <source src="https://res.cloudinary.com/nuxt/video/upload/v1665069410/nuxt3/nuxt-dynamic-page-transitions.mp4" type="video/mp4">

--- a/docs/1.getting-started/10.data-fetching.md
+++ b/docs/1.getting-started/10.data-fetching.md
@@ -52,7 +52,7 @@ async function handleFormSubmit () {
 </template>
 ```
 
-In the example above, `useFetch` would make sure that the request would occur in the server and is properly forwarded to the browser. `$fetch` has no such mechanism and is a better option to use when the request is solely made from the browser.
+In the example above, `useFetch` would make sure that the request would occur on the server and is properly forwarded to the browser. `$fetch` has no such mechanism and is a better option to use when the request is solely made from the browser.
 
 ### Suspense
 
@@ -180,7 +180,7 @@ It's developer experience sugar for the most common use case. (You can find out 
 
 :video-accordion{title="Watch a video from Alexander Lichter to dig deeper into the difference between useFetch and useAsyncData" videoId="0X-aOpSGabA"}
 
-There are some cases when using the [`useFetch`](/docs/4.x/api/composables/use-fetch) composable is not appropriate, for example when a CMS or a third-party provide their own query layer. In this case, you can use [`useAsyncData`](/docs/4.x/api/composables/use-async-data) to wrap your calls and still keep the benefits provided by the composable.
+There are some cases when using the [`useFetch`](/docs/4.x/api/composables/use-fetch) composable is not appropriate, for example when a CMS or a third-party provides their own query layer. In this case, you can use [`useAsyncData`](/docs/4.x/api/composables/use-async-data) to wrap your calls and still keep the benefits provided by the composable.
 
 ```vue [app/pages/users.vue]
 <script setup lang="ts">
@@ -576,7 +576,7 @@ If you need to force a refresh when other reactive values change, you can also [
 
 ### Not immediate
 
-The `useFetch` composable will start fetching data the moment is invoked. You may prevent this by setting `immediate: false`, for example, to wait for user interaction.
+The `useFetch` composable will start fetching data the moment it is invoked. You may prevent this by setting `immediate: false`, for example, to wait for user interaction.
 
 With that, you will need both the `status` to handle the fetch lifecycle, and `execute` to start the data fetch.
 

--- a/docs/1.getting-started/12.error-handling.md
+++ b/docs/1.getting-started/12.error-handling.md
@@ -59,7 +59,7 @@ You cannot currently define a server-side handler for these errors, but can rend
 
 You might encounter chunk loading errors due to a network connectivity failure or a new deployment (which invalidates your old, hashed JS chunk URLs). Nuxt provides built-in support for handling chunk loading errors by performing a hard reload when a chunk fails to load during route navigation.
 
-You can change this behavior by setting `experimental.emitRouteChunkError` to `false` (to disable hooking into these errors at all) or to `manual` if you want to handle them yourself. If you want to handle chunk loading errors manually, you can check out the [the automatic implementation](https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/app/plugins/chunk-reload.client.ts) for ideas.
+You can change this behavior by setting `experimental.emitRouteChunkError` to `false` (to disable hooking into these errors at all) or to `manual` if you want to handle them yourself. If you want to handle chunk loading errors manually, you can check out the [automatic implementation](https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/app/plugins/chunk-reload.client.ts) for ideas.
 
 ## Error Page
 

--- a/docs/1.getting-started/13.server.md
+++ b/docs/1.getting-started/13.server.md
@@ -84,7 +84,7 @@ export default defineNuxtConfig({
 ```
 
 ::read-more{to="/docs/4.x/guide/concepts/rendering#hybrid-rendering"}
-Learn about all available route rules are available to customize the rendering mode of your routes.
+Learn about all the route rules available to customize the rendering mode of your routes.
 ::
 
 In addition, there are some route rules (for example, `ssr`, `appMiddleware`, and `noScripts`) that are Nuxt specific to change the behavior when rendering your pages to HTML.

--- a/docs/1.getting-started/15.prerendering.md
+++ b/docs/1.getting-started/15.prerendering.md
@@ -42,7 +42,7 @@ You can now deploy the `.output/public` directory to any static hosting service 
 
 Static and prerender builds also emit `200.html` and `404.html` SPA fallbacks. See [What are 200.html and 404.html?](/docs/4.x/guide/concepts/rendering#what-are-200html-and-404html).
 
-Working of the Nitro crawler:
+How the Nitro crawler works:
 
 1. Load the HTML of your application's root route (`/`), any non-dynamic pages in your `~/pages` directory, and any other routes in the `nitro.prerender.routes` array.
 2. Save the HTML and `_payload.json` to the `~/.output/public/` directory to be served statically.

--- a/docs/1.getting-started/16.deployment.md
+++ b/docs/1.getting-started/16.deployment.md
@@ -123,7 +123,7 @@ Nuxt can be deployed to several cloud providers with a minimal amount of configu
 
 ## Presets
 
-In addition to Node.js servers and static hosting services, a Nuxt project can be deployed with several well-tested presets and minimal amount of configuration.
+In addition to Node.js servers and static hosting services, a Nuxt project can be deployed with several well-tested presets and a minimal amount of configuration.
 
 You can explicitly set the desired preset in the [`nuxt.config.ts`](/docs/4.x/directory-structure/nuxt-config) file:
 

--- a/docs/1.getting-started/17.testing.md
+++ b/docs/1.getting-started/17.testing.md
@@ -831,7 +831,7 @@ We provide built-in support using Playwright within `@nuxt/test-utils`, either p
 
 #### `createPage(url)`
 
-Within `vitest`, `jest` or `cucumber`, you can create a configured Playwright browser instance with `createPage`, and (optionally) point it at a path from the running server. You can find out more about the API methods available in [the Playwright documentation](https://playwright.dev/docs/api/class-page).
+Within `vitest`, `jest` or `cucumber`, you can create a configured Playwright browser instance with `createPage`, and (optionally) point it at a path from the running server. You can find out more about the API methods available in the [Playwright documentation](https://playwright.dev/docs/api/class-page).
 
 ```ts twoslash
 import { createPage } from '@nuxt/test-utils/e2e'

--- a/docs/1.getting-started/17.testing.md
+++ b/docs/1.getting-started/17.testing.md
@@ -93,7 +93,7 @@ We currently ship an environment for unit testing code that needs a [Nuxt](https
 3. If your Nuxt-environment tests live outside `test/nuxt/`, see [TypeScript Support in Tests](#typescript-support-in-tests) to add them to the TypeScript context.
 
 ::tip
-When importing `@nuxt/test-utils` in your vitest config, It is necessary to have `"type": "module"` specified in your `package.json` or rename your vitest config file appropriately.
+When importing `@nuxt/test-utils` in your vitest config, it is necessary to have `"type": "module"` specified in your `package.json` or rename your vitest config file appropriately.
 > i.e., `vitest.config.m{ts,js}`.
 ::
 
@@ -831,7 +831,7 @@ We provide built-in support using Playwright within `@nuxt/test-utils`, either p
 
 #### `createPage(url)`
 
-Within `vitest`, `jest` or `cucumber`, you can create a configured Playwright browser instance with `createPage`, and (optionally) point it at a path from the running server. You can find out more about the API methods available from [in the Playwright documentation](https://playwright.dev/docs/api/class-page).
+Within `vitest`, `jest` or `cucumber`, you can create a configured Playwright browser instance with `createPage`, and (optionally) point it at a path from the running server. You can find out more about the API methods available in [the Playwright documentation](https://playwright.dev/docs/api/class-page).
 
 ```ts twoslash
 import { createPage } from '@nuxt/test-utils/e2e'


### PR DESCRIPTION
### 🔗 Linked issue

### 📚 Description

Fixed typos, grammar and awkward phrasing throughout the pages. Docs cleanup in the `getting-started` section. Just prose, no code or behavior changes.