### PR TITLE
docs: document grouping folders in layout directories

### DIFF
--- a/docs/2.directory-structure/1.app/1.components.md
+++ b/docs/2.directory-structure/1.app/1.components.md
@@ -44,7 +44,7 @@ If you have a component in nested directories such as:
 For clarity, we recommend that the component's filename matches its name. So, in the example above, you could rename `Button.vue` to be `BaseFooButton.vue`.
 ::
 
-If you want to group components in a directory without affecting their name, you can use the parenthesis `(` `)` to name the grouping directory.
+If you want to group components in a directory without affecting their name, you can use the parenthesis `(` `)` to name the grouping directory :badge[v4.6]{color="info" size="xs" class="align-middle"}.
 
 ```bash [Grouping Directory]
 -| components/

--- a/docs/2.directory-structure/1.app/1.components.md
+++ b/docs/2.directory-structure/1.app/1.components.md
@@ -44,7 +44,7 @@ If you have a component in nested directories such as:
 For clarity, we recommend that the component's filename matches its name. So, in the example above, you could rename `Button.vue` to be `BaseFooButton.vue`.
 ::
 
-If you want to group components in a directory without affecting their name, you can use the parenthesis `(` `)` to name the grouping directory :badge[v4.6]{color="info" size="xs" class="align-middle"}.
+If you want to group components in a directory without affecting their name, you can enclose the directory name in parentheses like `(group)` :badge[v4.6]{color="info" size="xs" class="align-middle"}.
 
 ```bash [Grouping Directory]
 -| components/

--- a/docs/2.directory-structure/1.app/1.layouts.md
+++ b/docs/2.directory-structure/1.app/1.layouts.md
@@ -116,7 +116,7 @@ File | Layout Name
 `~/layouts/desktop-base/DesktopBase.vue` | `desktop-base`
 `~/layouts/desktop/Desktop.vue` | `desktop`
 
-If you want to group layouts in a directory without affecting their name, you can use the parenthesis `(` `)` to name the grouping directory :badge[v4.6]{color="info" size="xs" class="align-middle"}.
+If you want to group layouts in a directory without affecting their name, you can enclose the directory name in parentheses like `(group)` :badge[v4.6]{color="info" size="xs" class="align-middle"}.
 
 ```bash [Grouping Directory]
 -| layouts/

--- a/docs/2.directory-structure/1.app/1.layouts.md
+++ b/docs/2.directory-structure/1.app/1.layouts.md
@@ -116,6 +116,22 @@ File | Layout Name
 `~/layouts/desktop-base/DesktopBase.vue` | `desktop-base`
 `~/layouts/desktop/Desktop.vue` | `desktop`
 
+If you want to group layouts in a directory without affecting their name, you can use the parenthesis `(` `)` to name the grouping directory.
+
+```bash [Grouping Directory]
+-| layouts/
+---| desktop/
+-----| (foo)/
+-------| default.vue
+```
+
+... then the layout's name will skip the grouping directory, resulting in:
+
+File | Layout Name
+-- | --
+`~/layouts/desktop/(foo)/default.vue` | `desktop-default`
+`~/layouts/(foo)/default.vue` | `default`
+
 :link-example{to="/docs/4.x/examples/features/layouts"}
 
 ## Changing the Layout Dynamically

--- a/docs/2.directory-structure/1.app/1.layouts.md
+++ b/docs/2.directory-structure/1.app/1.layouts.md
@@ -116,7 +116,7 @@ File | Layout Name
 `~/layouts/desktop-base/DesktopBase.vue` | `desktop-base`
 `~/layouts/desktop/Desktop.vue` | `desktop`
 
-If you want to group layouts in a directory without affecting their name, you can use the parenthesis `(` `)` to name the grouping directory.
+If you want to group layouts in a directory without affecting their name, you can use the parenthesis `(` `)` to name the grouping directory :badge[v4.6]{color="info" size="xs" class="align-middle"}.
 
 ```bash [Grouping Directory]
 -| layouts/

--- a/packages/nuxt/test/naming.test.ts
+++ b/packages/nuxt/test/naming.test.ts
@@ -8,6 +8,10 @@ describe('getNameFromPath', () => {
     'base/base.vue': 'base',
     'base/base-layout.vue': 'base-layout',
     'base-1-layout': 'base-1-layout',
+    '(group)/default.vue': 'default',
+    '(group)/custom.vue': 'custom',
+    'desktop/(group)/default.vue': 'desktop-default',
+    '(group)/desktop/default.vue': 'desktop-default',
   }
   it.each(Object.keys(cases))('correctly deduplicates segments - %s', (filename) => {
     expect(getNameFromPath(filename)).toEqual(cases[filename])


### PR DESCRIPTION
### 🔗 Linked issue / discussion

- Resolves / Follow-up to https://github.com/nuxt/nuxt/discussions/32452
- Follow-up to https://github.com/nuxt/nuxt/pull/35699

### 📚 Description
PR #35699 introduced support for grouping directories using `(...)` syntax for components by updating `resolveComponentNameSegments`. Because layout resolution also uses `getNameFromPath` / `resolveComponentNameSegments`, layouts placed inside grouping directories (such as `layouts/(marketing)/default.vue`) automatically omit the grouping folder from their resolved layout name (resolving to `default`).
As requested in discussion https://github.com/nuxt/nuxt/discussions/32452, this PR:
1. Documents grouping directory support for layouts in `docs/2.directory-structure/1.app/1.layouts.md`.
2. Adds unit test cases in `packages/nuxt/test/naming.test.ts` covering path resolution for grouped layout folders.
### 📝 Checklist
- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
