### PR TITLE
fix(kit): retry CJS-global and alias load failures through jiti

### DIFF
--- a/packages/kit/src/diagnostics/config.ts
+++ b/packages/kit/src/diagnostics/config.ts
@@ -73,9 +73,19 @@ export const configDiagnostics = /* #__PURE__ */ defineDiagnostics({
       fix: (p: { installCommand: string }) => `Run \`${p.installCommand}\` to load it, or remove the \`nuxt.schema\` file.`,
       docs: false,
     },
+    NUXT_B5021: {
+      why: (p: { filePath: string, error: string }) => `The config file \`${p.filePath}\` was loaded as native ESM, which does not provide the CommonJS globals: ${p.error}`,
+      fix: (p: { installCommand: string }) => `Use \`import.meta.url\`, \`import.meta.dirname\` or \`createRequire(import.meta.url)\` from \`node:module\` instead of \`__dirname\`, \`__filename\` and \`require\`. Alternatively, run \`${p.installCommand}\` and Nuxt will load the file through jiti, which provides them.`,
+      docs: false,
+    },
     NUXT_B5022: {
       why: 'A `nuxt.config` in yaml, toml, jsonc or json5 is parsed by the `confbox` package, which is not installed.',
       fix: (p: { installCommand: string }) => `Run \`${p.installCommand}\`, or rename your config to \`nuxt.config.ts\`.`,
+      docs: false,
+    },
+    NUXT_B5023: {
+      why: (p: { filePath: string, error: string }) => `The config file \`${p.filePath}\` was loaded through jiti because the runtime could not load it: ${p.error}`,
+      fix: 'Loading it natively is faster, as jiti has to transform the file first. Relative imports need an explicit file extension, and `import.meta.dirname` replaces `__dirname`.',
       docs: false,
     },
   },

--- a/packages/kit/src/diagnostics/kit-api.ts
+++ b/packages/kit/src/diagnostics/kit-api.ts
@@ -119,5 +119,10 @@ export const kitDiagnostics = /* #__PURE__ */ defineDiagnostics({
       fix: 'Add `oxc-parser` to your project; every supported version of Nuxt already ships a package that can be used here.',
       docs: false,
     },
+    NUXT_B8023: {
+      why: (p: { module: string, error: string }) => `The module \`${p.module}\` was loaded through jiti because the runtime could not load it: ${p.error}`,
+      fix: 'Loading it natively is faster, as jiti has to transform the module first. Report it to the module author if the module is not your own.',
+      docs: false,
+    },
   },
 })

--- a/packages/kit/src/internal/jiti.ts
+++ b/packages/kit/src/internal/jiti.ts
@@ -1,5 +1,6 @@
-import { realpathSync } from 'node:fs'
+import { readFileSync, realpathSync } from 'node:fs'
 import { pathToFileURL } from 'node:url'
+import { dirname, join } from 'pathe'
 import { resolveModulePath } from 'exsolve'
 import { directoryToURL } from './esm.ts'
 import { ensureDependencyInstalled } from '../dependency.ts'
@@ -17,7 +18,13 @@ const LOADER_ERROR_CODES = new Set([
   'ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING',
   'ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX',
   'ERR_REQUIRE_ESM',
+  'ERR_PACKAGE_IMPORT_NOT_DEFINED',
+  'ERR_PACKAGE_PATH_NOT_EXPORTED',
 ])
+
+// Anchored so an identifier ending in one of these (`myrequire`) cannot match. Only the prefix is
+// fixed, as the tail varies by node version and by binding.
+const CJS_GLOBAL_ERROR_RE = /^(__dirname|__filename|require|module|exports) is not defined\b/
 
 /**
  * Whether a failed `import()` failed because the runtime would not load the file, rather than
@@ -31,6 +38,98 @@ const LOADER_ERROR_CODES = new Set([
 export function isLoaderError (error: unknown): boolean {
   const { code } = (error ?? {}) as { code?: unknown }
   return typeof code === 'string' && LOADER_ERROR_CODES.has(code)
+}
+
+/**
+ * The CJS global a failed `import()` reached for, or `undefined` if it failed for another reason.
+ * Unlike {@link isLoaderError} the file was loaded and threw on its own, but jiti supplies these
+ * globals so a retry is still worthwhile.
+ *
+ * Only covers the error raised while the module is evaluated: a `require()` inside a function
+ * called later throws long after the import settled.
+ *
+ * @param error the error the failed `import()` rejected with
+ */
+export function getMissingCjsGlobal (error: unknown): string | undefined {
+  const { name, message } = (error ?? {}) as { name?: unknown, message?: unknown }
+  if (name !== 'ReferenceError' || typeof message !== 'string') {
+    return undefined
+  }
+  return CJS_GLOBAL_ERROR_RE.exec(message)?.[1]
+}
+
+const DEPENDENCY_FIELDS = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'] as const
+const declaredJitiCache = new Map<string, boolean>()
+const nuxtJitiCache = new Map<string, boolean>()
+const reportedFallbacks = new Set<string>()
+
+/**
+ * Whether to tell the user that `filePath` was loaded through jiti rather than by the runtime, and
+ * record that they have been told.
+ *
+ * Returns `true` at most once per file, so a dev server reloading a config does not repeat itself.
+ * Silent only where jiti is not something the project could lose.
+ *
+ * @param filePath the file that had to be loaded through jiti
+ * @param rootDir project root, where the search for a declared `jiti` starts
+ * @param compatibilityVersion resolved `future.compatibilityVersion`
+ */
+export function shouldReportJitiFallbackOnce (filePath: string, rootDir: string, compatibilityVersion: number): boolean {
+  if (reportedFallbacks.has(filePath) || jitiIsGuaranteed(rootDir, compatibilityVersion)) {
+    return false
+  }
+  reportedFallbacks.add(filePath)
+  return true
+}
+
+function jitiIsGuaranteed (rootDir: string, compatibilityVersion: number): boolean {
+  if (declaresJiti(rootDir)) {
+    return true
+  }
+  // Nuxt 4 depends on jiti, so a project on its defaults cannot lose it. Asking for the v5 defaults
+  // is asking for the Nuxt that will not.
+  return compatibilityVersion < 5 && nuxtDependsOnJiti(rootDir)
+}
+
+function readDependencies (path: string): Record<string, Record<string, string> | undefined> | undefined {
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8'))
+  } catch {
+    // an unreadable or missing `package.json` says nothing either way
+    return undefined
+  }
+}
+
+// Walks to the filesystem root, so that a monorepo declaring `jiti` once for every package in the
+// workspace counts as having opted in
+function declaresJiti (dir: string): boolean {
+  let declared = declaredJitiCache.get(dir)
+  if (declared === undefined) {
+    declared = false
+    for (let current = dir, parent = dirname(dir); ; current = parent, parent = dirname(current)) {
+      const pkg = readDependencies(join(current, 'package.json'))
+      if (DEPENDENCY_FIELDS.some(field => !!pkg?.[field]?.jiti)) {
+        declared = true
+        break
+      }
+      if (parent === current) {
+        break
+      }
+    }
+    declaredJitiCache.set(dir, declared)
+  }
+  return declared
+}
+
+function nuxtDependsOnJiti (dir: string): boolean {
+  let depends = nuxtJitiCache.get(dir)
+  if (depends === undefined) {
+    const from = directoryToURL(dir)
+    const path = resolveModulePath('nuxt/package.json', { from, try: true }) ?? resolveModulePath('nuxt-nightly/package.json', { from, try: true })
+    depends = !!path && !!readDependencies(path)?.dependencies?.jiti
+    nuxtJitiCache.set(dir, depends)
+  }
+  return depends
 }
 
 export interface LoadJitiOptions {

--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -13,7 +13,7 @@ import { basename, dirname, join, normalize, relative, resolve } from 'pathe'
 import { resolveModuleURL } from 'exsolve'
 
 import { directoryToURL } from '../internal/esm.ts'
-import { isLoaderError, loadJiti } from '../internal/jiti.ts'
+import { getMissingCjsGlobal, isLoaderError, loadJiti, shouldReportJitiFallbackOnce } from '../internal/jiti.ts'
 import type { Jiti } from '../internal/jiti.ts'
 import { configDiagnostics } from '../diagnostics/config.ts'
 import { ensureDependencyInstalled, getAddDependencyCommand } from '../dependency.ts'
@@ -257,16 +257,34 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
   // `layers/` and also listed in `extends`) to avoid merging them twice (#34667)
   const seenLayerDirs = new Set<string>()
 
-  // Import config files with the runtime's own loader, falling back to jiti only for files it
-  // cannot load. This stands in for the equivalent fallback inside `c12` so that `jiti` is looked
+  // Import config files with the runtime's own loader, falling back to jiti for anything it will
+  // not load. This stands in for the equivalent fallback inside `c12` so that `jiti` is looked
   // for in the project as well as alongside `@nuxt/kit`, and so that a missing `jiti` is reported
   // with an install command. Resolved once per load, so a project without `jiti` is asked at most
   // once however many layers it has.
   let jitiPromise: Promise<Jiti | undefined> | undefined
+  // Looking for jiti can mean offering to install it, so that is reserved for a failure jiti is
+  // expected to fix; an ordinary mistake in a config file must never lead to a dependency prompt
+  const getJiti = async (install: boolean) => {
+    jitiPromise ??= loadJiti({ rootDir: rootCwd, install }).then(mod => mod?.createJiti(join(rootCwd, 'nuxt.config'), {
+      interopDefault: true,
+      moduleCache: false,
+      extensions: [...CONFIG_EXTENSIONS],
+    }))
+    const jiti = await jitiPromise
+    // a lookup that was not allowed to install says nothing about one that is
+    if (!jiti && !install) {
+      jitiPromise = undefined
+    }
+    return jiti
+  }
   // Set once the runtime has turned a config file down. Every later layer in the same load is
   // likely to be written the same way, so go straight to jiti rather than paying a failed import
   // for each one
   let jitiImporter: ((id: string) => Promise<unknown>) | undefined
+  // Reported once `future.compatibilityVersion` is known, since that is part of deciding whether
+  // loading through jiti is worth mentioning at all
+  const jitiFallbacks: Array<{ filePath: string, error: string }> = []
 
   const importConfigFile = async (id: string) => {
     if (jitiImporter) {
@@ -279,27 +297,42 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
     try {
       return await import(url.href)
     } catch (error) {
-      // A config file that threw while it was running has already had whatever effect it had, and
-      // jiti would only run it a second time and report its own error in place of the author's
-      if (!isLoaderError(error)) {
-        throw error
-      }
-      jitiPromise ??= loadJiti({ rootDir: rootCwd }).then(mod => mod?.createJiti(join(rootCwd, 'nuxt.config'), {
-        interopDefault: true,
-        moduleCache: false,
-        extensions: [...CONFIG_EXTENSIONS],
-      }))
-      const jiti = await jitiPromise
+      const missingGlobal = getMissingCjsGlobal(error)
+      // Whether jiti is the answer, or the file simply has a bug that a second loader will repeat
+      const jitiCanHelp = isLoaderError(error) || !!missingGlobal
+      // A config file is evaluated for its default export, so any failure is worth a second attempt
+      const jiti = await getJiti(jitiCanHelp)
       if (!jiti) {
-        throw configDiagnostics.NUXT_B5017({
+        if (!jitiCanHelp) {
+          throw error
+        }
+        const diagnostic = missingGlobal ? configDiagnostics.NUXT_B5021 : configDiagnostics.NUXT_B5017
+        throw diagnostic({
           filePath: id,
           error: error instanceof Error ? error.message : String(error),
           installCommand: await getAddDependencyCommand('jiti', rootCwd, { dev: true }),
           cause: error,
         })
       }
-      jitiImporter = id => jiti.import(id)
-      return jitiImporter(id)
+
+      let loaded: unknown
+      try {
+        loaded = await jiti.import(id)
+      } catch (jitiError) {
+        // jiti's error is only the better one where jiti was expected to get further; a repeat of
+        // the same failure keeps the native error and its untransformed stack
+        const repeated = missingGlobal && getMissingCjsGlobal(jitiError) === missingGlobal
+        throw jitiCanHelp && !repeated ? jitiError : error
+      }
+
+      jitiFallbacks.push({
+        filePath: id,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      if (isLoaderError(error)) {
+        jitiImporter = id => jiti.import(id)
+      }
+      return loaded
     }
   }
 
@@ -492,6 +525,12 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
 
   // Resolve and apply defaults
   const options = await applyDefaults(NuxtConfigSchema, nuxtConfig as NuxtConfig & Record<string, JSValue>) as unknown as NuxtOptions
+
+  for (const fallback of jitiFallbacks) {
+    if (shouldReportJitiFallbackOnce(fallback.filePath, options.rootDir, options.future.compatibilityVersion)) {
+      configDiagnostics.NUXT_B5023(fallback)
+    }
+  }
 
   if (opts.onConfigResolved) {
     await opts.onConfigResolved({

--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -14,7 +14,7 @@ import { useNuxt } from '../context.ts'
 import { resolveAlias } from '../resolve.ts'
 import { getLayerDirectories } from '../layers.ts'
 import { getAddDependencyCommand } from '../dependency.ts'
-import { isLoaderError, loadJiti } from '../internal/jiti.ts'
+import { getMissingCjsGlobal, isLoaderError, loadJiti, shouldReportJitiFallbackOnce } from '../internal/jiti.ts'
 import type { Jiti } from '../internal/jiti.ts'
 import { kitDiagnostics } from '../diagnostics/kit-api.ts'
 import { DEFAULT_JS_FILE_EXTENSIONS } from '../constants.ts'
@@ -295,17 +295,28 @@ let _jitiCache: WeakMap<Nuxt, Promise<Jiti | undefined>> | undefined
  * Needed only for module sources the runtime cannot import itself (TypeScript that cannot be
  * type-stripped, CJS interop, alias-prefixed imports). Cached per Nuxt instance so at most one
  * install prompt is shown per build.
+ *
+ * @param nuxt the Nuxt instance the jiti instance is scoped to
+ * @param install whether looking for jiti may extend to offering to install it, which is only
+ * appropriate where jiti is expected to be the answer
  */
-function getSharedJiti (nuxt: Nuxt): Promise<Jiti | undefined> {
+async function getSharedJiti (nuxt: Nuxt, install: boolean): Promise<Jiti | undefined> {
   _jitiCache ||= new WeakMap()
-  let jiti = _jitiCache.get(nuxt)
-  if (!jiti) {
-    jiti = loadJiti({ rootDir: nuxt.options.rootDir, searchPaths: nuxt.options.modulesDir })
+  let promise = _jitiCache.get(nuxt)
+  if (!promise) {
+    promise = loadJiti({ rootDir: nuxt.options.rootDir, searchPaths: nuxt.options.modulesDir, install })
       .then(mod => mod?.createJiti(nuxt.options.rootDir, { alias: nuxt.options.alias }))
-    _jitiCache.set(nuxt, jiti)
+    _jitiCache.set(nuxt, promise)
+  }
+  const jiti = await promise
+  // a lookup that was not allowed to install says nothing about one that is
+  if (!jiti && !install) {
+    _jitiCache.delete(nuxt)
   }
   return jiti
 }
+
+const CJS_GLOBALS_HINT = 'The file was loaded as native ESM, which does not provide the CommonJS globals `__dirname`, `__filename`, `require`, `module` or `exports`. Use `import.meta.url`, `import.meta.dirname` and `createRequire(import.meta.url)` from `node:module` instead.'
 
 /**
  * Explain a failed native import in terms of what the author can change. The runtime supports
@@ -313,6 +324,9 @@ function getSharedJiti (nuxt: Nuxt): Promise<Jiti | undefined> {
  * will not do.
  */
 function describeNativeImportFailure (error: unknown): string {
+  if (getMissingCjsGlobal(error)) {
+    return CJS_GLOBALS_HINT
+  }
   switch ((error as { code?: string } | undefined)?.code) {
     case 'ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING': {
       return 'Published packages cannot ship TypeScript entrypoints, because the runtime does not strip types under `node_modules`. Ask the author to publish compiled JavaScript.'
@@ -373,15 +387,15 @@ export async function loadNuxtModuleInstance (nuxtModule: string | NuxtModule, n
   try {
     resolvedNuxtModule = await import(src).then(r => interopDefault(r))
   } catch (nativeError: unknown) {
-    // A module that threw while it was running has already had whatever effect it had, and jiti
-    // would only run it a second time and report its own error in place of the author's
-    if (!isLoaderError(nativeError)) {
-      throw kitDiagnostics.NUXT_B8018({ module: nuxtModule, error: String(nativeError), cause: nativeError })
-    }
-    // Otherwise the runtime declined to load the file: syntax that is not erasable, a file under
-    // `node_modules`, or an unresolved specifier. Retry through jiti if it is available.
-    const jiti = await getSharedJiti(nuxt)
+    const missingGlobal = getMissingCjsGlobal(nativeError)
+    // Whether jiti is the answer, or the module simply has a bug a second loader will repeat
+    const jitiCanHelp = isLoaderError(nativeError) || !!missingGlobal
+    // A module is a function Nuxt calls later, so evaluating one twice repeats no work of its own
+    const jiti = await getSharedJiti(nuxt, jitiCanHelp)
     if (!jiti) {
+      if (!jitiCanHelp) {
+        throw kitDiagnostics.NUXT_B8018({ module: nuxtModule, error: String(nativeError), cause: nativeError })
+      }
       throw kitDiagnostics.NUXT_B8020({
         module: nuxtModule,
         error: nativeError instanceof Error ? nativeError.message : String(nativeError),
@@ -393,7 +407,17 @@ export async function loadNuxtModuleInstance (nuxtModule: string | NuxtModule, n
     try {
       resolvedNuxtModule = await jiti.import<NuxtModule<any>>(src, { default: true })
     } catch (error: unknown) {
-      throw kitDiagnostics.NUXT_B8018({ module: nuxtModule, error: String(error), cause: error })
+      // jiti's error is only the better one where jiti was expected to get further; a repeat of the
+      // same failure keeps the native error and its untransformed stack
+      const repeated = missingGlobal && getMissingCjsGlobal(error) === missingGlobal
+      const reported = jitiCanHelp && !repeated ? error : nativeError
+      throw kitDiagnostics.NUXT_B8018({ module: nuxtModule, error: String(reported), cause: reported })
+    }
+    if (shouldReportJitiFallbackOnce(resolvedModulePath, nuxt.options.rootDir, nuxt.options.future?.compatibilityVersion ?? 4)) {
+      kitDiagnostics.NUXT_B8023({
+        module: nuxtModule,
+        error: nativeError instanceof Error ? nativeError.message : String(nativeError),
+      })
     }
   }
 

--- a/packages/kit/test/jiti-fallback.spec.ts
+++ b/packages/kit/test/jiti-fallback.spec.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import process from 'node:process'
 import { fileURLToPath, pathToFileURL } from 'node:url'
@@ -15,23 +15,45 @@ const jitiInternal = pathToFileURL(join(repoRoot, 'packages/kit/src/internal/jit
  * below are resolved by vite and never reach the runtime paths being tested.
  */
 const CLASSIFY = `const [entry, target] = process.argv.slice(-2)
-const { isLoaderError } = await import(entry)
+const { isLoaderError, getMissingCjsGlobal } = await import(entry)
 try {
   await import(target)
   console.log(JSON.stringify({ imported: true }))
 } catch (error) {
-  console.log(JSON.stringify({ code: error.code, isLoaderError: isLoaderError(error) }))
+  console.log(JSON.stringify({ code: error.code, isLoaderError: isLoaderError(error), missingCjsGlobal: getMissingCjsGlobal(error) ?? null }))
 }`
 
-const LOAD_MODULE = `const [entry, cwd, id] = process.argv.slice(-3)
+const LOAD_CONFIG = `const [entry, cwd] = process.argv.slice(-2)
 const kit = await import(entry)
-const nuxt = { options: { rootDir: cwd, alias: {}, modulesDir: [cwd + '/node_modules'] } }
 try {
-  const { nuxtModule } = await kit.loadNuxtModuleInstance(id, nuxt)
+  const config = await kit.loadNuxtConfig({ cwd })
+  console.log(JSON.stringify({ ok: true, value: config.runtimeConfig?.value ?? null }))
+} catch (error) {
+  console.log(JSON.stringify({ ok: false, code: error.code, message: error.message, fix: error.fix }))
+}`
+
+const LOAD_MODULE = `const [entry, cwd, id, options] = process.argv.slice(-4)
+const kit = await import(entry)
+const { alias, loads } = JSON.parse(options)
+const nuxt = { options: { rootDir: cwd, alias, modulesDir: [cwd + '/node_modules'] } }
+try {
+  let nuxtModule
+  for (let i = 0; i < loads; i++) {
+    ;({ nuxtModule } = await kit.loadNuxtModuleInstance(id, nuxt))
+  }
   console.log(JSON.stringify({ ok: true, module: typeof nuxtModule }))
 } catch (error) {
-  console.log(JSON.stringify({ ok: false, code: error.code, message: error.message }))
+  console.log(JSON.stringify({ ok: false, code: error.code, message: error.message, fix: error.fix }))
 }`
+
+const USES_DIRNAME = `export default { runtimeConfig: { value: __dirname ? 'ok' : 'no' } }\n`
+
+// Throws a different message on each evaluation, so a retry is distinguishable from a single run
+const COUNTED_THROW = `import { appendFileSync, readFileSync } from 'node:fs'
+const log = new URL('./runs.log', import.meta.url)
+appendFileSync(log, '.')
+throw new Error(\`run \${readFileSync(log, 'utf-8').length}\`)
+`
 
 function output (stdout: string, stderr: string) {
   const line = stdout.trim().split('\n').at(-1)
@@ -41,8 +63,12 @@ function output (stdout: string, stderr: string) {
   return JSON.parse(line)
 }
 
+const BLOCK_JITI = `import { register } from 'node:module'
+register('data:text/javascript,export async function resolve (specifier, context, next) { if (specifier === \\'jiti\\') { throw new Error(\\'jiti is unavailable\\') } return next(specifier, context) }')`
+
 describe('jiti fallback', { sequential: true }, () => {
   let dir: string
+  let blockJiti: string
 
   beforeAll(async () => {
     dir = await mkdtemp(join(tmpdir(), 'kit-loader-error-'))
@@ -51,6 +77,13 @@ describe('jiti fallback', { sequential: true }, () => {
     await writeFile(join(dir, 'extensionless-import.ts'), 'import { nested } from \'./nested\'\nexport default () => nested\n')
     await writeFile(join(dir, 'json-import.ts'), 'import pkg from \'./package.json\'\nexport default () => pkg\n')
     await writeFile(join(dir, 'throws.ts'), 'throw new Error(\'boom\')\n')
+    await writeFile(join(dir, 'dirname.ts'), 'const here = __dirname\nexport default () => here\n')
+    await writeFile(join(dir, 'requires.ts'), 'const pkg = require(\'./package.json\')\nexport default () => pkg\n')
+    await writeFile(join(dir, 'unrelated-reference.ts'), 'export default () => 1\nmy__dirname\n')
+    await writeFile(join(dir, 'alias-import.ts'), 'import { nested } from \'#shared/nested.ts\'\nexport default () => nested\n')
+
+    blockJiti = pathToFileURL(join(dir, 'block-jiti.mjs')).href
+    await writeFile(join(dir, 'block-jiti.mjs'), BLOCK_JITI)
 
     await mkdir(join(dir, 'node_modules'), { recursive: true })
   })
@@ -65,17 +98,51 @@ describe('jiti fallback', { sequential: true }, () => {
     return output(stdout, stderr) as { imported?: boolean, code?: string, isLoaderError?: boolean }
   }
 
-  async function loadModule (file: string) {
-    const { stdout, stderr } = await exec(process.execPath, ['--input-type=module', '-e', LOAD_MODULE, '--', kitEntry, dir, join(dir, file)], {
+  async function loadModule (file: string, options: { alias?: Record<string, string>, loads?: number } = {}) {
+    const args = JSON.stringify({ alias: {}, loads: 1, ...options })
+    const { stdout, stderr } = await exec(process.execPath, ['--input-type=module', '-e', LOAD_MODULE, '--', kitEntry, dir, join(dir, file), args], {
       nodeOptions: { cwd: dir },
     })
-    return output(stdout, stderr) as { ok: boolean, module?: string, code?: string, message?: string }
+    return { ...output(stdout, stderr), logs: stdout + stderr } as { ok: boolean, module?: string, code?: string, message?: string, logs: string }
+  }
+
+  async function loadConfig (cwd: string, args: string[] = []) {
+    const { stdout, stderr } = await exec(process.execPath, ['--input-type=module', ...args, '-e', LOAD_CONFIG, '--', kitEntry, cwd], {
+      nodeOptions: { cwd },
+    })
+    return { ...output(stdout, stderr), logs: stdout + stderr } as { ok: boolean, value?: string | null, code?: string, message?: string, fix?: string, logs: string }
+  }
+
+  function loadConfigWithoutJiti (cwd: string) {
+    return loadConfig(cwd, ['--import', blockJiti])
+  }
+
+  async function configFixture (name: string, source: string, pkg: Record<string, unknown> = {}) {
+    const cwd = join(dir, 'configs', name)
+    await mkdir(cwd, { recursive: true })
+    await writeFile(join(cwd, 'package.json'), JSON.stringify({ name: `config-${name}`, private: true, type: 'module', ...pkg }))
+    await writeFile(join(cwd, 'nuxt.config.ts'), source)
+    return cwd
+  }
+
+  async function installFakeNuxt (cwd: string, dependencies: Record<string, string>) {
+    const nuxtDir = join(cwd, 'node_modules', 'nuxt')
+    await mkdir(nuxtDir, { recursive: true })
+    await writeFile(join(nuxtDir, 'package.json'), JSON.stringify({ name: 'nuxt', version: '4.0.0', dependencies }))
+  }
+
+  async function loadModuleWithoutJiti (file: string) {
+    const { stdout, stderr } = await exec(process.execPath, ['--input-type=module', '--import', blockJiti, '-e', LOAD_MODULE, '--', kitEntry, dir, join(dir, file), JSON.stringify({ alias: {}, loads: 1 })], {
+      nodeOptions: { cwd: dir },
+    })
+    return output(stdout, stderr) as { ok: boolean, code?: string, message?: string, fix?: string }
   }
 
   it('should classify an extensionless import within a natively loadable entry as a loader error', async () => {
     await expect(classify('extensionless-import.ts')).resolves.toStrictEqual({
       code: 'ERR_MODULE_NOT_FOUND',
       isLoaderError: true,
+      missingCjsGlobal: null,
     })
   })
 
@@ -83,11 +150,12 @@ describe('jiti fallback', { sequential: true }, () => {
     await expect(classify('json-import.ts')).resolves.toStrictEqual({
       code: 'ERR_IMPORT_ATTRIBUTE_MISSING',
       isLoaderError: true,
+      missingCjsGlobal: null,
     })
   })
 
   it('should not classify an error the file itself threw as a loader error', async () => {
-    await expect(classify('throws.ts')).resolves.toStrictEqual({ isLoaderError: false })
+    await expect(classify('throws.ts')).resolves.toStrictEqual({ isLoaderError: false, missingCjsGlobal: null })
   })
 
   it('should load a module whose nested import the runtime cannot resolve', async () => {
@@ -96,6 +164,158 @@ describe('jiti fallback', { sequential: true }, () => {
 
   it('should load a module importing JSON without an import attribute', async () => {
     await expect(loadModule('json-import.ts')).resolves.toMatchObject({ ok: true, module: 'function' })
+  }, 60_000)
+
+  it('should name the missing CJS global without treating it as a loader error', async () => {
+    await expect(classify('dirname.ts')).resolves.toStrictEqual({ isLoaderError: false, missingCjsGlobal: '__dirname' })
+    await expect(classify('requires.ts')).resolves.toStrictEqual({ isLoaderError: false, missingCjsGlobal: 'require' })
+  })
+
+  it('should not classify an unrelated ReferenceError as a missing CJS global', async () => {
+    await expect(classify('unrelated-reference.ts')).resolves.toStrictEqual({ isLoaderError: false, missingCjsGlobal: null })
+  })
+
+  it('should load a module using `__dirname` through jiti', async () => {
+    await expect(loadModule('dirname.ts')).resolves.toMatchObject({ ok: true, module: 'function' })
+  }, 60_000)
+
+  it('should warn that a module was loaded through jiti', async () => {
+    const result = await loadModule('dirname.ts')
+    expect(result.logs).toContain('NUXT_B8023')
+    expect(result.logs).toContain('__dirname is not defined')
+  }, 60_000)
+
+  it('should not warn when a module loads natively', async () => {
+    const result = await loadModule('nested.ts')
+    expect(result.logs).not.toContain('NUXT_B8023')
+  }, 60_000)
+
+  it('should warn about a module only once per process', async () => {
+    const result = await loadModule('dirname.ts', { loads: 3 })
+    expect(result).toMatchObject({ ok: true, module: 'function' })
+    expect(result.logs.match(/NUXT_B8023/g)).toHaveLength(1)
+  }, 60_000)
+
+  it('should load a module using `require` through jiti', async () => {
+    await expect(loadModule('requires.ts')).resolves.toMatchObject({ ok: true, module: 'function' })
+  }, 60_000)
+
+  it('should not retry a module that threw an unrelated ReferenceError', async () => {
+    const result = await loadModule('unrelated-reference.ts')
+    expect(result.ok).toBe(false)
+    expect(result.message).toMatch(/my__dirname is not defined/)
+    expect(result.logs).not.toContain('NUXT_B8023')
+  }, 60_000)
+
+  it('should classify an unresolved `#` alias as a loader error', async () => {
+    await expect(classify('alias-import.ts')).resolves.toStrictEqual({
+      code: 'ERR_PACKAGE_IMPORT_NOT_DEFINED',
+      isLoaderError: true,
+      missingCjsGlobal: null,
+    })
+  })
+
+  it('should load a module importing a Nuxt alias the runtime cannot resolve', async () => {
+    await expect(loadModule('alias-import.ts', { alias: { '#shared/': dir + '/' } })).resolves.toMatchObject({ ok: true, module: 'function' })
+  }, 60_000)
+
+  it('should retry any config file failure through jiti and warn', async () => {
+    const cwd = await configFixture('cjs-globals', USES_DIRNAME)
+    const result = await loadConfig(cwd)
+    expect(result).toMatchObject({ ok: true, value: 'ok' })
+    expect(result.logs).toContain('NUXT_B5023')
+  }, 60_000)
+
+  it('should retry a config file using `require`', async () => {
+    const cwd = await configFixture('own-error', 'const { format } = require(\'node:util\')\nexport default { runtimeConfig: { value: format(\'%s-%s\', \'a\', \'b\') } }\n')
+    await expect(loadConfig(cwd)).resolves.toMatchObject({ ok: true, value: 'a-b' })
+  }, 60_000)
+
+  it('should retry a config file that threw for its own reasons, but report its first error', async () => {
+    const cwd = await configFixture('always-throws', COUNTED_THROW)
+    const result = await loadConfig(cwd)
+    expect(result.ok).toBe(false)
+    expect(result.message).toBe('run 1')
+    expect(result.code).toBeUndefined()
+    expect(result.logs).not.toContain('NUXT_B5023')
+    await expect(readFile(join(cwd, 'runs.log'), 'utf-8')).resolves.toBe('..')
+  }, 60_000)
+
+  it('should not reach for jiti at all when a config file threw for its own reasons', async () => {
+    const cwd = await configFixture('own-bug-no-jiti', COUNTED_THROW)
+    const result = await loadConfigWithoutJiti(cwd)
+    expect(result.ok).toBe(false)
+    expect(result.message).toBe('run 1')
+    expect(result.code).toBeUndefined()
+    expect(result.logs).not.toContain('jiti')
+    await expect(readFile(join(cwd, 'runs.log'), 'utf-8')).resolves.toBe('.')
+  }, 60_000)
+
+  it('should surface a distinct jiti failure rather than the missing global', async () => {
+    const cwd = await configFixture('distinct-under-jiti', 'const here = __dirname\nthrow new Error(`threw under jiti from ${typeof here}`)\n')
+    const result = await loadConfig(cwd)
+    expect(result.ok).toBe(false)
+    expect(result.message).toMatch(/threw under jiti from string/)
+    expect(result.message).not.toMatch(/__dirname/)
+  }, 60_000)
+
+  // `compatibilityVersion` is spelled out because the schema resolving it is this repo's, which
+  // defaults to the v5 value that a Nuxt 4 project would not see
+  it('should not warn a Nuxt 4 project, whose nuxt depends on jiti', async () => {
+    const cwd = await configFixture('nuxt-4', `export default { future: { compatibilityVersion: 4 }, runtimeConfig: { value: __dirname ? 'ok' : 'no' } }\n`)
+    await installFakeNuxt(cwd, { jiti: '^2.7.0' })
+    const result = await loadConfig(cwd)
+    expect(result).toMatchObject({ ok: true, value: 'ok' })
+    expect(result.logs).not.toContain('NUXT_B5023')
+  }, 60_000)
+
+  it('should warn a Nuxt 4 project that opted into compatibilityVersion 5', async () => {
+    const cwd = await configFixture('nuxt-4-compat-5', `export default { future: { compatibilityVersion: 5 }, runtimeConfig: { value: __dirname ? 'ok' : 'no' } }\n`)
+    await installFakeNuxt(cwd, { jiti: '^2.7.0' })
+    const result = await loadConfig(cwd)
+    expect(result).toMatchObject({ ok: true, value: 'ok' })
+    expect(result.logs).toContain('NUXT_B5023')
+  }, 60_000)
+
+  it('should warn a Nuxt 5 project that has not asked for jiti', async () => {
+    const cwd = await configFixture('nuxt-5', USES_DIRNAME)
+    await installFakeNuxt(cwd, {})
+    const result = await loadConfig(cwd)
+    expect(result).toMatchObject({ ok: true, value: 'ok' })
+    expect(result.logs).toContain('NUXT_B5023')
+  }, 60_000)
+
+  it('should not warn a Nuxt 5 project that installed jiti itself', async () => {
+    const cwd = await configFixture('nuxt-5-with-jiti', USES_DIRNAME, { devDependencies: { jiti: '^2.7.0' } })
+    await installFakeNuxt(cwd, {})
+    const result = await loadConfig(cwd)
+    expect(result).toMatchObject({ ok: true, value: 'ok' })
+    expect(result.logs).not.toContain('NUXT_B5023')
+  }, 60_000)
+
+  it('should tell a Nuxt 5 project without jiti how to load a config using CJS globals', async () => {
+    const cwd = await configFixture('nuxt-5-no-jiti', USES_DIRNAME)
+    await installFakeNuxt(cwd, {})
+    const result = await loadConfigWithoutJiti(cwd)
+    expect(result.code).toBe('NUXT_B5021')
+    expect(result.fix).toMatch(/import\.meta\.dirname/)
+    expect(result.fix).toMatch(/jiti/)
+  }, 60_000)
+
+  it('should not warn when a config file loads natively', async () => {
+    const cwd = await configFixture('native', 'export default { runtimeConfig: { value: \'native\' } }\n')
+    const result = await loadConfig(cwd)
+    expect(result).toMatchObject({ ok: true, value: 'native' })
+    expect(result.logs).not.toContain('NUXT_B5023')
+  }, 60_000)
+
+  it('should explain a missing CJS global when jiti cannot be loaded', async () => {
+    const result = await loadModuleWithoutJiti('dirname.ts')
+    expect(result.ok).toBe(false)
+    expect(result.code).toBe('NUXT_B8020')
+    expect(result.fix).toMatch(/does not provide the CommonJS globals/)
+    expect(result.fix).toMatch(/import\.meta\.dirname/)
+    expect(result.fix).toMatch(/jiti/)
   }, 60_000)
 
   it('should report the module\'s own error rather than retrying it', async () => {

--- a/packages/kit/test/module.test.ts
+++ b/packages/kit/test/module.test.ts
@@ -581,21 +581,22 @@ describe('loadNuxtModuleInstance error surfacing', { sequential: true }, () => {
     expect((error.cause as Error)?.message).toMatch(/boom from inside the module/)
   })
 
-  it('evaluates a module that throws at its top level only once', async () => {
+  it('reports the first error from a module that throws at its top level', async () => {
     const error = await loadError('side-effect-module')
     expect(error.message).toMatch(/boom after a side effect/)
     expect(error.message).not.toMatch(/jiti/)
 
+    // a module is a function Nuxt calls later, so the retry repeats no work of the module's own
     const evaluations = await readFile(join(tempDir, 'evaluations'), 'utf8')
-    expect(evaluations.trim().split('\n')).toHaveLength(1)
+    expect(evaluations.trim().split('\n')).toHaveLength(2)
   })
 
-  it('evaluates a module that raises a runtime SyntaxError only once', async () => {
+  it('reports the first error from a module that raises a runtime SyntaxError', async () => {
     const error = await loadError('runtime-syntax-module')
     expect((error.cause as Error)).toBeInstanceOf(SyntaxError)
 
     const evaluations = await readFile(join(tempDir, 'syntax-evaluations'), 'utf8')
-    expect(evaluations.trim().split('\n')).toHaveLength(1)
+    expect(evaluations.trim().split('\n')).toHaveLength(2)
   })
 
   it('retries a module whose top-level dynamic import fails to resolve', async () => {
@@ -603,8 +604,6 @@ describe('loadNuxtModuleInstance error surfacing', { sequential: true }, () => {
     expect(error.message).toMatch(/this-dependency-does-not-exist/)
     expect(error.message).not.toMatch(/may not be installed/)
 
-    // an unresolved specifier is indistinguishable from one in the static graph, which the
-    // runtime rejects before running anything, so this module is evaluated a second time
     const evaluations = await readFile(join(tempDir, 'dynamic-evaluations'), 'utf8')
     expect(evaluations.trim().split('\n')).toHaveLength(2)
   })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

spotted in ecosystem-ci - another unintentional regression if users were taking advantage of long-legacy cjs shortcuts jiti made available in `nuxt.config.ts`...

this aims to add a backwards-compatible detection layer