### PR TITLE
fix(nuxt): start `<NuxtTime>` interval when `relative` is enabled after mount

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-time.vue
+++ b/packages/nuxt/src/app/components/nuxt-time.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, getCurrentInstance, onBeforeUnmount, ref } from 'vue'
+import { computed, getCurrentInstance, onBeforeUnmount, ref, watch } from 'vue'
 import { onPrehydrate } from '../composables/ssr'
 import { useNuxtApp } from '../nuxt'
 
@@ -60,12 +60,29 @@ const locale = computed(() => {
 })
 
 const now = ref(import.meta.client && nuxtApp.isHydrating && window._nuxtTimeNow ? new Date(window._nuxtTimeNow) : new Date())
-if (import.meta.client && props.relative) {
+if (import.meta.client) {
   const handler = () => {
     now.value = new Date()
   }
-  const interval = setInterval(handler, 1000)
-  onBeforeUnmount(() => clearInterval(interval))
+  let interval: ReturnType<typeof setInterval> | undefined
+  watch(() => props.relative, (relative) => {
+    if (interval) {
+      clearInterval(interval)
+      interval = undefined
+    }
+    if (relative) {
+      // resync `now` unless hydrating, where it must keep the prehydrate-seeded value
+      if (!nuxtApp.isHydrating) {
+        handler()
+      }
+      interval = setInterval(handler, 1000)
+    }
+  }, { immediate: true })
+  onBeforeUnmount(() => {
+    if (interval) {
+      clearInterval(interval)
+    }
+  })
 }
 
 const formatter = computed(() => {

--- a/test/nuxt/nuxt-time.test.ts
+++ b/test/nuxt/nuxt-time.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { defineComponent, h } from 'vue'
+import { defineComponent, h, nextTick, ref } from 'vue'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { injectHead } from '#unhead/composables'
 
@@ -76,6 +76,40 @@ describe('<NuxtTime>', () => {
     expect(thing.html()).toMatchInlineSnapshot(
       `"<time datetime="${new Date(datetime).toISOString()}">5 min ago</time>"`,
     )
+  })
+
+  it('should tick relative time when `relative` is enabled after mount', async () => {
+    vi.useFakeTimers()
+    try {
+      const datetime = Date.now() - 5 * 1000
+      const relative = ref(false)
+      const thing = await mountSuspended(
+        defineComponent({
+          render: () =>
+            h(NuxtTime, {
+              datetime,
+              relative: relative.value,
+              locale: 'en-GB',
+            }),
+        }),
+      )
+      expect(thing.element.textContent).not.toContain('ago')
+
+      // time passes while the component is not in relative mode
+      await vi.advanceTimersByTimeAsync(10_000)
+      relative.value = true
+      await nextTick()
+      expect(thing.element.textContent).toBe('15 seconds ago')
+
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(thing.element.textContent).toBe('16 seconds ago')
+
+      relative.value = false
+      await nextTick()
+      expect(thing.element.textContent).not.toContain('ago')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('should display datetime in title', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

None; found while re-reading the component after #35923.

### 📚 Description

The one-second interval that drives relative output only starts when `relative` is truthy at setup:

```ts
if (import.meta.client && props.relative) {
  const interval = setInterval(handler, 1000)
  onBeforeUnmount(() => clearInterval(interval))
}
```

Enable `relative` after mount (say, an absolute/relative toggle on a feed) and two things go wrong:

- the formatter switches to `Intl.RelativeTimeFormat`, but no interval is running, so the text never ticks again;
- the diff is computed against a `now` captured at mount, so the first paint is already wrong. A component mounted at 12:00 that switches to relative at 12:10 renders a 12:09:55 timestamp as "in 10 minutes".

The fix replaces the setup-time gate with an immediate `watch` on `relative` that starts and stops the interval. On enable it resyncs `now` first, except during hydration, where the prehydrate-seeded `window._nuxtTimeNow` value has to survive so the first client render matches the prehydrated text. Disabling `relative` now also clears the interval; previously it kept ticking a `now` nothing was reading.

The new test fails on `main` (the label freezes at "5 seconds ago") and passes with the fix.

Overlaps textually with #33559, which adds a `relativeReactive` opt-out inside the same `if` block; the two changes are independent and I am happy to rebase whichever lands second.