### PR TITLE
fix(webpack): use file URLs for dev externals on Windows 🤖🤖🤖

### DIFF
--- a/packages/webpack/src/configs/server.ts
+++ b/packages/webpack/src/configs/server.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from 'node:url'
 import { isAbsolute, normalize, resolve } from 'pathe'
 import { directoryToURL, logger, parseNodeModulePath, resolveAlias } from '@nuxt/kit'
 import { resolveModulePath } from 'exsolve'
@@ -9,6 +10,7 @@ import { TsCheckerPlugin, webpack } from '../builder.ts'
 
 const assetPattern = /\.(?:css|s[ca]ss|png|jpe?g|gif|svg|woff2?|eot|ttf|otf|webp|webm|mp4|ogv)(?:\?.*)?$/i
 const VIRTUAL_RE = /^\0?virtual:(?:nuxt:)?/
+const WINDOWS_DRIVE_PATH_RE = /^[a-z]:[\\/]/i
 
 export async function server (ctx: WebpackConfigContext) {
   ctx.name = 'server'
@@ -97,7 +99,9 @@ function serverStandalone (ctx: WebpackConfigContext) {
         try: true,
       })
       if (resolved && isAbsolute(resolved)) {
-        return cb(undefined, resolved)
+        return cb(undefined, ctx.nuxt.options.dev && WINDOWS_DRIVE_PATH_RE.test(resolved)
+          ? pathToFileURL(resolved, { windows: true }).href
+          : resolved)
       }
       return cb(undefined, true)
     }

--- a/packages/webpack/test/server.test.ts
+++ b/packages/webpack/test/server.test.ts
@@ -1,0 +1,93 @@
+import { pathToFileURL } from 'node:url'
+import { resolve } from 'pathe'
+import { describe, expect, it, vi } from 'vitest'
+import '../src/impl.ts'
+import { resolveModulePath } from 'exsolve'
+import { server } from '../src/configs/server.ts'
+import type { WebpackConfigContext } from '../src/utils/config.ts'
+
+vi.mock('exsolve', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('exsolve')>()
+  return {
+    ...actual,
+    resolveModulePath: vi.fn(),
+  }
+})
+
+vi.mock('../src/presets/nuxt.ts', () => ({ nuxt: vi.fn() }))
+vi.mock('../src/presets/node.ts', () => ({ node: vi.fn() }))
+
+async function resolveRuntimeDependency (dev: boolean, resolvedPath: string) {
+  vi.mocked(resolveModulePath).mockReturnValue(resolvedPath)
+
+  const rootDir = resolve('/project')
+  const options = {
+    build: { transpile: [] },
+    dev,
+    dir: { shared: 'shared' },
+    modulesDir: [resolve(rootDir, 'node_modules')],
+    rootDir,
+    sourcemap: { server: false },
+    test: true,
+  }
+  const ctx = {
+    config: {
+      externals: [],
+      output: {},
+    },
+    isDev: dev,
+    nuxt: {
+      options,
+      '~runtimeDependencies': ['runtime-dependency'],
+    },
+    options,
+    userConfig: {},
+  } as unknown as WebpackConfigContext
+
+  await server(ctx)
+
+  const externals = ctx.config.externals
+  if (!Array.isArray(externals)) {
+    throw new TypeError('expected server externals to be an array')
+  }
+  const resolver = externals.at(-1)
+  if (typeof resolver !== 'function') {
+    throw new TypeError('expected server external resolver to be a function')
+  }
+
+  return new Promise<unknown>((resolveResult, reject) => {
+    resolver(
+      {
+        context: resolve(rootDir, 'server'),
+        request: 'runtime-dependency',
+      } as any,
+      (error, result) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolveResult(result)
+        }
+      },
+    )
+  })
+}
+
+describe('server externals', () => {
+  const posixResolvedPath = '/project/node_modules/runtime-dependency/index.mjs'
+  const windowsResolvedPath = 'D:/project/node_modules/runtime-dependency/index.mjs'
+
+  it('uses file URLs for Windows resolved externals in development', async () => {
+    await expect(resolveRuntimeDependency(true, windowsResolvedPath)).resolves.toBe(
+      pathToFileURL(windowsResolvedPath, { windows: true }).href,
+    )
+  })
+
+  it('keeps POSIX resolved external paths unchanged in development', async () => {
+    await expect(resolveRuntimeDependency(true, posixResolvedPath)).resolves.toBe(posixResolvedPath)
+  })
+
+  it('keeps resolved external paths unchanged for production builds', async () => {
+    await expect(resolveRuntimeDependency(false, windowsResolvedPath)).resolves.toBe(windowsResolvedPath)
+    await expect(resolveRuntimeDependency(false, posixResolvedPath)).resolves.toBe(posixResolvedPath)
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #36067

### ❓ Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other

### 📚 Description

Resolved runtime dependencies were externalized as raw absolute paths. That works on POSIX, but in Windows development SSR Rspack emits paths such as D:/project/node_modules/... directly into ESM, where Node interprets d: as an unsupported URL scheme.

This converts Windows drive paths to file URLs only for development builds. POSIX development paths and all production paths remain unchanged because webpack can emit those development externals through CommonJS `require()`, which does not accept `file://` specifiers.

An initial implementation converted every development path; the upstream fixture matrix exposed the POSIX `require('file:///...')` regression. The focused unit tests now cover Windows development conversion, POSIX development preservation, and production preservation.

### 🧪 Testing

- RED: the Windows development assertion receives a raw `D:/...` path on current main
- GREEN: focused Vitest unit tests, including the POSIX regression case
- ESLint on the changed source and test
- @nuxt/webpack-builder package build

### 🤖 Automation disclosure

Prepared and verified through an automated Codex contribution workflow using Nuxt's documented 🤖🤖🤖 opt-in. Verification runs without publishing credentials and requires a real RED → GREEN transition.