### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/nuxt/src/core/cache.ts
+++ b/packages/nuxt/src/core/cache.ts
@@ -306,7 +306,11 @@ async function readFilesRecursive (dir: string | string[], opts: ReadFilesRecurs
   const files = await glob(opts.patterns, { cwd: dir })
 
   const fileEntries = await Promise.all(files.map(async (fileName) => {
-    if (!opts.shouldIgnore?.(fileName)) {
+    // `shouldIgnore` (e.g. `isIgnored` from `@nuxt/kit`) expects absolute paths,
+    // so resolve the glob-relative file name before testing it against the
+    // ignore rules. Otherwise every file escapes the layer roots and the
+    // rules never match, leaving ignored files in the build cache hash.
+    if (!opts.shouldIgnore?.(resolve(dir, fileName))) {
       const file = await readFileWithMeta(dir, fileName)
       if (!file) { return }
       return {

--- a/packages/nuxt/test/cache.test.ts
+++ b/packages/nuxt/test/cache.test.ts
@@ -279,4 +279,42 @@ describe('buildCache', { sequential: true, timeout: 120_000 }, async () => {
     const latestJson = JSON.parse(await readFile(join(nuxt2.options.buildDir, 'manifest', 'latest.json'), 'utf-8'))
     expect(latestJson.id).toBe('build-2')
   })
+
+  it('should ignore ignored files when computing the cache hash', async () => {
+    const rootDir = join(tmpDir, 'project')
+
+    // `unit.spec.ts` matches the default `ignore` rules (`**/*.{spec,test}.{js,ts}`)
+    // and must never influence the build cache hash
+    await writeFile(join(rootDir, 'unit.spec.ts'), 'export default () => "first"')
+
+    const nuxt1 = await loadNuxt({
+      cwd: rootDir,
+      overrides: {
+        buildId: 'ignore-1',
+        experimental: { buildCache: true },
+        dev: false,
+        workspaceDir: tmpDir,
+      },
+    })
+    await build(nuxt1)
+
+    // Change only the ignored file: this must still be a cache hit that
+    // restores the first buildId
+    await writeFile(join(rootDir, 'unit.spec.ts'), 'export default () => "second"')
+
+    const nuxt2 = await loadNuxt({
+      cwd: rootDir,
+      overrides: {
+        buildId: 'ignore-2',
+        experimental: { buildCache: true },
+        dev: false,
+        workspaceDir: tmpDir,
+      },
+    })
+
+    // The buildId is restored on a cache hit, so the ignored file change must
+    // not have invalidated the cache
+    expect(nuxt2.options.buildId).toBe('ignore-1')
+    await build(nuxt2)
+  })
 })


### PR DESCRIPTION
## What

Nuxt's build cache decides whether a rebuild is needed by hashing project files — but it should skip files the user told it to ignore (`.nuxtignore` and the default rules for spec/test files). It wasn't skipping them, because the ignore check received file names relative to the scanned directory while it expects absolute paths. Every name came out prefixed with `../`, which the ignore helper's escape guard rejects, so the rules silently never matched. Result: changing a file that is supposed to be ignored still invalidated the cache and triggered unnecessary rebuilds.

This PR resolves the file names to absolute paths before the ignore check, making the existing rules actually apply.

## Details

- One-line behavior fix in `packages/nuxt/src/core/cache.ts` at the call site that carries the "validate if works with absolute paths" TODO.
- A new test in `packages/nuxt/test/cache.test.ts` builds a project, changes only an ignored spec file, and asserts the cache still hits and restores the previous build id. It fails on the old code and passes with the fix.
- No API change — the function signature and the hashing logic for non-ignored files are untouched.

## Tests

- `pnpm exec vitest run --project unit packages/nuxt/test/cache.test.ts` — 7 tests, all passing.
- Lint clean on all touched files.