### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/docs/4.api/3.utils/navigate-to.md
+++ b/docs/4.api/3.utils/navigate-to.md
@@ -17,6 +17,10 @@ Make sure to always use `await` or `return` on result of `navigateTo` when calli
 ::
 
 ::note
+`await navigateTo(...)` does not halt the current execution flow like a hard redirect. The returned promise resolves once the navigation is performed, and code after the `await` will continue to run. If you need to stop further execution (for example, within route middleware), use `return navigateTo(...)` instead.
+::
+
+::note
 `navigateTo` cannot be used within Nitro routes. To perform a server-side redirect in Nitro routes, use [`sendRedirect`](https://h3.dev/utils/response#redirectlocation-status-statustext) instead.
 ::
 


### PR DESCRIPTION
Refs #36087

### What?
Added a note to the `navigateTo` docs page (docs/4.api/3.utils/navigate-to.md)
clarifying that `await navigateTo(...)` does not halt the current execution
flow like a hard redirect.

### Why?
The issue reporter assumed that awaiting `navigateTo` would stop code
execution and perform the navigation immediately, and only later learned
that code after the `await` continues to run. The docs only said to use
`await` or `return` without explaining why, which made the reporter's
false assumption easy to make.

The behavior matches the existing middleware section, which already shows
that `navigateTo(...)` without `return` leads to unexpected behavior.