### PR TITLE
fix(nuxt): preserve percent-encoding in server `navigateTo` redirects

### DIFF
--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -262,7 +262,13 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
       // We wait to perform the redirect last in case any other middleware will intercept the redirect
       // and redirect somewhere else instead.
       if (!isExternal && inMiddleware) {
-        router.afterEach(final => final.fullPath === fullPath ? redirect(false) : undefined)
+        // vue-router normalises queries so in this case we need to resolve instead of directly comparing
+        let expectedPath = fullPath
+        if (typeof to === 'string' && toPath.includes('?')) {
+          const target = router.resolve(to)
+          expectedPath = router.resolve({ path: target.path, query: target.query, hash: target.hash }).fullPath || '/'
+        }
+        router.afterEach(final => final.fullPath === expectedPath ? redirect(false) : undefined)
         return to
       }
       return redirect(!inMiddleware ? undefined : /* abort route navigation */ false)

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1486,6 +1486,18 @@ describe('middlewares', () => {
     expect(html.headers.get('location')).toEqual('/')
     expect(html.status).toEqual(307)
   })
+
+  it('should preserve percent-encoding in redirect query with navigateTo on server side', async () => {
+    const res = await fetch('/navigate-to-encoded-query', { redirect: 'manual' })
+    expect(res.headers.get('location')).toEqual('/?callback=%2Fother')
+    expect(res.status).toEqual(302)
+  })
+
+  it('should preserve percent-encoded spaces in redirect query with navigateTo on server side', async () => {
+    const res = await fetch('/navigate-to-encoded-space', { redirect: 'manual' })
+    expect(res.headers.get('location')).toEqual('/?q=a%20b')
+    expect(res.status).toEqual(302)
+  })
 })
 
 describe('plugins', () => {

--- a/test/fixtures/basic/app/middleware/redirect.global.ts
+++ b/test/fixtures/basic/app/middleware/redirect.global.ts
@@ -13,6 +13,12 @@ export default defineNuxtRouteMiddleware(async (to) => {
     // the path will be the same in this new route and vue-router should send a 500 response
     return navigateTo('/catchall/redirect-infinite?test=true')
   }
+  if (to.path === '/navigate-to-encoded-query') {
+    return navigateTo('/?callback=%2Fother')
+  }
+  if (to.path === '/navigate-to-encoded-space') {
+    return navigateTo('/?q=a%20b')
+  }
   if (to.path === '/navigate-to-external') {
     return navigateTo('/', { external: true })
   }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/33273

### 📚 Description

vue-router encodes the query, but when we were comparing paths we were doing so without the encoded query 