### PR TITLE
perf(kit): remove `confbox` and `pkg-types` from dependencies 

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -207,6 +207,7 @@ export default createConfigForNuxt({
           {
             definedTags: [
               'experimental',
+              'knipignore',
               '__NO_SIDE_EFFECTS__',
             ],
           },

--- a/knip.json
+++ b/knip.json
@@ -4,6 +4,7 @@
     "duplicates": "off"
   },
   "ignoreExportsUsedInFile": true,
+  "tags": ["-knipignore"],
   "ignoreIssues": {
     "**/.nuxt/**": ["unlisted", "unresolved"]
   },

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -32,7 +32,6 @@
     "test:attw": "node ../../scripts/test-attw.ts"
   },
   "dependencies": {
-    "confbox": "catalog:build",
     "consola": "catalog:build",
     "defu": "catalog:build",
     "destr": "catalog:build",
@@ -52,6 +51,7 @@
     "verkit": "catalog:build"
   },
   "peerDependencies": {
+    "confbox": "catalog:build",
     "dotenv": "catalog:build",
     "giget": "catalog:build",
     "jiti": "catalog:build",
@@ -60,6 +60,9 @@
     "rolldown": ">=1.0.0"
   },
   "peerDependenciesMeta": {
+    "confbox": {
+      "optional": true
+    },
     "dotenv": {
       "optional": true
     },
@@ -83,6 +86,7 @@
     "@nuxt/schema": "workspace:*",
     "c12": "catalog:build",
     "chokidar": "catalog:build",
+    "confbox": "catalog:build",
     "dotenv": "catalog:build",
     "giget": "catalog:build",
     "hookable": "catalog:app-runtime",

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -44,7 +44,6 @@
     "nostics": "catalog:build",
     "nypm": "catalog:build",
     "pathe": "catalog:build",
-    "pkg-types": "catalog:build",
     "rc9": "catalog:build",
     "scule": "catalog:build",
     "std-env": "catalog:build",
@@ -92,6 +91,7 @@
     "nitro": "catalog:nitro-runtime",
     "nitropack": "catalog:dev",
     "oxc-parser": "catalog:build",
+    "pkg-types": "catalog:build",
     "rolldown": "catalog:vite",
     "tsdown": "catalog:dev",
     "untyped": "catalog:build",
@@ -111,6 +111,7 @@
   },
   "inlinedDependencies": {
     "c12": "4.0.0-beta.5",
+    "pkg-types": "2.3.1",
     "untyped": "2.0.0"
   }
 }

--- a/packages/kit/src/compatibility.ts
+++ b/packages/kit/src/compatibility.ts
@@ -1,5 +1,5 @@
 import { satisfies } from 'verkit'
-import { readPackageJSON } from 'pkg-types'
+import { readPackageJSON } from './internal/package-json.ts'
 import type { Nuxt, NuxtCompatibility, NuxtCompatibilityIssues } from '@nuxt/schema'
 import { useNuxt } from './context.ts'
 import { kitDiagnostics } from './diagnostics/kit-api.ts'

--- a/packages/kit/src/diagnostics/config.ts
+++ b/packages/kit/src/diagnostics/config.ts
@@ -73,5 +73,10 @@ export const configDiagnostics = /* #__PURE__ */ defineDiagnostics({
       fix: (p: { installCommand: string }) => `Run \`${p.installCommand}\` to load it, or remove the \`nuxt.schema\` file.`,
       docs: false,
     },
+    NUXT_B5022: {
+      why: 'A `nuxt.config` in yaml, toml, jsonc or json5 is parsed by the `confbox` package, which is not installed.',
+      fix: (p: { installCommand: string }) => `Run \`${p.installCommand}\`, or rename your config to \`nuxt.config.ts\`.`,
+      docs: false,
+    },
   },
 })

--- a/packages/kit/src/internal/node-module.ts
+++ b/packages/kit/src/internal/node-module.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from 'node:url'
 import { normalize } from 'pathe'
-import { readPackageJSON } from 'pkg-types'
+import { readPackageJSON } from './package-json.ts'
 import type { PackageJson } from 'pkg-types'
 
 type Exports = Exclude<PackageJson['exports'], undefined>

--- a/packages/kit/src/internal/package-json.ts
+++ b/packages/kit/src/internal/package-json.ts
@@ -1,0 +1,109 @@
+import process from 'node:process'
+import { statSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, isAbsolute, join, normalize, resolve } from 'pathe'
+import { resolveModulePath } from 'exsolve'
+import type { PackageJson } from 'pkg-types'
+
+interface ResolveOptions {
+  from?: string | URL | Array<string | URL>
+  parent?: string | URL
+  try?: boolean
+}
+
+const WORKSPACE_FILES = ['pnpm-workspace.yaml', 'lerna.json', 'turbo.json', 'rush.json', 'deno.json', 'deno.jsonc']
+const LOCK_FILES = ['yarn.lock', 'package-lock.json', 'pnpm-lock.yaml', 'npm-shrinkwrap.json', 'bun.lockb', 'bun.lock', 'deno.lock']
+
+function isFile (path: string) {
+  try {
+    return statSync(path).isFile()
+  } catch {
+    return false
+  }
+}
+
+function resolveStartPath (id: string | URL, options: ResolveOptions) {
+  if (id instanceof URL || id.startsWith('file://')) {
+    return normalize(fileURLToPath(id))
+  }
+  if (isAbsolute(id)) {
+    return normalize(id)
+  }
+  return resolveModulePath(id, { ...options, from: options.from || options.parent })
+}
+
+/** Walk up from `start` looking for one of `filenames`, stopping at the nearest `node_modules`. */
+function findUp (start: string, filenames: string[], furthest?: boolean) {
+  const segments = resolve(start).split('/').filter(Boolean)
+  if (start[0] === '/') {
+    segments[0] = '/' + segments[0]
+  }
+  const root = Math.max(segments.findIndex(s => s === 'node_modules'), 0)
+  const length = segments.length - root
+  for (let i = 0; i < length; i++) {
+    const index = furthest ? root + 1 + i : segments.length - i
+    for (const filename of filenames) {
+      const candidate = join(...segments.slice(0, index), filename)
+      if (isFile(candidate)) {
+        return candidate
+      }
+    }
+  }
+}
+
+/** Find the `package.json` nearest to `id`, which may be a path, a URL or a module id. */
+export function resolvePackageJSON (id: string | URL = process.cwd(), options: ResolveOptions = {}): string | undefined {
+  const path = findUp(resolveStartPath(id, options), ['package.json'])
+  if (!path && !options.try) {
+    throw new Error(`Cannot find matching package.json in ${id} or parent directories.`)
+  }
+  return path
+}
+
+/** Find the directory containing the `package.json` nearest to `id`. */
+export function resolvePackageDir (id: string | URL, options: ResolveOptions = {}): string | undefined {
+  const path = resolvePackageJSON(id, options)
+  return path ? dirname(path) : undefined
+}
+
+/** Read the `package.json` nearest to `id`, which may be a path, a URL or a module id. */
+export async function readPackageJSON (id: string | URL = process.cwd(), options: ResolveOptions = {}): Promise<PackageJson> {
+  const path = resolvePackageJSON(id, options)!
+  return JSON.parse(await readFile(path, 'utf8')) as PackageJson
+}
+
+/**
+ * Detect the workspace root for `id`, preferring workspace manifests, then git, then lockfiles.
+ *
+ * Returns a promise because the inlined `c12` awaits this and attaches a `.catch()` to it.
+ */
+export function findWorkspaceDir (id: string | URL = process.cwd(), options: ResolveOptions = {}): Promise<string> {
+  return Promise.resolve().then(() => resolveWorkspaceDir(id, options))
+}
+
+function resolveWorkspaceDir (id: string | URL, options: ResolveOptions): string {
+  const start = resolveStartPath(id, options)
+
+  const workspaceFile = findUp(start, WORKSPACE_FILES, true)
+  if (workspaceFile) {
+    return dirname(workspaceFile)
+  }
+
+  const gitConfig = findUp(start, ['.git/config'])
+  if (gitConfig) {
+    return resolve(gitConfig, '../..')
+  }
+
+  const lockFile = findUp(start, LOCK_FILES, true)
+  if (lockFile) {
+    return dirname(lockFile)
+  }
+
+  const packageJSON = findUp(start, ['package.json'], true)
+  if (packageJSON) {
+    return dirname(packageJSON)
+  }
+
+  throw new Error(`Cannot detect workspace root from ${id}.`)
+}

--- a/packages/kit/src/internal/package-json.ts
+++ b/packages/kit/src/internal/package-json.ts
@@ -77,6 +77,8 @@ export async function readPackageJSON (id: string | URL = process.cwd(), options
  * Detect the workspace root for `id`, preferring workspace manifests, then git, then lockfiles.
  *
  * Returns a promise because the inlined `c12` awaits this and attaches a `.catch()` to it.
+ *
+ * @knipignore reached only through the `pkg-types` alias in `tsdown.config.ts`
  */
 export function findWorkspaceDir (id: string | URL = process.cwd(), options: ResolveOptions = {}): Promise<string> {
   return Promise.resolve().then(() => resolveWorkspaceDir(id, options))

--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -16,7 +16,7 @@ import { directoryToURL } from '../internal/esm.ts'
 import { isLoaderError, loadJiti } from '../internal/jiti.ts'
 import type { Jiti } from '../internal/jiti.ts'
 import { configDiagnostics } from '../diagnostics/config.ts'
-import { getAddDependencyCommand } from '../dependency.ts'
+import { ensureDependencyInstalled, getAddDependencyCommand } from '../dependency.ts'
 
 /**
  * A layer as it comes back from the underlying config loader, before its directory options have
@@ -205,6 +205,15 @@ async function assertRemoteLayerSupport (source: string, rootDir: string) {
   }
 }
 
+/**
+ * Whether a config load failed because `confbox` is not installed. It is an optional peer
+ * dependency, needed only to parse a `nuxt.config` written in yaml, toml, jsonc or json5.
+ */
+function isMissingConfbox (error: unknown): boolean {
+  const { code, message } = (error ?? {}) as { code?: unknown, message?: unknown }
+  return code === 'ERR_MODULE_NOT_FOUND' && typeof message === 'string' && message.includes(`'confbox`)
+}
+
 const merger = createDefu((obj, key, value) => {
   if (Array.isArray(obj[key]) && Array.isArray(value)) {
     obj[key] = obj[key].concat(value)
@@ -294,7 +303,7 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
     }
   }
 
-  const resolved = await withDefineNuxtConfig(
+  const loadRootConfig = () => withDefineNuxtConfig(
     () => loadConfig<NuxtConfig>({
       name: 'nuxt',
       configFile: 'nuxt.config',
@@ -360,6 +369,24 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
       },
     }),
   )
+
+  const resolved = await loadRootConfig().catch(async (error) => {
+    if (!isMissingConfbox(error)) {
+      throw error
+    }
+    if (!await ensureDependencyInstalled('confbox', { rootDir: rootCwd, from: import.meta.url })) {
+      throw configDiagnostics.NUXT_B5022({
+        installCommand: await getAddDependencyCommand('confbox', rootCwd, { dev: true }),
+        cause: error,
+      })
+    }
+    // The abandoned load already recorded the layers it reached, and a layer it has seen resolves
+    // to an empty config on the way past
+    seenLayerDirs.clear()
+    extendsLocalLayerOrder.length = 0
+    return loadRootConfig()
+  })
+
   const { configFile, layers = [], cwd, meta } = resolved
   // Clone with `klona` rather than `klona/full`: jiti-imported JSON/CJS modules in user config
   // carry a non-enumerable, self-referential `default` interop property, which `klona/full`

--- a/packages/kit/src/module/install.ts
+++ b/packages/kit/src/module/install.ts
@@ -4,7 +4,7 @@ import type { ModuleMeta, ModuleOptions, Nuxt, NuxtConfig, NuxtModule, NuxtOptio
 import { dirname, isAbsolute, join, resolve } from 'pathe'
 import { defu } from 'defu'
 import { resolveModulePath, resolveModuleURL } from 'exsolve'
-import { readPackageJSON, resolvePackageJSON } from 'pkg-types'
+import { readPackageJSON, resolvePackageDir } from '../internal/package-json.ts'
 import { read as readRc, update as updateRc } from 'rc9'
 import { isGreater, satisfies } from 'verkit'
 import { directoryToURL } from '../internal/esm.ts'
@@ -483,7 +483,7 @@ async function callModule (nuxt: Nuxt, nuxtModule: NuxtModule<any, Partial<any>,
     if (res !== false) {
       const moduleRoot = parsed.dir
         ? parsed.dir + parsed.name
-        : await resolvePackageJSON(modulePath, { try: true }).then(r => r ? dirname(r) : modulePath)
+        : resolvePackageDir(modulePath, { try: true }) || modulePath
       nuxt.options.build.transpile.push(normalizeModuleTranspilePath(moduleRoot))
       const directory = moduleRoot.replace(/\/?$/, '/')
       if (moduleRoot !== nameOrPath && !localLayerModuleDirs.some(dir => directory.startsWith(dir))) {

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -6,7 +6,7 @@ import type { Nuxt, NuxtServerTemplate, NuxtTemplate, NuxtTypeTemplate, Resolved
 import { defu } from 'defu'
 import type { TSConfig } from 'pkg-types'
 import { isGreaterOrEqual } from 'verkit'
-import { readPackageJSON } from 'pkg-types'
+import { readPackageJSON } from './internal/package-json.ts'
 import { resolveModulePath } from 'exsolve'
 import { captureStackTrace } from 'errx'
 

--- a/packages/kit/src/types.ts
+++ b/packages/kit/src/types.ts
@@ -1,7 +1,6 @@
 import { promises as fsp } from 'node:fs'
 import { resolveModulePath } from 'exsolve'
-import { dirname } from 'pathe'
-import { resolvePackageJSON } from 'pkg-types'
+import { resolvePackageDir } from './internal/package-json.ts'
 import { directoryToURL } from './internal/esm.ts'
 
 const TYPE_RESOLVE_OPTIONS = {
@@ -71,14 +70,14 @@ function resolveRoot (basePkg: string, from: Array<string | URL>): Promise<strin
   if (rootCache.has(cacheKey)) {
     return rootCache.get(cacheKey)!
   }
-  const promise = (async () => {
+  const promise = Promise.resolve().then(() => {
     try {
       const r = resolveModulePath(basePkg, { from, ...TYPE_RESOLVE_OPTIONS })
-      return dirname(await resolvePackageJSON(r))
+      return resolvePackageDir(r)
     } catch {
       return undefined
     }
-  })()
+  })
   rootCache.set(cacheKey, promise)
   return promise
 }

--- a/packages/kit/test/load-nuxt-config.test.ts
+++ b/packages/kit/test/load-nuxt-config.test.ts
@@ -275,3 +275,21 @@ describe('loadNuxtConfig onConfigResolved', () => {
     expect(done).toBe(true)
   })
 })
+
+describe('loadNuxtConfig confbox formats', () => {
+  const tempDir = join(repoRoot, 'temp', 'confbox-config')
+
+  beforeAll(async () => {
+    await mkdir(tempDir, { recursive: true })
+  })
+
+  afterAll(async () => {
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('loads a yaml `nuxt.config`', async () => {
+    await writeFile(join(tempDir, 'nuxt.config.yaml'), 'ssr: false\n')
+    const config = await loadNuxtConfig({ cwd: tempDir })
+    expect(config.ssr).toBe(false)
+  })
+})

--- a/packages/kit/tsdown.config.ts
+++ b/packages/kit/tsdown.config.ts
@@ -1,7 +1,11 @@
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
   entry: ['src/index.ts', 'src/internal/index.ts'],
+  alias: {
+    'pkg-types': fileURLToPath(new URL('src/internal/package-json.ts', import.meta.url)),
+  },
   // No `oxc: true`: it can't infer `defineDiagnostics()`'s return type, which the
   // diagnostics catalogs rely on. tsc handles it.
   dts: {},
@@ -11,7 +15,7 @@ export default defineConfig({
     //
     // `untyped` is inlined because only `applyDefaults` is used, and its package pulls in `jiti`
     // for a loader entry point Nuxt never imports.
-    onlyBundle: ['c12', 'untyped'],
+    onlyBundle: ['c12', 'untyped', 'pkg-types'],
     neverBundle: [
       // Optional peers the inlined `c12` reaches for with a dynamic import, and only for projects
       // that need them: remote layers, and `.env` files on runtimes without `util.parseEnv`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -828,9 +828,6 @@ importers:
       pathe:
         specifier: catalog:build
         version: 2.0.3
-      pkg-types:
-        specifier: catalog:build
-        version: 2.3.1
       rc9:
         specifier: catalog:build
         version: 3.0.1
@@ -883,6 +880,9 @@ importers:
       oxc-parser:
         specifier: 0.143.0
         version: 0.143.0
+      pkg-types:
+        specifier: catalog:build
+        version: 2.3.1
       rolldown:
         specifier: 1.2.3
         version: 1.2.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -792,9 +792,6 @@ importers:
 
   packages/kit:
     dependencies:
-      confbox:
-        specifier: catalog:build
-        version: 0.2.4
       consola:
         specifier: catalog:build
         version: 3.4.2
@@ -856,6 +853,9 @@ importers:
       chokidar:
         specifier: catalog:build
         version: 5.0.0
+      confbox:
+        specifier: catalog:build
+        version: 0.2.4
       dotenv:
         specifier: catalog:build
         version: 17.4.2

--- a/scripts/check-public-api.ts
+++ b/scripts/check-public-api.ts
@@ -32,8 +32,9 @@ const entrypoints: Record<string, PublicEntrypoint> = {
       'nitropack/types',
     ],
     augmentations: [
-      // Pulled in with `@nuxt/schema`, which augments `TSConfig`.
-      'pkg-types',
+      // Left over from bundling `pkg-types`' declarations, whose type-only imports of `exsolve`
+      // are elided. `exsolve` is a hard dependency of kit, so consumers always have it.
+      'exsolve',
     ],
   },
   // Schema describes configuration, so options that exist to configure a third party are typed


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this aims to make nuxt/kit as slim as we can, given users will potentially have multiple copies installed in their dependencies.