### PR TITLE
fix(nuxt): keep page bundle restrictions out of the pages array

### DIFF
--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -723,12 +723,15 @@ export default defineNuxtModule({
       nitroForRouteCoverage = nitro
     })
     function markPagesForRouteRules (pages: NuxtPage[]) {
+      const restrictedPages = new Map<NuxtPage, 'noScripts' | 'spaOnly'>()
       const nitro = nitroForRouteCoverage
-      if (!nitro) { return }
+      if (!nitro) { return restrictedPages }
 
       markPagesCoveredByRouteRule(pages, nitro, {
         isCovered: rules => !!rules.noScripts,
-        mark: (page, covered) => { page._noScripts = covered },
+        mark: (page, covered) => {
+          if (covered) { restrictedPages.set(page, 'noScripts') }
+        },
       })
 
       // server components render on the server by definition, whatever `ssr` says
@@ -737,16 +740,20 @@ export default defineNuxtModule({
         isCovered: rules => rules.ssr === false,
         filter: page => page.mode !== 'server',
         mark: (page, covered, resolvedPath) => {
-          if (covered && page._noScripts) {
+          if (!covered) { return }
+          if (restrictedPages.get(page) === 'noScripts') {
             conflicting.push(resolvedPath)
+            return
           }
-          page._spaOnly = covered && !page._noScripts
+          restrictedPages.set(page, 'spaOnly')
         },
       })
 
       if (conflicting.length) {
         logger.warn(`\`ssr: false\` and \`noScripts\` both apply to ${conflicting.map(path => `\`${path}\``).join(', ')}, which leaves nothing to render the route: the server emits an empty shell and no client bundle is loaded to fill it. Remove one of the two rules.`)
       }
+
+      return restrictedPages
     }
 
     // Add routes template
@@ -756,8 +763,9 @@ export default defineNuxtModule({
       dependsOn: nuxt.options.experimental.scanPageMeta ? ['pages'] : [],
       getContents ({ app }) {
         if (!app.pages) { return ROUTES_HMR_CODE + 'export default []' }
-        markPagesForRouteRules(app.pages)
+        const restrictedPages = markPagesForRouteRules(app.pages)
         const { routes, imports } = normalizeRoutes(app.pages, new Set(), {
+          restrictedPages,
           serverComponentRuntime,
           clientComponentRuntime,
           overrideMeta: !!nuxt.options.experimental.scanPageMeta,

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -513,6 +513,8 @@ type NormalizedRoute = Partial<Record<Exclude<keyof NuxtPage, 'file'>, string>> 
 type NormalizedRouteKeys = (keyof NormalizedRoute)[]
 interface NormalizeRoutesOptions {
   overrideMeta?: boolean
+  /** Pages whose component can only render in one environment, keyed by the stub to use elsewhere. */
+  restrictedPages?: ReadonlyMap<NuxtPage, keyof typeof PAGE_STUBS>
   serverComponentRuntime: string
   clientComponentRuntime: string
 }
@@ -613,7 +615,8 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
       const metaImportName = pageImportName + 'Meta'
       const metaImport = genImport(`${file}?macro=true`, [{ name: 'default', as: metaImportName }])
 
-      const stub = page._noScripts ? PAGE_STUBS.noScripts : page._spaOnly ? PAGE_STUBS.spaOnly : undefined
+      const restriction = options.restrictedPages?.get(page)
+      const stub = restriction ? PAGE_STUBS[restriction] : undefined
       if (stub) {
         metaImports.add(stub.declaration)
       }

--- a/packages/schema/src/types/hooks.ts
+++ b/packages/schema/src/types/hooks.ts
@@ -58,19 +58,6 @@ export interface NuxtPage {
   mode?: 'client' | 'server' | 'all'
   /** @internal */
   _sync?: boolean
-  /**
-   * The page is served by a `noScripts` route rule: its component is excluded
-   * from the client bundle and client-side navigation to it triggers a full
-   * document load.
-   * @internal
-   */
-  _noScripts?: boolean
-  /**
-   * The page is served by an `ssr: false` route rule, so its component is
-   * excluded from the server bundle.
-   * @internal
-   */
-  _spaOnly?: boolean
 }
 
 export type NuxtMiddleware = {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

for server/client-only pages, we were tracking them by adding a private flag to page metadata, but there's no need to do this (and it's risky!)