### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1888,7 +1888,7 @@ export interface ConfigSchema {
      *
      * @see [Nuxt TypeScript docs](https://nuxt.com/docs/4.x/guide/concepts/typescript)
      */
-    typeCheck: boolean | 'build'
+    typeCheck: boolean | 'build' | 'dev'
 
     /**
      * Extend the generated tsconfig files with shared options.

--- a/packages/vite/src/plugins/vite-plugin-checker.ts
+++ b/packages/vite/src/plugins/vite-plugin-checker.ts
@@ -3,7 +3,7 @@ import type { Nuxt } from '@nuxt/schema'
 import { readTSConfig, resolveTSConfig } from 'pkg-types'
 
 export async function VitePluginCheckerPlugin (nuxt: Nuxt, environment?: string): Promise<Array<Plugin | undefined> | undefined> {
-  if (!nuxt.options.test && (nuxt.options.typescript.typeCheck === true || (nuxt.options.typescript.typeCheck === 'build' && !nuxt.options.dev))) {
+  if (!nuxt.options.test && (nuxt.options.typescript.typeCheck === true || (nuxt.options.typescript.typeCheck === 'build' && !nuxt.options.dev) || (nuxt.options.typescript.typeCheck === 'dev' && nuxt.options.dev))) {
     const [checker, tsconfigPath] = await Promise.all([
       import('vite-plugin-checker').then(r => r.default),
       resolveTSConfig(nuxt.options.rootDir),

--- a/packages/webpack/src/configs/client.ts
+++ b/packages/webpack/src/configs/client.ts
@@ -164,7 +164,7 @@ function clientPlugins (ctx: WebpackConfigContext) {
   // Normally type checking runs in server config, but in `ssr: false` there is
   // no server build, so we inject here instead.
   if (!ctx.nuxt.options.ssr) {
-    if (!ctx.nuxt.options.test && (ctx.nuxt.options.typescript.typeCheck === true || (ctx.nuxt.options.typescript.typeCheck === 'build' && !ctx.nuxt.options.dev))) {
+    if (!ctx.nuxt.options.test && (ctx.nuxt.options.typescript.typeCheck === true || (ctx.nuxt.options.typescript.typeCheck === 'build' && !ctx.nuxt.options.dev) || (ctx.nuxt.options.typescript.typeCheck === 'dev' && ctx.nuxt.options.dev))) {
       ctx.config.plugins!.push(new TsCheckerPlugin({
         logger,
       }))

--- a/packages/webpack/src/configs/server.ts
+++ b/packages/webpack/src/configs/server.ts
@@ -149,7 +149,7 @@ function serverPlugins (ctx: WebpackConfigContext) {
   }
 
   // Add type-checking
-  if (!ctx.nuxt.options.test && (ctx.nuxt.options.typescript.typeCheck === true || (ctx.nuxt.options.typescript.typeCheck === 'build' && !ctx.nuxt.options.dev))) {
+  if (!ctx.nuxt.options.test && (ctx.nuxt.options.typescript.typeCheck === true || (ctx.nuxt.options.typescript.typeCheck === 'build' && !ctx.nuxt.options.dev) || (ctx.nuxt.options.typescript.typeCheck === 'dev' && ctx.nuxt.options.dev))) {
     ctx.config.plugins!.push(new TsCheckerPlugin({
       logger,
     }))


### PR DESCRIPTION
## Summary

This PR adds a new `'dev'` option to `typescript.typeCheck` that restricts type checking to development mode only. This complements the existing `'build'` option, which restricts type checking to production builds.

## Motivation

Currently, `typescript.typeCheck` supports:
- `true` — type check in both development and build
- `false` — no type checking
- `'build'` — type check only during production builds

Users who want type checking only during development (e.g., for faster CI builds or when using external type checkers in CI) had no option. This PR adds `'dev'` to support that use case.

## Changes

1. Updated `packages/schema/src/types/schema.ts` to add `'dev'` as a valid type for `typeCheck`
2. Updated `packages/vite/src/plugins/vite-plugin-checker.ts` to enable the checker when `typeCheck === 'dev' && nuxt.options.dev`
3. Updated `packages/webpack/src/configs/client.ts` and `packages/webpack/src/configs/server.ts` with the same condition for the webpack TsCheckerPlugin

## Usage

```ts
// nuxt.config.ts
export default defineNuxtConfig({
  typescript: {
    typeCheck: 'dev', // Only type check during development
  }
})
```

Refs #36004