### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -6,6 +6,7 @@ import type { Import, InlinePreset, Unimport } from 'unimport'
 import { createUnimport, scanDirExports, toExports, toTypeDeclarationFile, toTypeReExports } from 'unimport'
 import escapeRE from 'escape-string-regexp'
 import { resolveModulePath } from 'exsolve'
+import { klona } from 'klona'
 
 import { isDirectory, linkToAlias, logger } from '../utils.ts'
 import { TransformPlugin } from './transform.ts'
@@ -42,8 +43,14 @@ export default defineNuxtModule<Partial<ImportsOptions>>({
     polyfills: true,
   }),
   setup (options, nuxt) {
-    // TODO: fix sharing of defaults between invocations of modules
-    const presets: InlinePreset[] = JSON.parse(JSON.stringify(options.presets))
+    // Clone the presets so that mutations from `imports:sources` listeners (or the
+    // `appCompatPresets` push below) never leak back into `defaultPresets` or between
+    // invocations of this module. `klona` preserves RegExp/function values that
+    // `JSON.parse(JSON.stringify())` would silently drop (e.g. a package preset's
+    // `ignore` filter), keeping `#imports` consistent across invocations/layers.
+    // (`options.presets` is always defined via the module defaults; the fallback only
+    // satisfies the type system.)
+    const presets = klona(options.presets ?? []) as InlinePreset[]
 
     if (options.polyfills) {
       presets.push(...appCompatPresets)

--- a/packages/nuxt/test/imports-defaults.test.ts
+++ b/packages/nuxt/test/imports-defaults.test.ts
@@ -1,0 +1,68 @@
+import { fileURLToPath } from 'node:url'
+import { normalize } from 'pathe'
+import { withoutTrailingSlash } from 'ufo'
+import type { MockInstance } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { buildNuxt } from '@nuxt/kit'
+import type { Unimport } from 'unimport'
+import { loadNuxt } from '../src/index.ts'
+
+const fixtureDir = withoutTrailingSlash(normalize(fileURLToPath(new URL('./imports-preset-fixture', import.meta.url))))
+
+let warn: MockInstance<typeof console.warn>
+
+beforeEach(() => {
+  warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  warn.mockRestore()
+})
+
+describe('imports module defaults', () => {
+  it('preserves non-JSON preset content when cloning defaults between invocations', async () => {
+    let ctx: Unimport | undefined
+
+    const nuxt = await loadNuxt({
+      cwd: fixtureDir,
+      ready: true,
+      overrides: {
+        hooks: {
+          'imports:context': (unimportCtx: Unimport) => {
+            ctx = unimportCtx
+          },
+        },
+        imports: {
+          presets: [
+            {
+              package: 'defu',
+              cache: false,
+              ignore: [/^createDefu$/],
+            },
+          ],
+        },
+        builder: {
+          bundle: () => {
+            nuxt.hooks.removeAllHooks()
+            return Promise.resolve()
+          },
+        },
+      },
+    })
+
+    await buildNuxt(nuxt)
+    await nuxt.close()
+
+    // The imports module registers its own `modules:done` hook after all modules,
+    // which calls `imports:context`. Assert the resolved imports respect the RegExp
+    // `ignore` entry of the package preset.
+    expect(ctx).toBeDefined()
+    const imports = await ctx!.getImports()
+    const names = imports.map(i => i.name)
+    // `createDefu` is excluded by the RegExp `ignore` entry — the JSON clone in the
+    // module corrupts RegExp values into `{}`, so this fails without the fix.
+    expect(names).not.toContain('createDefu')
+    // other exports of the package must still be present
+    expect(names).toContain('defu')
+  })
+})


### PR DESCRIPTION
## What

The imports module keeps a working copy of the auto-import presets so its own additions never leak back into the shared defaults. The copy was made with a JSON round-trip, which silently drops everything JSON cannot represent — most notably `RegExp` and function values that preset authors use for ignore filters and custom logic. Those presets lost part of their configuration, and the inconsistency could differ between module invocations and layers.

This PR switches the copy to `klona`, which preserves RegExp and function values while still giving each invocation its own isolated array.

## Details

- The change is in `packages/nuxt/src/imports/module.ts`, replacing the JSON-based clone with `klona`.
- A new test reuses the existing `imports-preset-fixture` and verifies a preset with a RegExp-based `ignore` filter keeps working end to end.
- No preset content, ordering, or public behavior is changed for the normal case.

## Tests

- `pnpm exec vitest run --project unit packages/nuxt/test/imports-defaults.test.ts` — passing.
- Lint clean on all touched files.