### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/docs/3.guide/6.going-further/1.experimental-features.md
+++ b/docs/3.guide/6.going-further/1.experimental-features.md
@@ -385,20 +385,22 @@ You can even get typed params within a page by using `const route = useRoute('ro
 
 Set an alternative watcher that will be used as the watching service for Nuxt.
 
-Nuxt uses `chokidar-granular` by default, which will ignore top-level directories
-(like `node_modules` and `.git`) that are excluded from watching.
+By default (with `future.compatibilityVersion: 5`), Nuxt uses `'builder'` to
+reuse the active builder's own file watcher (for example, Vite's
+`server.watcher`) instead of starting a second one. This reduces the number of
+file watchers active in dev mode. If the active builder does not implement its
+own watcher (currently webpack and rspack), Nuxt logs a warning and falls back
+to its default selection.
+
+With `future.compatibilityVersion: 4`, Nuxt uses `chokidar-granular` by default
+if your source directory is the same as your root directory. This will ignore
+top-level directories (like `node_modules` and `.git`) that are excluded from
+watching.
 
 You can set this instead to `parcel` to use `@parcel/watcher`, which may improve
 performance in large projects or on Windows platforms.
 
 You can also set this to `chokidar` to watch all files in your source directory.
-
-Set to `'builder'` to reuse the active builder's own file watcher (for example,
-Vite's `server.watcher`) instead of starting a second one. This reduces the
-number of file watchers active in dev mode and becomes the default when
-`future.compatibilityVersion` is `5`. If the active builder does not implement
-its own watcher (currently webpack and rspack), Nuxt logs a warning and falls
-back to its default selection.
 
 ```ts twoslash [nuxt.config.ts]
 export default defineNuxtConfig({


### PR DESCRIPTION

---
## Summary

The `experimental.watcher` docs section stated "Nuxt uses `chokidar-granular` by default", but `future.compatibilityVersion` already resolves to `5` by default (see `packages/schema/src/config/experimental.ts`: `future.compatibilityVersion: { $resolve: val => typeof val === 'number' ? val as 4 | 5 : 5 }`). With `compatibilityVersion: 5`, `experimental.watcher` resolves to `'builder'` — so the page contradicted its own later sentence claiming `'builder'` "becomes the default when `future.compatibilityVersion` is `5`".

This PR corrects the section:

- States the actual default: `'builder'` (with the default `future.compatibilityVersion: 5`), reusing the active builder's own file watcher (e.g. Vite's `server.watcher`).
- Scopes the `chokidar-granular` default to `future.compatibilityVersion: 4` (when `srcDir === rootDir`), matching the resolver's fallback logic.
- Keeps the accurate `parcel` and `chokidar` option descriptions and the webpack/rspack fallback note (only Vite implements `setupWatcher`; Nuxt logs `NUXT_B1020` and falls back for other builders).

## Type

Documentation (docs/) — accuracy fix for a config-option default. Docs-only; no code, dependency, or behavior changes.

## Testing

No build needed (markdown-only change). Every rewritten claim was cross-checked against the implementation:

- `packages/schema/src/config/experimental.ts` — `future.compatibilityVersion` default is `5`; `experimental.watcher.$resolve` returns `'builder'` when `compatibilityVersion >= 5`, else `'chokidar-granular'` when `srcDir === rootDir`, else `'chokidar'`.
- `packages/schema/test/experimental.spec.ts` — `defaults to 'builder' when compatibilityVersion is 5`, `defaults to 'chokidar-granular' for v3-style layout (srcDir === rootDir)`.
- `packages/schema/src/types/schema.ts` — watcher `@default` doc matches the new wording exactly.
- `packages/nuxt/src/core/builder.ts` + `packages/kit/src/diagnostics/build.ts` (`NUXT_B1020`) — confirms the webpack/rspack fallback warning path (only Vite implements `setupWatcher`).
- `git diff --check` clean; frontmatter and all code fences intact; no links/anchors changed.

**AI disclosure:** This contribution was prepared with the assistance of AI tools and was human-reviewed before submission. The author understands and can explain the change.
---
