### PR TITLE
fix(nuxt): validate `scopeId` prop passed to `<NuxtIsland>`

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -183,7 +183,11 @@ const NuxtIsland = defineComponent({
       let html = ssrHTML.value
 
       if (props.scopeId) {
-        html = html.replace(ISLAND_SCOPE_ID_RE, full => full + ' ' + props.scopeId)
+        if (VUE_SCOPE_ID_RE.test(props.scopeId)) {
+          html = html.replace(ISLAND_SCOPE_ID_RE, full => full + ' ' + props.scopeId)
+        } else if (import.meta.dev) {
+          renderDiagnostics.NUXT_E4019({ scopeId: props.scopeId })
+        }
       }
 
       if (import.meta.client && !canLoadClientComponent.value) {

--- a/packages/nuxt/src/app/diagnostics/render.ts
+++ b/packages/nuxt/src/app/diagnostics/render.ts
@@ -99,5 +99,10 @@ export const renderDiagnostics = !import.meta.dev
           fix: (p: { key: string }) => `Declare \`${p.key}\` as a prop on the island, or set \`inheritAttrs: false\` so request input cannot reach the root element.`,
           docs: false,
         },
+        NUXT_E4019: {
+          why: (p: { scopeId: string }) => `\`<NuxtIsland>\` was passed a \`scopeId\` prop that is not a Vue scope attribute (\`${p.scopeId}\`) and it was ignored. The value is inserted into the island's opening tag, so only \`data-v-\` attributes are accepted.`,
+          fix: 'Pass a compiler-generated scope ID such as `data-v-abc123`, or omit the prop.',
+          docs: false,
+        },
       },
     })

--- a/test/nuxt/nuxt-island.test.ts
+++ b/test/nuxt/nuxt-island.test.ts
@@ -277,6 +277,25 @@ describe('runtime server component', () => {
       wrapper.unmount()
     }
   })
+
+  it('should ignore a scopeId that is not a Vue scope attribute', async () => {
+    stubFetchRaw(() => Promise.resolve(islandResponse({
+      id: '123',
+      html: '<div>hello</div>',
+      state: {},
+      head: { link: [], style: [] },
+    })))
+
+    const wrapper = await mountSuspended(NuxtIsland, {
+      props: {
+        name: 'dummyName',
+        scopeId: `x><img src=x onerror="globalThis.__xss=1"><x`,
+      },
+    })
+
+    expect(wrapper.html()).not.toContain('onerror')
+    expect(wrapper.html()).not.toContain('<img')
+  })
 })
 
 describe('client components', () => {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

the only thing that passes this at the moment from server components is the vue compiler, but it's a good idea to validate all the same in case this gets exposed in future