### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -237,7 +237,10 @@ const NuxtIsland = defineComponent({
         throw createError({ status: r.status, statusText: r.statusText })
       }
       try {
-        const result = r._data!
+        const result: unknown = r._data
+        if (typeof result !== 'object' || result === null || typeof (result as NuxtIslandResponse).html !== 'string' || !(result as NuxtIslandResponse).html) {
+          throw createError({ status: 500, statusText: 'Invalid island response' })
+        }
         // TODO: support passing on more headers
         if (import.meta.server && import.meta.prerender) {
           const hints = r.headers.get('x-nitro-prerender')
@@ -245,8 +248,8 @@ const NuxtIsland = defineComponent({
             event!.res.headers.append('x-nitro-prerender', hints)
           }
         }
-        setPayload(key, result)
-        return result
+        setPayload(key, result as NuxtIslandResponse)
+        return result as NuxtIslandResponse
       } catch (e: any) {
         if (r.status !== 200) {
           throw renderDiagnostics.NUXT_E4012({ name: props.name, status: r.status, detail: e.message, cause: e })

--- a/test/nuxt/nuxt-island.test.ts
+++ b/test/nuxt/nuxt-island.test.ts
@@ -220,6 +220,50 @@ describe('runtime server component', () => {
     fetchRaw.mockReset()
   })
 
+  it('expect NuxtIsland to emit an error for a malformed (non-object) payload', async () => {
+    const fetchRaw = stubFetchRaw(() => {
+      return Promise.resolve(islandResponse('<html>not an island response</html>'))
+    })
+
+    const wrapper = await mountSuspended(createServerComponent('MalformedPayloadServerComponent'), {
+      props: {
+        name: 'MalformedPayload',
+        props: {
+          force: true,
+        },
+      },
+      attachTo: 'body',
+    })
+
+    expect(fetchRaw).toHaveBeenCalledOnce()
+    expect(wrapper.emitted('error')).toHaveLength(1)
+    const [[emitted]] = wrapper.emitted('error')!
+    expect((emitted as Error & { status?: number }).status).toBe(500)
+    fetchRaw.mockReset()
+  })
+
+  it('expect NuxtIsland to emit an error for a payload missing html', async () => {
+    const fetchRaw = stubFetchRaw(() => {
+      return Promise.resolve(islandResponse({ head: { link: [], style: [] } }))
+    })
+
+    const wrapper = await mountSuspended(createServerComponent('MissingHtmlServerComponent'), {
+      props: {
+        name: 'MissingHtml',
+        props: {
+          force: true,
+        },
+      },
+      attachTo: 'body',
+    })
+
+    expect(fetchRaw).toHaveBeenCalledOnce()
+    expect(wrapper.emitted('error')).toHaveLength(1)
+    const [[emitted]] = wrapper.emitted('error')!
+    expect((emitted as Error & { status?: number }).status).toBe(500)
+    fetchRaw.mockReset()
+  })
+
   it('expect NuxtIsland to have parent scopeId', async () => {
     stubFetchRaw(() => Promise.resolve(islandResponse({
       id: '123',


### PR DESCRIPTION
## What

When a Nuxt island fetches its content from the server, the response was used without any shape checking (the code carried a "validate response" TODO). A malformed payload — a non-object body, or an object without the required `html` field — flowed into the hydration path and surfaced as a raw `TypeError` deep inside rendering, which is confusing and hard to trace.

This PR validates the response shape and turns those cases into a clean `500` error that flows through Nuxt's normal error path.

## Details

- The check lives in `packages/nuxt/src/app/components/nuxt-island.ts` inside the existing fetch handler, before any payload state is written.
- Two new cases in `test/nuxt/nuxt-island.test.ts` cover the non-object body and the missing-`html` body. Both fail on the old code and pass with the fix.
- Valid responses take the exact same path as before — no behavior change for working islands.

## Tests

- `pnpm exec vitest run --project nuxt test/nuxt/nuxt-island.test.ts` — 15 tests, all passing.
- Lint clean on all touched files.