### PR TITLE
feat(nuxt): environment-specific components, pages, layouts, and middleware (.dev, .prod)

### DIFF
--- a/docs/2.directory-structure/1.app/1.components.md
+++ b/docs/2.directory-structure/1.app/1.components.md
@@ -534,6 +534,50 @@ In this case, the `.server` + `.client` components are two 'halves' of a compone
 </template>
 ```
 
+## Environment-Specific Components
+
+You can specify that a component should only be included in specific environments by adding the `.dev` or `.prod` suffix to its filename.
+
+### Dev-Only Components
+
+Dev-only components are only loaded during local development (`nuxt dev`). In production builds (`nuxt build`), Nuxt automatically replaces them with an empty stub, guaranteeing that dev component code and heavy dependencies are 100% tree-shaken and excluded from the production bundle without throwing unresolved component errors.
+
+```bash [Directory Structure]
+-| components/
+---| InspectorPanel.dev.vue
+---| DebugOverlay.dev.client.vue
+```
+
+```vue [app/pages/example.vue]
+<template>
+  <div>
+    <!-- Rendered in dev, safely auto-stubbed in production -->
+    <InspectorPanel />
+  </div>
+</template>
+```
+
+### Prod-Only Components
+
+Prod-only components with a `.prod` suffix (e.g. `Analytics.prod.vue`) are only active in production builds and auto-stubbed during development.
+
+You can also pair a `.dev.vue` and `.prod.vue` component of the same name for separate environment implementations:
+
+```bash [Directory Structure]
+-| components/
+---| Analytics.dev.vue
+---| Analytics.prod.vue
+```
+
+```vue [app/pages/example.vue]
+<template>
+  <div>
+    <!-- Uses Analytics.dev in dev, and Analytics.prod in production -->
+    <Analytics />
+  </div>
+</template>
+```
+
 ## Built-In Nuxt Components
 
 There are a number of components that Nuxt provides, including `<ClientOnly>` and `<DevOnly>`. You can read more about them in the API documentation.

--- a/docs/2.directory-structure/1.app/1.components.md
+++ b/docs/2.directory-structure/1.app/1.components.md
@@ -534,7 +534,7 @@ In this case, the `.server` + `.client` components are two 'halves' of a compone
 </template>
 ```
 
-## Environment-Specific Components
+## Environment-Specific Components :badge[v4.6]{color="info" size="xs" class="align-middle"}
 
 You can specify that a component should only be included in specific environments by adding the `.dev` or `.prod` suffix to its filename.
 

--- a/docs/2.directory-structure/1.app/1.layouts.md
+++ b/docs/2.directory-structure/1.app/1.layouts.md
@@ -116,6 +116,13 @@ File | Layout Name
 `~/layouts/desktop-base/DesktopBase.vue` | `desktop-base`
 `~/layouts/desktop/Desktop.vue` | `desktop`
 
+## Environment-Specific Layouts
+
+You can create environment-specific layouts with the `.dev` or `.prod` suffix (such as `layouts/custom.dev.vue` $\rightarrow$ `layout: 'custom'`).
+
+* **Dev-Only Layouts (`*.dev.vue`)**: Loaded during `nuxt dev`. In production builds (`nuxt build`), if a page requests a dev-only layout, `<NuxtLayout>` safely falls back to a pass-through `<slot />` to render the page content directly without dev wrappers.
+* **Prod-Only Layouts (`*.prod.vue`)**: Active only in production builds.
+
 :link-example{to="/docs/4.x/examples/features/layouts"}
 
 ## Changing the Layout Dynamically

--- a/docs/2.directory-structure/1.app/1.layouts.md
+++ b/docs/2.directory-structure/1.app/1.layouts.md
@@ -116,7 +116,7 @@ File | Layout Name
 `~/layouts/desktop-base/DesktopBase.vue` | `desktop-base`
 `~/layouts/desktop/Desktop.vue` | `desktop`
 
-## Environment-Specific Layouts
+## Environment-Specific Layouts :badge[v4.6]{color="info" size="xs" class="align-middle"}
 
 You can create environment-specific layouts with the `.dev` or `.prod` suffix (such as `layouts/custom.dev.vue` $\rightarrow$ `layout: 'custom'`).
 

--- a/docs/2.directory-structure/1.app/1.layouts.md
+++ b/docs/2.directory-structure/1.app/1.layouts.md
@@ -120,8 +120,8 @@ File | Layout Name
 
 You can create environment-specific layouts with the `.dev` or `.prod` suffix (such as `layouts/custom.dev.vue` $\rightarrow$ `layout: 'custom'`).
 
-* **Dev-Only Layouts (`*.dev.vue`)**: Loaded during `nuxt dev`. In production builds (`nuxt build`), if a page requests a dev-only layout, `<NuxtLayout>` safely falls back to a pass-through `<slot />` to render the page content directly without dev wrappers.
-* **Prod-Only Layouts (`*.prod.vue`)**: Active only in production builds.
+- **Dev-Only Layouts (`*.dev.vue`)**: Loaded during `nuxt dev`. In production builds (`nuxt build`), if a page requests a dev-only layout, `<NuxtLayout>` safely falls back to a pass-through `<slot />` to render the page content directly without dev wrappers.
+- **Prod-Only Layouts (`*.prod.vue`)**: Active only in production builds.
 
 :link-example{to="/docs/4.x/examples/features/layouts"}
 

--- a/docs/2.directory-structure/1.app/1.middleware.md
+++ b/docs/2.directory-structure/1.app/1.middleware.md
@@ -256,6 +256,6 @@ export default defineNuxtConfig({
 
 You can specify that a middleware should only run in specific environments by adding the `.dev` or `.prod` suffix to its filename:
 
-* **Dev-Only Middleware (`*.dev.ts`)**: Active only in `nuxt dev` (e.g. `middleware/logger.dev.ts` or `middleware/auth.global.dev.ts`). In production builds, named dev-only middleware are automatically auto-stubbed to a no-op handler so that any pages referencing them continue navigating safely without runtime errors.
-* **Prod-Only Middleware (`*.prod.ts`)**: Active only in production builds (e.g. `middleware/analytics.global.prod.ts`). Auto-stubbed during `nuxt dev`.
+* **Dev-Only Middleware (`*.dev.ts`)**: Active only in `nuxt dev` (e.g. `middleware/logger.dev.ts` or `middleware/auth.global.dev.ts`). In production builds, inactive global middleware is omitted, while inactive named middleware is automatically auto-stubbed to a no-op handler so that any pages referencing them continue navigating safely without runtime errors.
+* **Prod-Only Middleware (`*.prod.ts`)**: Active only in production builds (e.g. `middleware/analytics.global.prod.ts`). In `nuxt dev`, inactive global middleware is omitted, while inactive named middleware is auto-stubbed.
 * **Paired Middleware**: You can provide both `middleware/auth.dev.ts` and `middleware/auth.prod.ts` for separate dev/prod implementations under the same name (`middleware: 'auth'`).

--- a/docs/2.directory-structure/1.app/1.middleware.md
+++ b/docs/2.directory-structure/1.app/1.middleware.md
@@ -256,6 +256,6 @@ export default defineNuxtConfig({
 
 You can specify that a middleware should only run in specific environments by adding the `.dev` or `.prod` suffix to its filename:
 
-- **Dev-Only Middleware (`*.dev.ts`)**: Active only in `nuxt dev` (e.g. `middleware/logger.dev.ts` or `middleware/auth.global.dev.ts`). In production builds, named dev-only middleware are automatically auto-stubbed to a no-op handler so that any pages referencing them continue navigating safely without runtime errors.
-- **Prod-Only Middleware (`*.prod.ts`)**: Active only in production builds (e.g. `middleware/analytics.global.prod.ts`). Auto-stubbed during `nuxt dev`.
-- **Paired Middleware**: You can provide both `middleware/auth.dev.ts` and `middleware/auth.prod.ts` for separate dev/prod implementations under the same name (`middleware: 'auth'`).
+* **Dev-Only Middleware (`*.dev.ts`)**: Active only in `nuxt dev` (e.g. `middleware/logger.dev.ts` or `middleware/auth.global.dev.ts`). In production builds, named dev-only middleware are automatically auto-stubbed to a no-op handler so that any pages referencing them continue navigating safely without runtime errors.
+* **Prod-Only Middleware (`*.prod.ts`)**: Active only in production builds (e.g. `middleware/analytics.global.prod.ts`). Auto-stubbed during `nuxt dev`.
+* **Paired Middleware**: You can provide both `middleware/auth.dev.ts` and `middleware/auth.prod.ts` for separate dev/prod implementations under the same name (`middleware: 'auth'`).

--- a/docs/2.directory-structure/1.app/1.middleware.md
+++ b/docs/2.directory-structure/1.app/1.middleware.md
@@ -251,3 +251,11 @@ export default defineNuxtConfig({
   },
 })
 ```
+
+## Environment-Specific Middleware
+
+You can specify that a middleware should only run in specific environments by adding the `.dev` or `.prod` suffix to its filename:
+
+- **Dev-Only Middleware (`*.dev.ts`)**: Active only in `nuxt dev` (e.g. `middleware/logger.dev.ts` or `middleware/auth.global.dev.ts`). In production builds, named dev-only middleware are automatically auto-stubbed to a no-op handler so that any pages referencing them continue navigating safely without runtime errors.
+- **Prod-Only Middleware (`*.prod.ts`)**: Active only in production builds (e.g. `middleware/analytics.global.prod.ts`). Auto-stubbed during `nuxt dev`.
+- **Paired Middleware**: You can provide both `middleware/auth.dev.ts` and `middleware/auth.prod.ts` for separate dev/prod implementations under the same name (`middleware: 'auth'`).

--- a/docs/2.directory-structure/1.app/1.middleware.md
+++ b/docs/2.directory-structure/1.app/1.middleware.md
@@ -252,7 +252,7 @@ export default defineNuxtConfig({
 })
 ```
 
-## Environment-Specific Middleware
+## Environment-Specific Middleware :badge[v4.6]{color="info" size="xs" class="align-middle"}
 
 You can specify that a middleware should only run in specific environments by adding the `.dev` or `.prod` suffix to its filename:
 

--- a/docs/2.directory-structure/1.app/1.pages.md
+++ b/docs/2.directory-structure/1.app/1.pages.md
@@ -471,6 +471,13 @@ You can define a page as [server only](/docs/4.x/directory-structure/app/compone
 Server-only pages must have a single root element. (HTML comments are considered elements as well.)
 ::
 
+## Environment-Specific Pages
+
+You can define a page to be included only in specific environments by giving it a `.dev.vue` or `.prod.vue` suffix.
+
+- **Dev-Only Pages (`*.dev.vue`)**: Included only in `nuxt dev` (for example, `pages/sandbox.dev.vue` creates the route `/sandbox`). In production builds, the route is completely excluded from the route table and returns a `404 Not Found`.
+- **Prod-Only Pages (`*.prod.vue`)**: Included only in production builds.
+
 ## Custom Routing
 
 As your app gets bigger and more complex, your routing might require more flexibility. For this reason, Nuxt directly exposes the router, routes and router options for customization in different ways.

--- a/docs/2.directory-structure/1.app/1.pages.md
+++ b/docs/2.directory-structure/1.app/1.pages.md
@@ -471,7 +471,7 @@ You can define a page as [server only](/docs/4.x/directory-structure/app/compone
 Server-only pages must have a single root element. (HTML comments are considered elements as well.)
 ::
 
-## Environment-Specific Pages
+## Environment-Specific Pages :badge[v4.6]{color="info" size="xs" class="align-middle"}
 
 You can define a page to be included only in specific environments by giving it a `.dev.vue` or `.prod.vue` suffix.
 

--- a/docs/2.directory-structure/1.app/1.pages.md
+++ b/docs/2.directory-structure/1.app/1.pages.md
@@ -476,7 +476,7 @@ Server-only pages must have a single root element. (HTML comments are considered
 You can define a page to be included only in specific environments by giving it a `.dev.vue` or `.prod.vue` suffix.
 
 - **Dev-Only Pages (`*.dev.vue`)**: Included only in `nuxt dev` (for example, `pages/sandbox.dev.vue` creates the route `/sandbox`). In production builds, the route is completely excluded from the route table and returns a `404 Not Found`.
-- **Prod-Only Pages (`*.prod.vue`)**: Included only in production builds.
+- **Prod-Only Pages (`*.prod.vue`)**: Active in production builds. During `nuxt dev`, Nuxt registers an informative dev stub for the route so internal `<NuxtLink>` components resolve without missing-route warnings.
 
 ## Custom Routing
 

--- a/packages/nuxt/src/components/scan.ts
+++ b/packages/nuxt/src/components/scan.ts
@@ -1,5 +1,5 @@
 import { readdir } from 'node:fs/promises'
-import { basename, dirname, extname, join, relative } from 'pathe'
+import { basename, dirname, extname, join, relative, resolve } from 'pathe'
 import { glob } from 'tinyglobby'
 import { kebabCase, pascalCase, splitByCase } from 'scule'
 import { isIgnored, useNuxt } from '@nuxt/kit'
@@ -10,10 +10,11 @@ import { QUOTE_RE, resolveComponentNameSegments } from '../core/utils/index.ts'
 import { linkToAlias, resolveToAlias } from '../utils.ts'
 import type { Component, ComponentsDir } from 'nuxt/schema'
 
-const ISLAND_RE = /\.island(?:\.global)?$/
-const GLOBAL_RE = /\.global(?:\.island)?$/
-const COMPONENT_MODE_RE = /(?<=\.)(client|server)(?:\.global|\.island)*$/
-const MODE_REPLACEMENT_RE = /(?:\.(?:client|server))?(?:\.global|\.island)*$/
+const ISLAND_RE = /(?:^|\.)island(?=\.|$)/
+const GLOBAL_RE = /(?:^|\.)global(?=\.|$)/
+const COMPONENT_ENV_RE = /(?:^|\.)(dev|prod)(?=\.|$)/
+const COMPONENT_MODE_RE = /(?:^|\.)(client|server)(?=\.|$)/
+const MODIFIER_REPLACEMENT_RE = /\.(?:dev|prod|client|server|global|island)(?=\.|$)/g
 /**
  * Scan the components inside different components folders
  * and return a unique list of components
@@ -22,6 +23,9 @@ const MODE_REPLACEMENT_RE = /(?:\.(?:client|server))?(?:\.global|\.island)*$/
  * @returns {Promise} Component found promise
  */
 export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Promise<Component[]> {
+  const nuxt = useNuxt()
+  const isDev = nuxt.options?.dev ?? true
+
   // All scanned components
   const components: Component[] = []
 
@@ -48,7 +52,6 @@ export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Pr
         const directoryLowerCase = directory.toLowerCase()
         for (const sibling of siblings) {
           if (sibling.toLowerCase() === directoryLowerCase) {
-            const nuxt = useNuxt()
             const original = resolveToAlias(dir.path, nuxt)
             const corrected = resolveToAlias(join(dirname(dir.path), sibling), nuxt)
             componentDiagnostics.NUXT_B3008({ scannedPath: corrected, expectedPath: original })
@@ -89,10 +92,15 @@ export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Pr
        */
       let fileName = basename(filePath, extname(filePath))
 
+      const env = fileName.match(COMPONENT_ENV_RE)?.[1]
+      const shouldStub = Boolean((env === 'dev' && !isDev) || (env === 'prod' && isDev))
+      const placeholderPath = nuxt?.options?.appDir ? resolve(nuxt.options.appDir, 'components/server-placeholder') : 'virtual:nuxt-empty'
+      const resolvedFilePath = shouldStub ? placeholderPath : filePath
+
       const island = ISLAND_RE.test(fileName) || dir.island
       const global = GLOBAL_RE.test(fileName) || dir.global
       const mode = island ? 'server' : (fileName.match(COMPONENT_MODE_RE)?.[1] || 'all') as 'client' | 'server' | 'all'
-      fileName = fileName.replace(MODE_REPLACEMENT_RE, '')
+      fileName = fileName.replace(MODIFIER_REPLACEMENT_RE, '')
 
       if (fileName.toLowerCase() === 'index') {
         fileName = dir.pathPrefix === false ? basename(dirname(filePath)) : '' /* inherits from path */
@@ -107,10 +115,15 @@ export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Pr
       }
 
       if (resolvedNames.has(pascalName + suffix) || resolvedNames.has(pascalName)) {
-        warnAboutDuplicateComponent(pascalName, filePath, resolvedNames.get(pascalName) || resolvedNames.get(pascalName + suffix)!)
-        continue
+        if (!shouldStub) {
+          const existingEntry = componentsByName.get(pascalName)?.find(e => e.component.mode === 'all' || e.component.mode === mode)
+          if (existingEntry && (existingEntry.component.priority ?? 0) > 0) {
+            warnAboutDuplicateComponent(pascalName, filePath, resolvedNames.get(pascalName) || resolvedNames.get(pascalName + suffix)!)
+          }
+        }
+      } else {
+        resolvedNames.set(pascalName + suffix, filePath)
       }
-      resolvedNames.set(pascalName + suffix, filePath)
 
       const kebabName = kebabCase(componentNameSegments)
       const shortPath = relative(srcDir, filePath)
@@ -124,15 +137,15 @@ export async function scanComponents (dirs: ComponentsDir[], srcDir: string): Pr
         prefetch: Boolean(dir.prefetch),
         preload: Boolean(dir.preload),
         // specific to the file
-        filePath,
+        filePath: resolvedFilePath,
         declarationPath: filePath,
         pascalName,
         kebabName,
         chunkName,
         shortPath,
         export: 'default',
-        // by default, give priority to scanned components
-        priority: dir.priority ?? 1,
+        // by default, give priority to scanned components, real implementation over stub
+        priority: shouldStub ? 0 : (dir.priority ?? 1),
         // @ts-expect-error untyped property
         _scanned: true,
       }

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -209,6 +209,12 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
   for (const dirs of layerDirs) {
     const layoutFiles = await resolveFiles(dirs.appLayouts, `**/*{${extensionGlob}}`)
     for (const file of layoutFiles) {
+      if (!nuxt.options.dev && /\.dev\.[^.]+$/.test(file)) {
+        continue
+      }
+      if (nuxt.options.dev && /\.prod\.[^.]+$/.test(file)) {
+        continue
+      }
       const name = getNameFromPath(file, dirs.appLayouts)
       if (!name) {
         // Ignore files like `~/layouts/index.vue` which end up not having a name at all
@@ -227,6 +233,12 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
       `*/index{${extensionGlob}}`,
     ])
     for (const file of middlewareFiles) {
+      if (!nuxt.options.dev && /\.dev\.[^.]+$/.test(file)) {
+        continue
+      }
+      if (nuxt.options.dev && /\.prod\.[^.]+$/.test(file)) {
+        continue
+      }
       const name = getNameFromPath(file)
       if (!name) {
         // Ignore files like `~/middleware/index.vue` which end up not having a name at all

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -209,10 +209,10 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
   for (const dirs of layerDirs) {
     const layoutFiles = await resolveFiles(dirs.appLayouts, `**/*{${extensionGlob}}`)
     for (const file of layoutFiles) {
-      if (!nuxt.options.dev && /\.dev\.[^.]+$/.test(file)) {
+      if (!nuxt.options.dev && /(?:^|\.)dev(?:\.|$)/.test(file)) {
         continue
       }
-      if (nuxt.options.dev && /\.prod\.[^.]+$/.test(file)) {
+      if (nuxt.options.dev && /(?:^|\.)prod(?:\.|$)/.test(file)) {
         continue
       }
       const name = getNameFromPath(file, dirs.appLayouts)
@@ -227,27 +227,44 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
 
   // Resolve middleware/ from all config layers, layers first
   let middleware: NuxtApp['middleware'] = []
+  const namedMiddlewareEntries = new Map<string, NuxtMiddleware>()
+  const globalMiddlewareEntries: NuxtMiddleware[] = []
+
   for (const dirs of reversedLayerDirs) {
     const middlewareFiles = await resolveFiles(dirs.appMiddleware, [
       `*{${extensionGlob}}`,
       `*/index{${extensionGlob}}`,
     ])
     for (const file of middlewareFiles) {
-      if (!nuxt.options.dev && /\.dev\.[^.]+$/.test(file)) {
+      const isGlobal = hasSuffix(file, '.global')
+      const isDevOnly = /(?:^|\.)dev(?:\.|$)/.test(file)
+      const isProdOnly = /(?:^|\.)prod(?:\.|$)/.test(file)
+      const shouldStub = (!nuxt.options.dev && isDevOnly) || (nuxt.options.dev && isProdOnly)
+
+      if (isGlobal && shouldStub) {
         continue
       }
-      if (nuxt.options.dev && /\.prod\.[^.]+$/.test(file)) {
-        continue
-      }
+
       const name = getNameFromPath(file)
       if (!name) {
         // Ignore files like `~/middleware/index.vue` which end up not having a name at all
         pageDiagnostics.NUXT_B4010({ file: linkToAlias(file, nuxt) })
         continue
       }
-      middleware.push({ name, path: file, global: hasSuffix(file, '.global') })
+
+      if (isGlobal) {
+        globalMiddlewareEntries.push({ name, path: file, global: true })
+      } else {
+        const existing = namedMiddlewareEntries.get(name)
+        const resolvedPath = shouldStub ? 'virtual:nuxt-middleware-stub' : file
+        if (!existing || (existing.path === 'virtual:nuxt-middleware-stub' && !shouldStub)) {
+          namedMiddlewareEntries.set(name, { name, path: resolvedPath, global: false })
+        }
+      }
     }
   }
+
+  middleware.push(...globalMiddlewareEntries, ...namedMiddlewareEntries.values())
 
   const reversedLayers = nuxt.options._layers.slice().reverse()
   // Resolve plugins, first extended layers and then base

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -411,7 +411,10 @@ export const middlewareTemplate: NuxtTemplate = {
       ...!nuxt.options.dev
         ? [
             `export const globalMiddleware = ${genArrayFromRaw(globalMiddleware.map(mw => genSafeVariableName(mw.name)))}`,
-            `export const namedMiddleware = ${genObjectFromRawEntries(namedMiddleware.map(mw => [mw.name, genDynamicImport(mw.path)]))}`,
+            `export const namedMiddleware = ${genObjectFromRawEntries(namedMiddleware.map(mw => [
+              mw.name,
+              mw.path === 'virtual:nuxt-middleware-stub' ? '() => () => {}' : genDynamicImport(mw.path),
+            ]))}`,
           ]
         : [
             `const _globalMiddleware = ${genObjectFromRawEntries(globalMiddleware.map(mw => [reverseResolveAlias(mw.path, alias).pop() || mw.path, genSafeVariableName(mw.name)]))}`,
@@ -422,7 +425,7 @@ export const middlewareTemplate: NuxtTemplate = {
             `const _namedMiddleware = ${genArrayFromRaw(namedMiddleware.map(mw => ({
               name: genString(mw.name),
               path: genString(reverseResolveAlias(mw.path, alias).pop() || mw.path),
-              import: genDynamicImport(mw.path),
+              import: mw.path === 'virtual:nuxt-middleware-stub' ? '() => () => {}' : genDynamicImport(mw.path),
             })))}`,
             `for (const mw of _namedMiddleware) {`,
             `  const i = mw.import`,

--- a/packages/nuxt/src/core/templates.ts
+++ b/packages/nuxt/src/core/templates.ts
@@ -425,7 +425,7 @@ export const middlewareTemplate: NuxtTemplate = {
             `const _namedMiddleware = ${genArrayFromRaw(namedMiddleware.map(mw => ({
               name: genString(mw.name),
               path: genString(reverseResolveAlias(mw.path, alias).pop() || mw.path),
-              import: mw.path === 'virtual:nuxt-middleware-stub' ? '() => () => {}' : genDynamicImport(mw.path),
+              import: mw.path === 'virtual:nuxt-middleware-stub' ? '() => Promise.resolve(() => {})' : genDynamicImport(mw.path),
             })))}`,
             `for (const mw of _namedMiddleware) {`,
             `  const i = mw.import`,

--- a/packages/nuxt/src/core/utils/names.ts
+++ b/packages/nuxt/src/core/utils/names.ts
@@ -14,7 +14,7 @@ export function getNameFromPath (path: string, relativeTo?: string) {
     ? normalize(path).replace(withTrailingSlash(normalize(relativeTo)), '')
     : basename(path)
   const prefixParts = splitByCase(dirname(relativePath))
-  const fileName = basename(relativePath, extname(relativePath))
+  const fileName = basename(relativePath, extname(relativePath)).replace(/\.(?:dev|prod|client|server|global|island)(?=\.|$)/g, '')
   const segments = resolveComponentNameSegments(fileName.toLowerCase() === 'index' ? '' : fileName, prefixParts).filter(Boolean)
   return kebabCase(segments).replace(QUOTE_RE, '')
 }

--- a/packages/nuxt/src/core/utils/names.ts
+++ b/packages/nuxt/src/core/utils/names.ts
@@ -22,7 +22,7 @@ export function getNameFromPath (path: string, relativeTo?: string) {
 export function hasSuffix (path: string, suffix: string) {
   const base = basename(path, extname(path))
   const cleanSuffix = suffix.startsWith('.') ? suffix.slice(1) : suffix
-  return new RegExp(`(?:^|\\.)${cleanSuffix}(?:\\.|$)`).test(base) || base.endsWith(suffix)
+  return new RegExp(`(?:^|\\.)${cleanSuffix}(?:\\.|$)`).test(base)
 }
 
 export function resolveComponentNameSegments (fileName: string, prefixParts: string[]) {

--- a/packages/nuxt/src/core/utils/names.ts
+++ b/packages/nuxt/src/core/utils/names.ts
@@ -20,7 +20,9 @@ export function getNameFromPath (path: string, relativeTo?: string) {
 }
 
 export function hasSuffix (path: string, suffix: string) {
-  return basename(path, extname(path)).endsWith(suffix)
+  const base = basename(path, extname(path))
+  const cleanSuffix = suffix.startsWith('.') ? suffix.slice(1) : suffix
+  return new RegExp(`(?:^|\\.)${cleanSuffix}(?:\\.|$)`).test(base) || base.endsWith(suffix)
 }
 
 export function resolveComponentNameSegments (fileName: string, prefixParts: string[]) {

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -38,10 +38,16 @@ export interface PagesContext {
 export interface PagesContextOptions {
   roots?: string[]
   shouldUseServerComponents?: boolean
+  dev?: boolean
 }
 
 export function createPagesContext (options: PagesContextOptions = {}): PagesContext {
-  const modes = options.shouldUseServerComponents ? ['server', 'client'] : ['client']
+  const isDev = options.dev ?? true
+  const modes = [
+    ...(options.shouldUseServerComponents ? ['server', 'client'] : ['client']),
+    'dev',
+    'prod',
+  ]
   const treeOptions: BuildTreeOptions = {
     roots: options.roots,
     modes,
@@ -59,11 +65,24 @@ export function createPagesContext (options: PagesContextOptions = {}): PagesCon
   let tree: RouteTree = buildTree([], treeOptions)
   const trackedFiles = new Set<string>()
 
+  function shouldIncludeFile (filePath: string) {
+    if (!isDev && /\.dev\.[^.]+$/.test(filePath)) {
+      return false
+    }
+    if (isDev && /\.prod\.[^.]+$/.test(filePath)) {
+      return false
+    }
+    return true
+  }
+
   return {
     emit () {
       return toVueRouter4(tree, emitOptions)
     },
     addFile (filePath: string, priority = 0) {
+      if (!shouldIncludeFile(filePath)) {
+        return
+      }
       addFile(tree, { path: filePath, priority }, compiledParse)
       trackedFiles.add(filePath)
     },
@@ -75,9 +94,10 @@ export function createPagesContext (options: PagesContextOptions = {}): PagesCon
       return removed
     },
     rebuild (files: InputFile[]) {
-      tree = buildTree(files, treeOptions)
+      const filteredFiles = files.filter(f => shouldIncludeFile(f.path))
+      tree = buildTree(filteredFiles, treeOptions)
       trackedFiles.clear()
-      for (const f of files) {
+      for (const f of filteredFiles) {
         trackedFiles.add(f.path)
       }
     },
@@ -107,7 +127,11 @@ export async function resolvePagesRoutes (pattern: string | string[], nuxt = use
     pages = ctx.emit()
   } else {
     // One-shot for production / no-context case
-    const oneShot = createPagesContext({ roots: pagesDirs, shouldUseServerComponents: !!nuxt.options.experimental.componentIslands })
+    const oneShot = createPagesContext({
+      roots: pagesDirs,
+      shouldUseServerComponents: !!nuxt.options.experimental.componentIslands,
+      dev: nuxt.options.dev,
+    })
     oneShot.rebuild(inputFiles)
     pages = oneShot.emit()
   }

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -684,11 +684,11 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
       // A statically imported page would be linked into the bundle it is being
       // dropped from even when its component is never referenced there, so
       // environment-restricted pages fall back to a droppable dynamic import
-      if (page._sync && !stub) {
+      if (page._sync && !stub && !isProdOnlyInDev) {
         metaImports.add(genImport(file, [{ name: 'default', as: pageImportName }]))
       }
 
-      const isSyncImport = page._sync && page.mode !== 'client' && !stub
+      const isSyncImport = page._sync && page.mode !== 'client' && !stub && !isProdOnlyInDev
       const pageImport = isSyncImport ? pageImportName : genDynamicImport(file)
       // Mirror whatever the route's own `name` resolves to below, so that a name extracted at
       // build time does not pull in the macro module purely to set `__name`. That import is the

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -66,10 +66,7 @@ export function createPagesContext (options: PagesContextOptions = {}): PagesCon
   const trackedFiles = new Set<string>()
 
   function shouldIncludeFile (filePath: string) {
-    if (!isDev && /\.dev\.[^.]+$/.test(filePath)) {
-      return false
-    }
-    if (isDev && /\.prod\.[^.]+$/.test(filePath)) {
+    if (!isDev && /(?:^|\.)dev(?:\.|$)/.test(filePath)) {
       return false
     }
     return true
@@ -665,14 +662,24 @@ export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = 
       const metaImportName = pageImportName + 'Meta'
       const metaImport = genImport(`${file}?macro=true`, [{ name: 'default', as: metaImportName }])
 
-      const restriction = options.restrictedPages?.get(page)
+      const isProdOnlyInDev = Boolean(nuxt.options.dev && /(?:^|\.)prod(?:\.|$)/.test(file))
+      if (isProdOnlyInDev) {
+        metaImports.add('\nconst _prodOnlyPageStub = { setup () { showError({ statusCode: 404, statusMessage: \'Production-Only Page\', message: \'This page is configured with a .prod suffix and will render its real content in production builds.\' }) }, render: () => null };')
+      }
+
+      const restriction = isProdOnlyInDev ? undefined : options.restrictedPages?.get(page)
       const stub = restriction ? PAGE_STUBS[restriction] : undefined
       if (stub) {
         metaImports.add(stub.declaration)
       }
-      const restrictToEnvironment = (loader: string) => stub
-        ? `import.meta.${stub.env} ? ${loader} : () => Promise.resolve(${stub.name})`
-        : loader
+      const restrictToEnvironment = (loader: string) => {
+        if (isProdOnlyInDev) {
+          return '() => Promise.resolve(_prodOnlyPageStub)'
+        }
+        return stub
+          ? `import.meta.${stub.env} ? ${loader} : () => Promise.resolve(${stub.name})`
+          : loader
+      }
 
       // A statically imported page would be linked into the bundle it is being
       // dropped from even when its component is never referenced there, so

--- a/packages/nuxt/test/components-fixture/components/DebugOnly.dev.vue
+++ b/packages/nuxt/test/components-fixture/components/DebugOnly.dev.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Debug Only Component</div>
+</template>

--- a/packages/nuxt/test/components-fixture/components/DevClient.dev.client.vue
+++ b/packages/nuxt/test/components-fixture/components/DevClient.dev.client.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Dev Client Component</div>
+</template>

--- a/packages/nuxt/test/components-fixture/components/ProdOnly.prod.vue
+++ b/packages/nuxt/test/components-fixture/components/ProdOnly.prod.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Prod Only Component</div>
+</template>

--- a/packages/nuxt/test/naming.test.ts
+++ b/packages/nuxt/test/naming.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { pascalCase } from 'scule'
-import { getNameFromPath, resolveComponentNameSegments } from '../src/core/utils/index.ts'
+import { getNameFromPath, hasSuffix, resolveComponentNameSegments } from '../src/core/utils/index.ts'
 
 describe('getNameFromPath', () => {
   const cases: Record<string, string> = {
@@ -11,11 +11,24 @@ describe('getNameFromPath', () => {
     'base.dev.vue': 'base',
     'base.prod.vue': 'base',
     'base.dev.client.vue': 'base',
+    'base.client.dev.vue': 'base',
+    'base.prod.server.vue': 'base',
+    'base.server.prod.vue': 'base',
     'desktop/default.dev.vue': 'desktop-default',
     '(group)/default.dev.vue': 'default',
+    '(group)/default.client.dev.vue': 'default',
   }
   it.each(Object.keys(cases))('correctly deduplicates segments - %s', (filename) => {
     expect(getNameFromPath(filename)).toEqual(cases[filename])
+  })
+})
+
+describe('hasSuffix', () => {
+  it('detects simple and chained suffixes', () => {
+    expect(hasSuffix('logger.global.ts', '.global')).toBe(true)
+    expect(hasSuffix('logger.global.dev.ts', '.global')).toBe(true)
+    expect(hasSuffix('logger.dev.global.ts', '.global')).toBe(true)
+    expect(hasSuffix('logger.dev.ts', '.global')).toBe(false)
   })
 })
 

--- a/packages/nuxt/test/naming.test.ts
+++ b/packages/nuxt/test/naming.test.ts
@@ -8,6 +8,11 @@ describe('getNameFromPath', () => {
     'base/base.vue': 'base',
     'base/base-layout.vue': 'base-layout',
     'base-1-layout': 'base-1-layout',
+    'base.dev.vue': 'base',
+    'base.prod.vue': 'base',
+    'base.dev.client.vue': 'base',
+    'desktop/default.dev.vue': 'desktop-default',
+    '(group)/default.dev.vue': 'default',
   }
   it.each(Object.keys(cases))('correctly deduplicates segments - %s', (filename) => {
     expect(getNameFromPath(filename)).toEqual(cases[filename])

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -1283,23 +1283,26 @@ export const pageTests: Array<{
 ]
 
 describe('pages:environment-specific routes (.dev, .prod)', () => {
-  it('should include .dev routes and exclude .prod routes in dev mode', () => {
+  it('should include both .dev routes and .prod routes (with stub) in dev mode', () => {
     const files = [
       { path: 'pages/index.vue' },
       { path: 'pages/sandbox.dev.vue' },
+      { path: 'pages/client-sandbox.client.dev.vue' },
       { path: 'pages/maintenance.prod.vue' },
     ]
     const devRoutes = generateRoutesFromFiles(files, { roots: ['pages/'], dev: true })
     const devPaths = devRoutes.map(r => r.path)
     expect(devPaths).toContain('/sandbox')
+    expect(devPaths).toContain('/client-sandbox')
     expect(devPaths).toContain('/')
-    expect(devPaths).not.toContain('/maintenance')
+    expect(devPaths).toContain('/maintenance')
   })
 
   it('should include .prod routes and exclude .dev routes in prod mode', () => {
     const files = [
       { path: 'pages/index.vue' },
       { path: 'pages/sandbox.dev.vue' },
+      { path: 'pages/client-sandbox.client.dev.vue' },
       { path: 'pages/maintenance.prod.vue' },
     ]
     const prodRoutes = generateRoutesFromFiles(files, { roots: ['pages/'], dev: false })
@@ -1307,5 +1310,6 @@ describe('pages:environment-specific routes (.dev, .prod)', () => {
     expect(prodPaths).toContain('/maintenance')
     expect(prodPaths).toContain('/')
     expect(prodPaths).not.toContain('/sandbox')
+    expect(prodPaths).not.toContain('/client-sandbox')
   })
 })

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -1281,3 +1281,31 @@ export const pageTests: Array<{
     ],
   },
 ]
+
+describe('pages:environment-specific routes (.dev, .prod)', () => {
+  it('should include .dev routes and exclude .prod routes in dev mode', () => {
+    const files = [
+      { path: 'pages/index.vue' },
+      { path: 'pages/sandbox.dev.vue' },
+      { path: 'pages/maintenance.prod.vue' },
+    ]
+    const devRoutes = generateRoutesFromFiles(files, { roots: ['pages/'], dev: true })
+    const devPaths = devRoutes.map(r => r.path)
+    expect(devPaths).toContain('/sandbox')
+    expect(devPaths).toContain('/')
+    expect(devPaths).not.toContain('/maintenance')
+  })
+
+  it('should include .prod routes and exclude .dev routes in prod mode', () => {
+    const files = [
+      { path: 'pages/index.vue' },
+      { path: 'pages/sandbox.dev.vue' },
+      { path: 'pages/maintenance.prod.vue' },
+    ]
+    const prodRoutes = generateRoutesFromFiles(files, { roots: ['pages/'], dev: false })
+    const prodPaths = prodRoutes.map(r => r.path)
+    expect(prodPaths).toContain('/maintenance')
+    expect(prodPaths).toContain('/')
+    expect(prodPaths).not.toContain('/sandbox')
+  })
+})

--- a/packages/nuxt/test/scan-components.test.ts
+++ b/packages/nuxt/test/scan-components.test.ts
@@ -8,9 +8,11 @@ import type { ComponentsDir } from 'nuxt/schema'
 
 const rFixture = (...p: string[]) => resolve(componentsFixtureDir, ...p)
 
+let mockDev = true
 vi.mock('@nuxt/kit', () => ({
   isIgnored: () => false,
   useLogger: () => consola.create({}).withTag('nuxt'),
+  useNuxt: () => ({ options: { dev: mockDev } }),
 }))
 
 const dirs: ComponentsDir[] = [
@@ -243,12 +245,42 @@ const expectedComponents = [
 const srcDir = rFixture('.')
 
 it('components:scanComponents', async () => {
+  mockDev = true
   const scannedComponents = await scanComponents(dirs, srcDir)
-  for (const c of scannedComponents) {
+  const baseComponents = scannedComponents.filter(c => !['DebugOnly', 'DevClient', 'ProdOnly'].includes(c.pascalName))
+  for (const c of baseComponents) {
     // @ts-expect-error filePath is not optional but we don't want it to be in the snapshot
     delete c.filePath
     // @ts-expect-error _scanned is added internally but we don't want it to be in the snapshot
     delete c._scanned
   }
-  expect(scannedComponents).deep.eq(expectedComponents)
+  expect(baseComponents).deep.eq(expectedComponents)
+})
+
+it('components:scanComponents environment modifiers (.dev, .prod)', async () => {
+  mockDev = true
+  const devComponents = await scanComponents(dirs, srcDir)
+  const debugInDev = devComponents.find(c => c.pascalName === 'DebugOnly')
+  const prodInDev = devComponents.find(c => c.pascalName === 'ProdOnly')
+  const devClientInDev = devComponents.find(c => c.pascalName === 'DevClient')
+
+  expect(debugInDev?.priority).toBe(1)
+  expect(debugInDev?.filePath).toContain('DebugOnly.dev.vue')
+  expect(devClientInDev?.mode).toBe('client')
+  expect(devClientInDev?.priority).toBe(1)
+  // Prod-only component is stubbed in dev
+  expect(prodInDev?.priority).toBe(0)
+  expect(prodInDev?.filePath).not.toContain('ProdOnly.prod.vue')
+
+  mockDev = false
+  const prodComponents = await scanComponents(dirs, srcDir)
+  const debugInProd = prodComponents.find(c => c.pascalName === 'DebugOnly')
+  const prodInProd = prodComponents.find(c => c.pascalName === 'ProdOnly')
+
+  expect(prodInProd?.priority).toBe(1)
+  expect(prodInProd?.filePath).toContain('ProdOnly.prod.vue')
+  // Dev-only component is stubbed in prod
+  expect(debugInProd?.priority).toBe(0)
+  expect(debugInProd?.filePath).not.toContain('DebugOnly.dev.vue')
+  expect(debugInProd?.declarationPath).toContain('DebugOnly.dev.vue')
 })

--- a/packages/nuxt/test/templates.test.ts
+++ b/packages/nuxt/test/templates.test.ts
@@ -71,4 +71,17 @@ describe('middlewareTemplate', () => {
     expect(contents).toContain('logs: () => () => {}')
     expect(contents).toContain('auth: () => import("/path/to/auth.prod.ts")')
   })
+
+  it('emits Promise-wrapped no-op function for stubbed named middleware in dev mode', async () => {
+    const app = makeApp({
+      middleware: [
+        { name: 'auth', path: '/path/to/auth.dev.ts', global: false },
+        { name: 'prodOnly', path: 'virtual:nuxt-middleware-stub', global: false },
+      ],
+    })
+    const contents = await middlewareTemplate.getContents!({ nuxt: makeNuxt({ dev: true }), app, options: {} })
+
+    expect(contents).toContain('import: () => Promise.resolve(() => {})')
+    expect(contents).toContain('import: () => import("/path/to/auth.dev.ts")')
+  })
 })

--- a/packages/nuxt/test/templates.test.ts
+++ b/packages/nuxt/test/templates.test.ts
@@ -7,7 +7,7 @@ import { resolve } from 'pathe'
 // it does in production; otherwise the test would see partially-initialised
 // exports and crash before any assertions run.
 import '../src/core/app.ts'
-import { appConfigTemplate, publicPathTemplate } from '../src/core/templates.ts'
+import { appConfigTemplate, middlewareTemplate, publicPathTemplate } from '../src/core/templates.ts'
 
 import type { Nuxt, NuxtApp } from 'nuxt/schema'
 
@@ -22,8 +22,12 @@ function makeNuxt (overrides: Partial<Nuxt['options']> = {}): Nuxt {
   } as unknown as Nuxt
 }
 
-function makeApp (configs: string[] = []): NuxtApp {
-  return { configs } as unknown as NuxtApp
+function makeApp (overrides: Partial<NuxtApp> = {}): NuxtApp {
+  return {
+    configs: [],
+    middleware: [],
+    ...overrides,
+  } as unknown as NuxtApp
 }
 
 describe('appConfigTemplate', () => {
@@ -51,5 +55,20 @@ describe('publicPathTemplate', () => {
 
     expect(contents).not.toMatch(/runtime-config/)
     expect(contents).toMatch(/getAppConfig = \(\) => \(/)
+  })
+})
+
+describe('middlewareTemplate', () => {
+  it('emits no-op function for stubbed named middleware in production', async () => {
+    const app = makeApp({
+      middleware: [
+        { name: 'auth', path: '/path/to/auth.prod.ts', global: false },
+        { name: 'logs', path: 'virtual:nuxt-middleware-stub', global: false },
+      ],
+    })
+    const contents = await middlewareTemplate.getContents!({ nuxt: makeNuxt({ dev: false }), app, options: {} })
+
+    expect(contents).toContain('logs: () => () => {}')
+    expect(contents).toContain('auth: () => import("/path/to/auth.prod.ts")')
   })
 })


### PR DESCRIPTION
### 🔗 Linked Discussion
Resolves https://github.com/nuxt/nuxt/discussions/32451

---

### 📝 Summary

This PR introduces first-class support for **environment-specific files** across Nuxt's core directory structure using `.dev` and `.prod` file modifiers:

- **Components (`components/`)**:
  - `*.dev.vue`: Active in `nuxt dev`. Auto-stubbed to a lightweight empty component in production builds with TypeScript declarations preserved.
  - `*.prod.vue`: Active in production builds. Auto-stubbed in development mode.
  - Supports paired implementations (e.g. `AppHeader.dev.vue` + `AppHeader.prod.vue`).

- **Pages (`pages/`)**:
  - `*.dev.vue`: Included in the route tree only during `nuxt dev` (e.g. `sandbox.dev.vue` $\rightarrow$ `/sandbox`). Completely excluded from production builds (404 Not Found).
  - `*.prod.vue`: Active in production builds. In `nuxt dev`, registered with a dev-stub that renders the official 404 template with a production notice, ensuring zero Vue Router `[VUE_ROUTER_R0004]` missing-route warnings for internal `<NuxtLink>` components.

- **Layouts (`layouts/`)**:
  - `*.dev.vue`: Available only in `nuxt dev`.
  - `*.prod.vue`: Available only in production builds.
  - Naturally supported by `<NuxtLayout>` fallback slot pass-through.

- **Middleware (`middleware/`)**:
  - `*.global.dev.ts` / `*.global.prod.ts`: Global middleware active only in their respective environments.
  - Named middleware (e.g. `auth.dev.ts`): Automatically auto-stubbed (`() => () => {}`) in production builds if no `.prod` counterpart is provided, preventing runtime router lookup errors while ensuring 100% tree-shaking.

- **Compound / Chained Modifiers**:
  - Full support for multi-dot chained modifiers in any order (e.g. `*.client.dev.vue`, `*.dev.client.vue`, `*.server.prod.vue`, `*.global.dev.ts`).

---

### 🧪 Test Coverage

Comprehensive unit tests added across all layers:
- `test/scan-components.test.ts`: Scanning, priority resolution, and stubbing for `.dev` and `.prod` components.
- `test/pages.test.ts`: Environment-specific route tree generation and compound modifier handling (`.client.dev.vue`).
- `test/naming.test.ts`: Suffix stripping and compound modifier detection (`hasSuffix`).
- `test/templates.test.ts`: Production `middleware.mjs` no-op stub generation for named middleware.

---

### 📖 Documentation

Updated official documentation with `:badge[v4.6]` badges:
- `docs/2.directory-structure/1.app/1.components.md`
- `docs/2.directory-structure/1.app/1.pages.md`
- `docs/2.directory-structure/1.app/1.layouts.md`
- `docs/2.directory-structure/1.app/1.middleware.md`

---

### 📋 Checklist

- [x] I have linked to the discussion / issue.
- [x] I have updated the documentation accordingly.
- [x] I have added unit tests to cover my changes.
- [x] All existing and new tests pass locally (`pnpm test`).
