### PR TITLE
feat(nuxt): respect `DO_NOT_TRACK` env var for telemetry

### DIFF
--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -980,7 +980,7 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   )
   options.alias['vue-demi'] = resolve(options.appDir, 'compat/vue-demi')
   options.alias['@vue/composition-api'] = resolve(options.appDir, 'compat/capi')
-  if (options.telemetry !== false && !process.env.NUXT_TELEMETRY_DISABLED && process.env.DO_NOT_TRACK !== '1') {
+  if (options.telemetry !== false && !process.env.NUXT_TELEMETRY_DISABLED && !process.env.DO_NOT_TRACK) {
     options._modules.push('@nuxt/telemetry')
   }
   if (options.experimental.typescriptPlugin) {

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -980,7 +980,7 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   )
   options.alias['vue-demi'] = resolve(options.appDir, 'compat/vue-demi')
   options.alias['@vue/composition-api'] = resolve(options.appDir, 'compat/capi')
-  if (options.telemetry !== false && !process.env.NUXT_TELEMETRY_DISABLED) {
+  if (options.telemetry !== false && !process.env.NUXT_TELEMETRY_DISABLED && process.env.DO_NOT_TRACK !== '1') {
     options._modules.push('@nuxt/telemetry')
   }
   if (options.experimental.typescriptPlugin) {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Today I learned about the `DO_NOT_TRACK` env (https://donottrack.sh/), and I do like the idea, and I think it would be nice to support that initiative.

Let me know if you think we should update the docs as well or not.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
