### PR TITLE
fix(nuxt): correctly detect authority-relative useFetch request URLs

### DIFF
--- a/packages/nuxt/src/app/composables/fetch.ts
+++ b/packages/nuxt/src/app/composables/fetch.ts
@@ -3,6 +3,7 @@ import type { $Fetch, NitroFetchRequest, TypedInternalResponse, AvailableRouterM
 import type { MaybeRef, MaybeRefOrGetter, Ref } from 'vue'
 import { computed, reactive, toValue, watch } from 'vue'
 import { isPlainObject } from '@vue/shared'
+import { hasProtocol } from 'ufo'
 import { hashKey } from '../utils/hash'
 import type { AsyncData, AsyncDataOptions, KeysOf, MultiWatchSources, PickFrom, _Transform } from './asyncData'
 import { useAsyncData } from './asyncData'
@@ -14,6 +15,20 @@ import { alwaysRunFetchOnKeyChange, fetchDefaults } from '#build/nuxt.config.mjs
 import { $fetch as _$fetch } from '#build/fetch'
 
 const $fetch = _$fetch as $Fetch
+
+// Resolve the request against a safe `.invalid` host and check that the host
+// does not change. This catches cases like `//evil.com`, `/\\evil.com`, and
+// URLs with leading whitespace that browsers may resolve to another host.
+const FETCH_REQUEST_SENTINEL_HOST = 'nuxt-request.invalid'
+
+function isAuthorityRelativeRequest (request: unknown): request is string {
+  if (typeof request !== 'string' || hasProtocol(request)) { return false }
+  try {
+    return new URL(request, `https://${FETCH_REQUEST_SENTINEL_HOST}`).host !== FETCH_REQUEST_SENTINEL_HOST
+  } catch {
+    return false
+  }
+}
 
 // support uppercase methods, detail: https://github.com/nuxt/nuxt/issues/22313
 type AvailableRouterMethod<R extends NitroFetchRequest> = _AvailableRouterMethod<R> | Uppercase<_AvailableRouterMethod<R>>
@@ -321,7 +336,7 @@ export const createUseFetch: CreateUseFetch = defineKeyedFunctionFactory<CreateU
 
       const key = computed(() => toValue(fetchOptions.key) || ('$f' + hashKey([autoKey, typeof _request.value === 'string' ? _request.value : '', ...generateOptionSegments(fetchOptions)])))
 
-      if (!fetchOptions.baseURL && typeof _request.value === 'string' && (_request.value[0] === '/' && _request.value[1] === '/')) {
+      if (!fetchOptions.baseURL && isAuthorityRelativeRequest(_request.value)) {
         throw dataDiagnostics.NUXT_E3001({ url: _request.value })
       }
 

--- a/packages/nuxt/src/app/diagnostics/data.ts
+++ b/packages/nuxt/src/app/diagnostics/data.ts
@@ -12,8 +12,8 @@ export const dataDiagnostics = !import.meta.dev
       reporters,
       codes: {
         NUXT_E3001: {
-          why: (p: { url: string }) => `The \`useFetch\` request URL must not start with "//" (received \`${p.url}\`).`,
-          fix: 'Use an absolute URL with a protocol or a relative path instead.',
+          why: (p: { url: string }) => `The \`useFetch\` request URL must not resolve to a different host (received \`${p.url}\`).`,
+          fix: 'Use an absolute URL with a protocol, or a same-origin relative path instead.',
         },
         NUXT_E3002: {
           why: '`useFetch` failed to hash the request body for the cache key.',

--- a/test/nuxt/use-fetch.test.ts
+++ b/test/nuxt/use-fetch.test.ts
@@ -456,6 +456,61 @@ describe('useFetch', () => {
   })
 })
 
+describe('useFetch authority-relative URL guard', () => {
+  function expectAuthorityGuardError (fn: () => unknown) {
+    let error: unknown
+    try {
+      fn()
+    } catch (err) {
+      error = err
+    }
+    expect(error).toBeInstanceOf(Error)
+    expect((error as { code?: string }).code).toBe('NUXT_E3001')
+  }
+
+  // A browser (or `new URL()`) resolves every one of these to a different
+  // host than the page it came from. That happens because browsers read a
+  // leading backslash the same way they read a slash for schemes like http,
+  // and they strip tabs, newlines, and carriage returns before parsing even
+  // starts.
+  const bypassPayloads = [
+    '//evil.com/x',
+    '/\\evil.com/x',
+    '\\\\evil.com/x',
+    '\\/evil.com/x',
+    '///evil.com/x',
+    '/\t/evil.com/x',
+    '\t//evil.com/x',
+    '\n//evil.com/x',
+    '//user:pw@evil.com/x',
+  ]
+
+  it.each(bypassPayloads)('rejects authority-relative request %j', (url) => {
+    const mockFetch = vi.fn().mockResolvedValue({})
+    expectAuthorityGuardError(() => useFetch(url, { $fetch: mockFetch as unknown as typeof $fetch } as any))
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  const allowedPayloads = [
+    '/api/users',
+    'api/users',
+    '/api?x=1',
+    '/api#frag',
+    'https://api.example.com/v1',
+    'http://api.example.com/v1',
+    '/api//users',
+    '/api/%2F/users',
+    '/api/a:b',
+    '/api/../users',
+  ]
+
+  it.each(allowedPayloads)('allows legitimate request %j', async (url) => {
+    const mockFetch = vi.fn().mockResolvedValue({})
+    await useFetch(url, { $fetch: mockFetch as unknown as typeof $fetch } as any)
+    expect(mockFetch).toHaveBeenCalledOnce()
+  })
+})
+
 describe('createUseFetch', () => {
   let scope: EffectScope
   beforeEach(() => {


### PR DESCRIPTION
📚 Description

The check, in `packages/nuxt/src/app/composables/fetch.ts`:

```ts
if (!fetchOptions.baseURL && typeof _request.value === 'string' && (_request.value[0] === '/' && _request.value[1] === '/')) {
  throw dataDiagnostics.NUXT_E3001({ url: _request.value })
}
```

catches a literal `//` prefix, but a browser resolving a relative reference for a special scheme also treats a leading \ the same as /, and strips leading tab/newline/carriage-return characters before parsing. So `/\\evil.com/x`, `\t//evil.com/x` and tab-prefixed variants all resolve to `evil.com/x` exactly like `//evil.com/x` does, but none are caught. The bypass only requires the untrusted text to be at position 0 of the string.

Any fixed, non-empty prefix (`useFetch('/api/products/' + userInput)`) fully prevents it, since the host decision is made once, from the first character, and nothing later can reopen it. Setting an explicit baseURL also fully neutralizes it. 

Server-side is unaffected: Nitro routes /-prefixed strings internally rather than resolving them as a URL, and h3 concatenates rather than resolves backslash-prefixed strings.

This PR replaces the two-character string check with isAuthorityRelativeRequest, which resolves the request string with new URL() against a .invalid sentinel host and compares the resulting host. This delegates to the same URL-parsing algorithm a browser actually uses, so it can't drift out of sync the way a hand-written character check can. Includes unit tests in test/nuxt/use-fetch.test.ts covering the full reject set (9 payloads) and allow set (10 payloads, to guard against false positives on legitimate relative paths).