### PR TITLE
fix(rspack,webpack): respect `inlineStyles` predicate for global css

### DIFF
--- a/packages/webpack/src/configs/client.ts
+++ b/packages/webpack/src/configs/client.ts
@@ -105,7 +105,8 @@ function clientHMR (ctx: WebpackConfigContext) {
 }
 
 function clientOptimization (ctx: WebpackConfigContext) {
-  if (!ctx.nuxt.options.features.inlineStyles) {
+  const inlineStyles = ctx.nuxt.options.features.inlineStyles
+  if (!inlineStyles) {
     return
   }
 
@@ -134,7 +135,7 @@ function clientOptimization (ctx: WebpackConfigContext) {
         const identifier = normalize(module.identifier())
         for (const globalPath of globalCSSPaths) {
           if (identifier.includes(globalPath)) {
-            return true
+            return typeof inlineStyles === 'boolean' ? inlineStyles : inlineStyles(module.identifier())
           }
         }
         return false

--- a/packages/webpack/src/plugins/ssr-styles.ts
+++ b/packages/webpack/src/plugins/ssr-styles.ts
@@ -135,9 +135,9 @@ export class SSRStylesPlugin {
     return str.replace(/[`\\$]/g, m => m === '$' ? '\\$' : `\\${m}`)
   }
 
-  private isBuildAsset (url: string) {
+  private buildAssetPath (url: string) {
     const buildDir = withTrailingSlash(this.nuxt.options.app.buildAssetsDir || '/_nuxt/')
-    return url.startsWith(buildDir)
+    return url.startsWith(buildDir) ? url.slice(buildDir.length) : null
   }
 
   private isPublicAsset (url: string, nitro: ReturnType<typeof useNitro>) {
@@ -170,15 +170,18 @@ export class SSRStylesPlugin {
       const full = match[0]
       const rawUrl = match[2] || ''
       const stripped = rawUrl.replace(/[?#].*$/, '')
+      const quote = match[1] || ''
+      // build assets live within the public directory, so they must be matched first
+      const buildAssetPath = this.buildAssetPath(stripped)
 
-      if (this.isPublicAsset(stripped, nitro)) {
-        needsPublicAsset = true
-        changed = true
-        out += '${publicAssetsURL(' + JSON.stringify(rawUrl) + ')}'
-      } else if (this.isBuildAsset(stripped)) {
+      if (buildAssetPath) {
         needsBuildAsset = true
         changed = true
-        out += '${buildAssetsURL(' + JSON.stringify(rawUrl) + ')}'
+        out += `url(${quote}\${buildAssetsURL(${JSON.stringify(buildAssetPath + rawUrl.slice(stripped.length))})}${quote})`
+      } else if (this.isPublicAsset(stripped, nitro)) {
+        needsPublicAsset = true
+        changed = true
+        out += `url(${quote}\${publicAssetsURL(${JSON.stringify(rawUrl)})}${quote})`
       } else {
         out += this.escapeTemplateLiteral(full)
       }

--- a/packages/webpack/src/utils/postcss.ts
+++ b/packages/webpack/src/utils/postcss.ts
@@ -39,6 +39,7 @@ export async function getPostcssConfig (nuxt: Nuxt) {
   }
 
   const postcssOptions = defu({}, nuxt.options.postcss, {
+    config: false,
     plugins: defaultPlugins,
     sourceMap: nuxt.options.webpack.cssSourceMap,
   })

--- a/test/dynamic-paths.test.ts
+++ b/test/dynamic-paths.test.ts
@@ -20,8 +20,8 @@ describe.skipIf(!runsOncePerBuilderInMatrix)('dynamic paths', () => {
   const publicFiles = ['/public.svg', '/css-only-public-asset.svg']
   const isPublicFile = (base = '/', file: string) => {
     if (isWebpack) {
-      // TODO: webpack does not yet support dynamic static paths
-      expect(publicFiles).toContain(file)
+      // TODO: webpack does not yet apply the base URL to public assets referenced from templates
+      expect(publicFiles).toContain(file.startsWith(base) ? file.replace(base, '/') : file)
       return true
     }
 
@@ -87,6 +87,19 @@ describe.skipIf(!runsOncePerBuilderInMatrix)('dynamic paths', () => {
 
     // TODO: document as breaking change
     expect(await $fetch<string>('/foo/url')).toContain('path: /url')
+  })
+
+  // remove `.fails` when webpack applies the base URL to public assets referenced from templates
+  it.skipIf(!isWebpack).fails('should apply base URL to public assets referenced from templates', async () => {
+    await startServer({
+      env: {
+        NUXT_APP_BASE_URL: '/foo/',
+      },
+    })
+
+    const html = await $fetch<string>('/foo/assets')
+    const sources = Array.from(html.matchAll(/<img[^>]+src="([^"]+)"/g), m => m[1]!)
+    expect(sources).toContain('/foo/public.svg')
   })
 
   it('should allow setting relative baseURL', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this is a grab bag of fixes highlighted by a reproduction provided by the vuetify team in https://github.com/nuxt/nuxt/issues/35941#issuecomment-5292149165 - thank you @j-sek

another fix launched in impound (waiting minimum release age) and another in the PR this is stacked on

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
