### PR TITLE
perf(kit): drop `ufo` dependency

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -41,7 +41,6 @@
     "scule": "catalog:build",
     "std-env": "catalog:build",
     "tinyglobby": "catalog:build",
-    "ufo": "catalog:build",
     "unctx": "catalog:build",
     "verkit": "catalog:build"
   },

--- a/packages/kit/src/internal/node-module.ts
+++ b/packages/kit/src/internal/node-module.ts
@@ -1,6 +1,5 @@
 import { fileURLToPath } from 'node:url'
 import { normalize } from 'pathe'
-import { joinURL } from 'ufo'
 import { readPackageJSON } from 'pkg-types'
 import type { PackageJson } from 'pkg-types'
 
@@ -87,7 +86,8 @@ function flattenExports (exports: Exports, parentSubpath = './'): Array<{ subpat
   }
 
   return Object.entries(exports).flatMap(([key, value]) => {
-    const childSubpath = joinURL(parentSubpath, key.startsWith('.') ? key.slice(1) : '')
+    const segment = key.startsWith('.') ? key.slice(1).replace(/^\//, '') : ''
+    const childSubpath = segment ? `${parentSubpath.replace(/\/$/, '')}/${segment}` : parentSubpath
 
     if (typeof value === 'string') {
       return [{ subpath: childSubpath, fsPath: value }]

--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -11,7 +11,6 @@ import { klona } from 'klona'
 import microdiff from 'microdiff'
 import { basename, dirname, join, normalize, relative, resolve } from 'pathe'
 import { resolveModuleURL } from 'exsolve'
-import { withTrailingSlash, withoutTrailingSlash } from 'ufo'
 
 import { directoryToURL } from '../internal/esm.ts'
 import { isLoaderError, loadJiti } from '../internal/jiti.ts'
@@ -228,7 +227,7 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
   // can be told apart from them) and the canonical directory of every local layer.
   const autoScanSources = new Set(localLayers)
   const localLayerDirs = new Set(
-    localLayers.map(dir => canonicalLayerDir(resolve(rootCwd, withoutTrailingSlash(dir)))),
+    localLayers.map(dir => canonicalLayerDir(resolve(rootCwd, dir.replace(/\/$/, '')))),
   )
   // Local layers referenced in the root project's `extends`, in listed order (first = highest
   // priority). Used to reorder the auto-scanned layers so ordering can be driven from
@@ -410,7 +409,7 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
 
   const _layers: LoadedConfigLayer[] = []
   const processedLayers = new Set<string>()
-  const localRelativePaths = new Set(localLayers.map(layer => withoutTrailingSlash(layer)))
+  const localRelativePaths = new Set(localLayers.map(layer => layer.replace(/\/$/, '')))
   for (const layer of layers) {
     // Resolve `rootDir` & `srcDir` of layers
     // Create a shallow copy to avoid mutating the cached ESM config object
@@ -488,6 +487,13 @@ function canonicalLayerDir (path: string): string {
   return normalize(realpathSync(statSync(path).isDirectory() ? path : dirname(path)))
 }
 
+function withTrailingSlash (path: string | undefined): string {
+  if (!path) {
+    return '/'
+  }
+  return path.endsWith('/') ? path : `${path}/`
+}
+
 const LAYER_EXTENDS_ALIASES = ['~~', '@@', '~', '@']
 
 /**
@@ -517,7 +523,7 @@ function reorderLocalLayersByExtends (
   localLayerDirs: Set<string>,
 ) {
   const layerDir = (layer: LoadedConfigLayer) => {
-    const dir = withoutTrailingSlash(layer.config?.rootDir ?? layer.cwd ?? '')
+    const dir = (layer.config?.rootDir ?? layer.cwd ?? '').replace(/\/$/, '')
     try {
       return normalize(realpathSync(dir))
     } catch {

--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -4,7 +4,6 @@ import type { ModuleMeta, ModuleOptions, Nuxt, NuxtConfig, NuxtModule, NuxtOptio
 import { dirname, isAbsolute, join, resolve } from 'pathe'
 import { defu } from 'defu'
 import { resolveModulePath, resolveModuleURL } from 'exsolve'
-import { isRelative } from 'ufo'
 import { readPackageJSON, resolvePackageJSON } from 'pkg-types'
 import { read as readRc, update as updateRc } from 'rc9'
 import { isGreater, satisfies } from 'verkit'
@@ -348,7 +347,7 @@ export async function loadNuxtModuleInstance (nuxtModule: string | NuxtModule, n
   // Import if input is string
   nuxtModule = resolveAlias(nuxtModule, nuxt.options.alias)
 
-  if (isRelative(nuxtModule)) {
+  if (nuxtModule.startsWith('./') || nuxtModule.startsWith('../')) {
     nuxtModule = resolve(nuxt.options.rootDir, nuxtModule)
   }
 

--- a/packages/kit/src/resolve.test.ts
+++ b/packages/kit/src/resolve.test.ts
@@ -1,7 +1,6 @@
 import { stat } from 'node:fs/promises'
 import { describe, expect, it } from 'vitest'
 import { resolve } from 'pathe'
-import { withTrailingSlash } from 'ufo'
 import { loadNuxt } from './loader/nuxt.ts'
 import { findPath, resolveNuxtModule, resolvePath } from './resolve.ts'
 import { defineNuxtModule } from './module/define.ts'
@@ -36,7 +35,7 @@ describe('resolveNuxtModule', () => {
       ]
     `)
 
-    const resolved = await resolveNuxtModule(withTrailingSlash(nuxt.options.rootDir), [
+    const resolved = await resolveNuxtModule(`${nuxt.options.rootDir.replace(/\/$/, '')}/`, [
       ...installedModulePaths,
       '@nuxt/test-utils/module',
     ])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -843,9 +843,6 @@ importers:
       tinyglobby:
         specifier: catalog:build
         version: 0.2.17
-      ufo:
-        specifier: catalog:build
-        version: 1.6.4
       unctx:
         specifier: catalog:build
         version: 3.0.0(magic-string@1.1.0)(oxc-parser@0.143.0)(rolldown@1.2.3)(unplugin@3.3.0(@rspack/core@2.1.7(@swc/helpers@0.5.23))(esbuild@0.28.1)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1)(webpack@5.109.2(cssnano@8.0.2(postcss@8.5.25))(csso@5.0.5)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.25)))


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

another kit perf improvement - this drops `ufo` which was being wrongly used - it's a URL lib but was being used for file path arithmetic 🤦