### PR TITLE
docs: document reverse proxy path handling

### DIFF
--- a/docs/1.getting-started/16.deployment.md
+++ b/docs/1.getting-started/16.deployment.md
@@ -38,6 +38,20 @@ It respects the following runtime environment variables:
 - `NITRO_HOST` or `HOST` (defaults to `'0.0.0.0'`)
 - `NITRO_SSL_CERT` and `NITRO_SSL_KEY` - if both are present, this will launch the server in HTTPS mode. In the vast majority of cases, this should not be used other than for testing, and the Nitro server should be run behind a reverse proxy like nginx or Cloudflare which terminates SSL.
 
+### Serving the Same Build at Multiple Paths
+
+For a normal subpath deployment, set [`app.baseURL`](/docs/4.x/api/nuxt-config#baseurl) or the `NUXT_APP_BASE_URL` environment variable.
+
+If a reverse proxy deliberately exposes the same rendered page at multiple public paths, Nuxt may replace the browser URL with the path used for server rendering during hydration. You can keep the browser URL by removing the rendered path from the payload in a server plugin:
+
+```ts [app/plugins/preserve-proxy-url.server.ts]
+export default defineNuxtPlugin((nuxtApp) => {
+  delete nuxtApp.payload.path
+})
+```
+
+Use this only when the proxy already handles assets and routing for every public path. Without the rendered path, Nuxt cannot correct a genuine mismatch between the requested URL and the server-rendered route.
+
 ### PM2
 
 [PM2](https://pm2.keymetrics.io/) (Process Manager 2) is a fast and easy solution for hosting your Nuxt application on your server or VM.


### PR DESCRIPTION
### 🔗 Linked issue

Documents the workaround for #21716.

### 📚 Description

Reverse proxies can deliberately expose the same server-rendered page at multiple public paths, but Nuxt then restores the rendering path during hydration. This documents the server plugin that preserves the browser URL, plus when `app.baseURL` is the correct option instead.

Verified against current main by reproducing the hydration redirect and confirming that the documented plugin preserves the public URL.