### PR TITLE
fix(nuxt): hide internal dynamic page meta key behind a symbol

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -180,7 +180,9 @@ export async function augmentPages (routes: NuxtPage[], vfs: Record<string, stri
       const fileContent = vfs[route.file] ?? fs.readFileSync(ctx.fullyResolvedPaths?.has(route.file) ? route.file : await resolvePath(route.file), 'utf-8')
       const routeMeta = getRouteMeta(fileContent, route.file, ctx.extraExtractionKeys, { extractSerializable: ctx.extractSerializable })
       if (route.meta) {
+        const dynamic = [...getDynamicMeta(routeMeta.meta), ...getDynamicMeta(route.meta)]
         routeMeta.meta = defu({}, routeMeta.meta, route.meta)
+        addDynamicMeta(routeMeta.meta, dynamic)
       }
       if (route.rules) {
         routeMeta.rules = defu({}, routeMeta.rules, route.rules)
@@ -233,7 +235,25 @@ const PAGE_META_MACRO_NAMES = new Set(['definePageMeta', 'defineRouteRules'])
 // is what actually identifies calls.
 const HAS_PAGE_MACRO_RE = new RegExp(`\\b(?:${[...PAGE_META_MACRO_NAMES].join('|')})\\b`)
 export const defaultExtractionKeys = ['name', 'path', 'props', 'alias', 'redirect', 'middleware'] as const
-const DYNAMIC_META_KEY = '__nuxt_dynamic_meta_key' as const
+/**
+ * Marks which `definePageMeta` keys could not be statically extracted and must come from the
+ * runtime macro module. A symbol keeps it out of `JSON.stringify`/`Object.keys` snapshots taken by
+ * modules that observe `page.meta`, at the cost of being dropped by key-enumerating helpers
+ * (`defu`, `klona`), so it is re-attached explicitly wherever meta is merged or cloned.
+ */
+const DYNAMIC_META_KEY = Symbol.for('nuxt:dynamic-page-meta')
+
+function getDynamicMeta (meta: Record<PropertyKey, any> | undefined): Set<string> {
+  const dynamic = meta?.[DYNAMIC_META_KEY] as Set<string> | undefined
+  return dynamic ?? new Set<string>()
+}
+
+function addDynamicMeta (meta: Record<PropertyKey, any> | undefined, keys: Iterable<string>) {
+  const dynamic = new Set(keys)
+  if (meta && dynamic.size) {
+    meta[DYNAMIC_META_KEY] = dynamic
+  }
+}
 
 type StaticExpressionWrapper = ESTree.Node & { expression: ESTree.Node }
 
@@ -366,7 +386,7 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
   }
 
   if (cacheKey in extractCache && extractCache[cacheKey]) {
-    return klona(extractCache[cacheKey])
+    return cloneExtractedData(extractCache[cacheKey])
   }
 
   const loader = getLoader(absolutePath)
@@ -497,11 +517,17 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
 
   if (dynamicProperties.size) {
     extractedData.meta ??= {}
-    extractedData.meta[DYNAMIC_META_KEY] = dynamicProperties
+    addDynamicMeta(extractedData.meta, dynamicProperties)
   }
 
   extractCache[cacheKey] = extractedData
-  return klona(extractedData)
+  return cloneExtractedData(extractedData)
+}
+
+function cloneExtractedData (data: Partial<Record<keyof NuxtPage, any>>) {
+  const cloned = klona(data)
+  addDynamicMeta(cloned.meta, getDynamicMeta(data.meta))
+  return cloned
 }
 
 function serializeRouteValue (value: any, skipSerialisation = false) {
@@ -572,11 +598,11 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
   return {
     imports: metaImports,
     routes: genArrayFromRaw(routes.map((page) => {
-      const markedDynamic = page.meta?.[DYNAMIC_META_KEY] as Set<string> | undefined ?? new Set<string>()
+      const markedDynamic = getDynamicMeta(page.meta)
       const metaFiltered: Record<string, any> = {}
       let skipMeta = true
       for (const key in page.meta || {}) {
-        if (key !== DYNAMIC_META_KEY && page.meta![key] !== undefined) {
+        if (page.meta![key] !== undefined) {
           skipMeta = false
           metaFiltered[key] = page.meta![key]
         }

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -49,7 +49,7 @@ definePageMeta({
 
     expect(meta).toStrictEqual({
       meta: {
-        __nuxt_dynamic_meta_key: new Set(['meta']),
+        [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']),
       },
     })
   })
@@ -213,7 +213,7 @@ definePageMeta({ name: 'bar' })
           "/alias",
         ],
         "meta": {
-          "__nuxt_dynamic_meta_key": Set {
+          Symbol(nuxt:dynamic-page-meta): Set {
             "middleware",
             "meta",
           },
@@ -295,7 +295,7 @@ definePageMeta({ name: 'bar' })
     expect(meta).toMatchInlineSnapshot(`
       {
         "meta": {
-          "__nuxt_dynamic_meta_key": Set {
+          Symbol(nuxt:dynamic-page-meta): Set {
             "redirect",
           },
         },
@@ -328,7 +328,7 @@ definePageMeta({ name: 'bar' })
     expect(meta).toMatchInlineSnapshot(`
       {
         "meta": {
-          "__nuxt_dynamic_meta_key": Set {
+          Symbol(nuxt:dynamic-page-meta): Set {
             "middleware",
             "meta",
           },
@@ -357,7 +357,7 @@ definePageMeta({ name: 'bar' })
     expect(meta).toMatchInlineSnapshot(`
       {
         "meta": {
-          "__nuxt_dynamic_meta_key": Set {
+          Symbol(nuxt:dynamic-page-meta): Set {
             "middleware",
           },
         },
@@ -381,7 +381,7 @@ definePageMeta({ name: 'bar' })
     expect(meta).toMatchInlineSnapshot(`
       {
         "meta": {
-          "__nuxt_dynamic_meta_key": Set {
+          Symbol(nuxt:dynamic-page-meta): Set {
             "meta",
           },
         },
@@ -441,7 +441,7 @@ definePageMeta({ name: 'bar' })
     expect(meta).toMatchInlineSnapshot(`
       {
         "meta": {
-          "__nuxt_dynamic_meta_key": Set {
+          Symbol(nuxt:dynamic-page-meta): Set {
             "meta",
           },
         },
@@ -461,7 +461,7 @@ definePageMeta({ name: 'bar' })
     expect(meta).toMatchInlineSnapshot(`
       {
         "meta": {
-          "__nuxt_dynamic_meta_key": Set {
+          Symbol(nuxt:dynamic-page-meta): Set {
             "meta",
           },
         },
@@ -480,7 +480,7 @@ definePageMeta({ name: 'bar' })
     expect(meta).toMatchInlineSnapshot(`
       {
         "meta": {
-          "__nuxt_dynamic_meta_key": Set {
+          Symbol(nuxt:dynamic-page-meta): Set {
             "meta",
           },
         },
@@ -1408,7 +1408,7 @@ definePageMeta({ [name]: 'some-title' })
       `
       expect(macroModule(sfc, extractionKeys)).toContain('[name]: \'some-title\'')
       expect(getRouteMeta(sfc, '/app/pages/computed.vue')).toEqual({
-        meta: { __nuxt_dynamic_meta_key: new Set(['meta']) },
+        meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) },
       })
     })
 
@@ -1422,7 +1422,7 @@ definePageMeta({ layout: { name: 'admin', props: { collapsed: true } } })
       expect(macro).toContain('layout: \'admin\'')
       expect(macro).toContain('layoutProps: { collapsed: true }')
       expect(getRouteMeta(sfc, '/app/pages/layout.vue', new Set(['layout']))).toEqual({
-        meta: { __nuxt_dynamic_meta_key: new Set(['meta']) },
+        meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) },
       })
     })
 
@@ -1455,7 +1455,7 @@ definePageMeta(meta)
       `
       expect(macroModule(sfc, extractionKeys)).toContain('const __nuxt_page_meta = meta')
       expect(getRouteMeta(sfc, '/app/pages/variable.vue')).toEqual({
-        meta: { __nuxt_dynamic_meta_key: new Set(['meta']) },
+        meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) },
       })
     })
 
@@ -1470,7 +1470,7 @@ definePageMeta({ layout: { ...shared, props: { collapsed: true } } })
       expect(macro).toContain('...shared')
       expect(macro).not.toContain('layoutProps')
       expect(getRouteMeta(sfc, '/app/pages/layout-spread.vue')).toEqual({
-        meta: { __nuxt_dynamic_meta_key: new Set(['meta']) },
+        meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) },
       })
     })
 
@@ -1494,7 +1494,7 @@ definePageMeta({ get name () { return 'from-getter' } })
       `
       expect(macroModule(sfc, extractionKeys)).toContain('from-getter')
       expect(getRouteMeta(sfc, '/app/pages/getter.vue')).toEqual({
-        meta: { __nuxt_dynamic_meta_key: new Set(['meta']) },
+        meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) },
       })
     })
   })
@@ -1534,7 +1534,7 @@ definePageMeta({ title: 'hello', validate: () => true })
 </script>
       `
       expect(extract(sfc)).toEqual({
-        meta: { title: 'hello', __nuxt_dynamic_meta_key: new Set(['meta']) },
+        meta: { title: 'hello', [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) },
       })
       expect(macroModule(sfc)).toContain('validate')
     })
@@ -1546,7 +1546,7 @@ definePageMeta({ path: ref('/dynamic') })
 </script>
       `
       expect(extract(sfc)).toEqual({
-        meta: { __nuxt_dynamic_meta_key: new Set(['path']) },
+        meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['path']) },
       })
       expect(macroModule(sfc)).toContain('ref(\'/dynamic\')')
     })
@@ -1568,7 +1568,7 @@ definePageMeta({ title: 'first', title: 'last' })
       const path = '/app/pages/cache-key.vue'
       expect(getRouteMeta(sfc, path, new Set(), options)).toEqual({ meta: { title: 'hello' } })
       expect(getRouteMeta(sfc, path)).toEqual({
-        meta: { __nuxt_dynamic_meta_key: new Set(['meta']) },
+        meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) },
       })
     })
 
@@ -1580,7 +1580,7 @@ definePageMeta({ title: 'first', title: 'last' })
       const updated = `<script setup lang="ts">definePageMeta({ title: 'goodbye' })</script>`
       expect(getRouteMeta(updated, path, new Set(), options)).toEqual({ meta: { title: 'goodbye' } })
       expect(getRouteMeta(updated, path)).toEqual({
-        meta: { __nuxt_dynamic_meta_key: new Set(['meta']) },
+        meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) },
       })
     })
 
@@ -1645,7 +1645,7 @@ definePageMeta({ layout: { name: 'admin', props: { collapsed: true } } as const 
 definePageMeta({ layout: { props: { collapsed: true } } })
 </script>
         `
-        expect(extract(sfc)).toEqual({ meta: { __nuxt_dynamic_meta_key: new Set(['meta']) } })
+        expect(extract(sfc)).toEqual({ meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) } })
         const macro = macroModule(sfc)
         expect(macro).toContain('layoutProps: { collapsed: true }')
         expect(macro).not.toContain('layout:')
@@ -1657,7 +1657,7 @@ definePageMeta({ layout: { props: { collapsed: true } } })
 definePageMeta({ layout: {} })
 </script>
         `
-        expect(extract(sfc)).toEqual({ meta: { __nuxt_dynamic_meta_key: new Set(['meta']) } })
+        expect(extract(sfc)).toEqual({ meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) } })
       })
 
       it('should leave a non-serializable layout name to the macro module', () => {
@@ -1667,7 +1667,7 @@ const layoutName = 'admin'
 definePageMeta({ layout: { name: layoutName } })
 </script>
         `
-        expect(extract(sfc)).toEqual({ meta: { __nuxt_dynamic_meta_key: new Set(['meta']) } })
+        expect(extract(sfc)).toEqual({ meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) } })
         expect(macroModule(sfc)).toContain('layout: layoutName')
       })
 
@@ -1677,7 +1677,7 @@ definePageMeta({ layout: { name: layoutName } })
 definePageMeta({ layout: { name: 'admin', props: { onClick: () => {} } } })
 </script>
         `
-        expect(extract(sfc)).toEqual({ meta: { __nuxt_dynamic_meta_key: new Set(['meta']) } })
+        expect(extract(sfc)).toEqual({ meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) } })
         const macro = macroModule(sfc)
         expect(macro).toContain('layout: \'admin\'')
         expect(macro).toContain('layoutProps: { onClick: () => {} }')
@@ -1690,7 +1690,7 @@ const shared = { name: 'admin' }
 definePageMeta({ layout: { ...shared } })
 </script>
         `
-        expect(extract(sfc)).toEqual({ meta: { __nuxt_dynamic_meta_key: new Set(['meta']) } })
+        expect(extract(sfc)).toEqual({ meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) } })
         expect(macroModule(sfc)).toContain('...shared')
       })
 
@@ -1700,7 +1700,7 @@ definePageMeta({ layout: { ...shared } })
 definePageMeta({ layout: { name: 'admin', other: 1 } })
 </script>
         `
-        expect(extract(sfc)).toEqual({ meta: { __nuxt_dynamic_meta_key: new Set(['meta']) } })
+        expect(extract(sfc)).toEqual({ meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) } })
         expect(macroModule(sfc)).toContain('other: 1')
       })
 

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -432,7 +432,7 @@ describe('pages:relativizeToParent', () => {
 })
 
 describe('page:extends', () => {
-  const DYNAMIC_META_KEY = '__nuxt_dynamic_meta_key' as const
+  const DYNAMIC_META_KEY = Symbol.for('nuxt:dynamic-page-meta')
   it('should preserve distinct metadata for multiple routes referencing the same file', async () => {
     const files: NuxtPage[] = [
       { path: 'home', file: `pages/index.vue` },
@@ -490,7 +490,7 @@ describe('page:extends', () => {
 
 const pagesDir = 'pages'
 const layerDir = 'layer/pages'
-const DYNAMIC_META_KEY = '__nuxt_dynamic_meta_key' as const
+const DYNAMIC_META_KEY = Symbol.for('nuxt:dynamic-page-meta')
 
 export const pageTests: Array<{
   description: string


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this avoids exposing `__nuxt_dynamic_meta_key` in `JSON.stringify`