### PR TITLE
feat(nuxt): add experimental early return after `navigateTo`

### DIFF
--- a/docs/3.guide/6.going-further/1.experimental-features.md
+++ b/docs/3.guide/6.going-further/1.experimental-features.md
@@ -616,6 +616,43 @@ export default defineNuxtConfig({
 })
 ```
 
+## navigateToEarlyReturn
+
+Transform top-level `await navigateTo()` calls in `<script setup>` into an early return from the compiled `setup()` function when the navigation succeeds.
+
+Without this flag, code after `await navigateTo()` continues to run, which can result in later code (including subsequent `navigateTo` calls) overriding the redirect or attempting to render a page with missing data. With this flag enabled, a successful navigation stops execution of the rest of your setup code and the component renders a placeholder comment while the navigation proceeds.
+
+This flag is enabled by default with `compatibilityVersion: 5`, but you can disable it:
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  experimental: {
+    navigateToEarlyReturn: false,
+  },
+})
+```
+
+```vue [pages/example.vue]
+<script setup lang="ts">
+const { data } = await useFetch('/api/data')
+
+if (!data.value) {
+  await navigateTo('/fallback')
+}
+
+// with the flag enabled, this only runs if the navigation did not happen
+const processed = data.value!.map(item => item.name)
+</script>
+```
+
+The transform only applies to top-level `await navigateTo()` statements in `<script setup>` whose result is not used. Calls with the `open` option (or options that cannot be statically analysed) are not transformed, as they should not stop the current page from rendering.
+
+The early return only happens when the navigation succeeds (that is, when `navigateTo` resolves to `undefined`). If the navigation is aborted or fails (for example, blocked by a navigation guard, or navigating to the current route), the rest of your setup code continues to run. On a successful navigation, nothing after the `navigateTo` call runs: this includes `defineExpose` and any lifecycle hook registrations later in `<script setup>`.
+
+::read-more{icon="i-simple-icons-github" to="https://github.com/nuxt/nuxt/issues/23698" target="_blank"}
+See full explanation on the GitHub issue.
+::
+
 ## normalizeComponentNames
 
 Nuxt updates auto-generated Vue component names to match the full component name you would use to auto-import the component.

--- a/docs/4.api/3.utils/navigate-to.md
+++ b/docs/4.api/3.utils/navigate-to.md
@@ -41,6 +41,10 @@ await navigateTo({
 </script>
 ```
 
+::note
+Calling `navigateTo` does not stop execution of the rest of your `<script setup>` code. If you want a successful navigation to return early from `setup()`, enable [`experimental.navigateToEarlyReturn`](/docs/4.x/guide/going-further/experimental-features#navigatetoearlyreturn).
+::
+
 ### Within Route Middleware
 
 ```ts

--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -304,6 +304,34 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
 }
 
 /**
+ * Produces the render function returned from `setup()` when
+ * `experimental.navigateToEarlyReturn` short-circuits after a successful navigation.
+ *
+ * The returned function renders a placeholder comment both as a client render function
+ * and as an inline `ssrRender` (where it is called with a `push` function). On the server
+ * it is also assigned to `instance.ssrRender`, because the server renderer prefers the
+ * component's compiled `ssrRender` over a render function returned from `setup()`, and the
+ * compiled template must not run against the empty setup state left by the early return.
+ * @internal
+ */
+export function _navigateToEarlyReturn () {
+  const render = (_ctx?: unknown, push?: unknown) => {
+    if (typeof push === 'function') {
+      push('<!---->')
+      return
+    }
+    return null
+  }
+  if (import.meta.server) {
+    const instance = getCurrentInstance() as (ComponentInternalInstance & { ssrRender?: typeof render }) | null
+    if (instance) {
+      instance.ssrRender = render
+    }
+  }
+  return render
+}
+
+/**
  * This will abort navigation within a Nuxt route middleware handler.
  * @since 3.0.0
  */

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -53,6 +53,7 @@ import { NuxtPerfProfiler } from './perf.ts'
 import schemaModule from './schema.ts'
 import { RemovePluginMetadataPlugin } from './plugins/plugin-metadata.ts'
 import { AsyncContextInjectionPlugin } from './plugins/async-context.ts'
+import { NavigateToEarlyReturnPlugin } from './plugins/navigate-to.ts'
 import { PrehydrateTransformPlugin } from './plugins/prehydrate.ts'
 import { ExtractAsyncDataHandlersPlugin } from './plugins/extract-async-data-handlers.ts'
 import { VirtualFSPlugin } from './plugins/virtual.ts'
@@ -724,6 +725,12 @@ async function initNuxt (nuxt: Nuxt) {
   }
 
   await installModules(modules, resolvedModulePaths, nuxt)
+
+  // Transform top-level `await navigateTo()` in `<script setup>` into an early return.
+  // Registered after modules so its `post` transform runs after auto-import injection.
+  if (nuxt.options.experimental.navigateToEarlyReturn) {
+    addBuildPlugin(NavigateToEarlyReturnPlugin())
+  }
 
   if (nuxt.options.experimental.debugModuleMutation) {
     stripDebugProxies(nuxt.options)

--- a/packages/nuxt/src/core/plugins/navigate-to.ts
+++ b/packages/nuxt/src/core/plugins/navigate-to.ts
@@ -2,7 +2,7 @@ import { createUnplugin } from 'unplugin'
 import { generateTransform, rolldownString } from 'rolldown-string'
 import { ScopeTracker, walk } from 'oxc-walker'
 import type { ESTree } from 'rolldown/utils'
-import { isVue } from '../utils/index.ts'
+import { VUE_SCRIPT_ID_FILTER } from '../utils/index.ts'
 import { parseModule } from '../utils/parse.ts'
 
 const NAVIGATE_TO_RE = /\bnavigateTo\s*\(/
@@ -32,11 +32,12 @@ export const NavigateToEarlyReturnPlugin = () => createUnplugin(() => {
   return {
     name: 'nuxt:navigate-to-early-return',
     enforce: 'post',
-    transformInclude (id) {
-      return isVue(id, { type: ['script'] })
-    },
     transform: {
       filter: {
+        id: {
+          include: VUE_SCRIPT_ID_FILTER,
+          exclude: /node_modules\//,
+        },
         code: { include: /withAsyncContext/ },
       },
       handler (code, id, meta?: unknown) {

--- a/packages/nuxt/src/core/plugins/navigate-to.ts
+++ b/packages/nuxt/src/core/plugins/navigate-to.ts
@@ -79,10 +79,13 @@ export const NavigateToEarlyReturnPlugin = () => createUnplugin(() => {
               return
             }
 
-            s.appendLeft(node.start, 'if ((')
+            // wrap in a block so an `else` attached to an enclosing unbraced `if`
+            // does not rebind to the `if` statement we generate here
+            s.appendLeft(node.start, '{ if ((')
             s.appendLeft(match.awaited.start, `${match.tempName} = `)
             const end = code[node.end - 1] === ';' ? node.end - 1 : node.end
             s.appendLeft(end, `, ${match.tempName}) === undefined) return ${HELPER_LOCAL}()`)
+            s.appendLeft(node.end, ' }')
             transformed = true
           },
           leave (node) {

--- a/packages/nuxt/src/core/plugins/navigate-to.ts
+++ b/packages/nuxt/src/core/plugins/navigate-to.ts
@@ -1,0 +1,158 @@
+import { createUnplugin } from 'unplugin'
+import { generateTransform, rolldownString } from 'rolldown-string'
+import { ScopeTracker, walk } from 'oxc-walker'
+import type { ESTree } from 'rolldown/utils'
+import { isVue } from '../utils/index.ts'
+import { parseModule } from '../utils/parse.ts'
+
+const NAVIGATE_TO_RE = /\bnavigateTo\s*\(/
+const NAVIGATE_TO_SOURCES = new Set(['#app', '#imports', 'nuxt/app', '#app/composables', '#app/composables/router'])
+
+const HELPER_SOURCE = '#app/composables/router'
+const HELPER_NAME = '_navigateToEarlyReturn'
+const HELPER_LOCAL = '__nuxt_navigate_to_early_return'
+
+interface MatchedStatement {
+  awaited: ESTree.AwaitExpression
+  tempName: string
+}
+
+/**
+ * Transforms top-level `await navigateTo(...)` statements in `<script setup>` into
+ * early returns from `setup()`, so that code after a successful navigation does not run.
+ *
+ * The compiled setup function returns `_navigateToEarlyReturn()`, a render function that
+ * renders a placeholder comment in both environments (see its definition for the SSR
+ * mechanics) while the navigation proceeds.
+ *
+ * Runs with `enforce: 'post'`, after the auto-import transform, so that an explicit or
+ * injected import of a user-defined `navigateTo` override is visible and skipped.
+ */
+export const NavigateToEarlyReturnPlugin = () => createUnplugin(() => {
+  return {
+    name: 'nuxt:navigate-to-early-return',
+    enforce: 'post',
+    transformInclude (id) {
+      return isVue(id, { type: ['script'] })
+    },
+    transform: {
+      filter: {
+        code: { include: /withAsyncContext/ },
+      },
+      handler (code, id, meta?: unknown) {
+        if (!NAVIGATE_TO_RE.test(code)) { return }
+
+        const { program } = parseModule(code, id)
+
+        const scopeTracker = new ScopeTracker({ preserveExitedScopes: true })
+        walk(program, { scopeTracker })
+        scopeTracker.freeze()
+
+        const s = rolldownString(code, id, meta)
+
+        const setupFns = new Set<ESTree.Node>()
+        const functionStack: ESTree.Node[] = []
+        let transformed = false
+
+        walk(program, {
+          scopeTracker,
+          enter (node, parent) {
+            if (node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression') {
+              // only consider `setup` methods on objects at module scope, so that a `setup`
+              // property on an object created inside another function is never matched
+              if (functionStack.length === 0 && parent?.type === 'Property' && !parent.computed && parent.key.type === 'Identifier' && parent.key.name === 'setup') {
+                setupFns.add(node)
+              }
+              functionStack.push(node)
+              return
+            }
+
+            const enclosingFn = functionStack[functionStack.length - 1]
+            if (node.type !== 'ExpressionStatement' || !enclosingFn || !setupFns.has(enclosingFn)) { return }
+
+            const match = matchAwaitedNavigateTo(node)
+            if (!match) { return }
+
+            const declaration = scopeTracker.getDeclaration('navigateTo')
+            if (declaration && (declaration.type !== 'Import' || typeof declaration.importNode.source.value !== 'string' || !NAVIGATE_TO_SOURCES.has(declaration.importNode.source.value))) {
+              return
+            }
+
+            s.appendLeft(node.start, 'if ((')
+            s.appendLeft(match.awaited.start, `${match.tempName} = `)
+            const end = code[node.end - 1] === ';' ? node.end - 1 : node.end
+            s.appendLeft(end, `, ${match.tempName}) === undefined) return ${HELPER_LOCAL}()`)
+            transformed = true
+          },
+          leave (node) {
+            if (node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression') {
+              functionStack.pop()
+            }
+          },
+        })
+
+        if (transformed) {
+          s.prepend(`import { ${HELPER_NAME} as ${HELPER_LOCAL} } from '${HELPER_SOURCE}';\n`)
+        }
+
+        return generateTransform(s, id)
+      },
+    },
+  }
+})
+
+/**
+ * Matches the statement shape `@vue/compiler-sfc` produces for a bare top-level
+ * `await navigateTo(...)` in `<script setup>`:
+ *
+ * ```js
+ * ;(
+ *   ([__temp,__restore] = _withAsyncContext(() => navigateTo('/'))),
+ *   await __temp,
+ *   __restore()
+ * )
+ * ```
+ */
+function unwrapParens (node: ESTree.Expression): ESTree.Expression {
+  while (node.type === 'ParenthesizedExpression') {
+    node = node.expression
+  }
+  return node
+}
+
+function matchAwaitedNavigateTo (statement: ESTree.ExpressionStatement): MatchedStatement | undefined {
+  const expression = unwrapParens(statement.expression)
+  if (expression.type !== 'SequenceExpression' || expression.expressions.length < 3) { return }
+
+  const assignment = unwrapParens(expression.expressions[0]!)
+  const awaited = unwrapParens(expression.expressions[1]!)
+
+  if (
+    assignment.type !== 'AssignmentExpression'
+    || assignment.right.type !== 'CallExpression'
+    || assignment.right.callee.type !== 'Identifier'
+    || !assignment.right.callee.name.endsWith('withAsyncContext')
+  ) { return }
+
+  const wrapped = assignment.right.arguments[0]
+  if (wrapped?.type !== 'ArrowFunctionExpression' || wrapped.body.type === 'BlockStatement') { return }
+
+  const call = unwrapParens(wrapped.body)
+  if (call.type !== 'CallExpression' || call.callee.type !== 'Identifier' || call.callee.name !== 'navigateTo') { return }
+
+  // `navigateTo` with `open` targets a new window, so the current component must keep rendering.
+  // Skip the transform unless we can statically rule that (and other unknown option shapes) out.
+  const options = call.arguments[1]
+  if (options) {
+    if (options.type !== 'ObjectExpression') { return }
+    for (const property of options.properties) {
+      if (property.type !== 'Property' || property.computed) { return }
+      const name = property.key.type === 'Identifier' ? property.key.name : property.key.type === 'Literal' ? String(property.key.value) : undefined
+      if (!name || name === 'open') { return }
+    }
+  }
+
+  if (awaited.type !== 'AwaitExpression' || awaited.argument.type !== 'Identifier') { return }
+
+  return { awaited, tempName: awaited.argument.name }
+}

--- a/packages/nuxt/test/navigate-to-early-return.test.ts
+++ b/packages/nuxt/test/navigate-to-early-return.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { compileScript, parse } from '@vue/compiler-sfc'
+import { createSSRApp, defineComponent } from 'vue'
+import { renderToString, ssrInterpolate } from 'vue/server-renderer'
+import { NavigateToEarlyReturnPlugin } from '../src/core/plugins/navigate-to.ts'
+import { _navigateToEarlyReturn } from '../src/app/composables/router.ts'
+
+const plugin = NavigateToEarlyReturnPlugin().raw({}, { framework: 'vite', versions: {} }) as {
+  transform: { handler: (code: string, id: string) => { code: string } | null | undefined }
+}
+
+function compileSFC (source: string, { inlineTemplate = false } = {}) {
+  const { descriptor } = parse(source, { filename: 'app.vue' })
+  return compileScript(descriptor, { id: 'app.vue', inlineTemplate }).content
+}
+
+async function transform (source: string, id = 'app.vue') {
+  const result = await plugin.transform.handler(compileSFC(source), id)
+  return typeof result === 'string' ? result : result?.code
+}
+
+describe('navigateTo early return transform', () => {
+  it('transforms top-level `await navigateTo()` into an early return', async () => {
+    const result = await transform(`
+<template><div>{{ a }}</div></template>
+<script setup>
+const a = 1
+await navigateTo('/a')
+await navigateTo('/b')
+</script>
+`)
+    expect(result).toContain('return __nuxt_navigate_to_early_return()')
+    expect(result?.match(/return __nuxt_navigate_to_early_return\(\)/g)).toHaveLength(2)
+    expect(result).toMatchInlineSnapshot(`
+      "import { _navigateToEarlyReturn as __nuxt_navigate_to_early_return } from '#app/composables/router';
+      import { withAsyncContext as _withAsyncContext } from 'vue'
+      const a = 1
+
+      export default {
+        __name: 'app',
+        async setup(__props, { expose: __expose }) {
+        __expose();
+
+      let __temp, __restore
+
+      ;if (((
+        ([__temp,__restore] = _withAsyncContext(() => navigateTo('/a'))),
+        __temp = await __temp,
+        __restore()
+      )
+      , __temp) === undefined) return __nuxt_navigate_to_early_return();if (((
+        ([__temp,__restore] = _withAsyncContext(() => navigateTo('/b'))),
+        __temp = await __temp,
+        __restore()
+      ), __temp) === undefined) return __nuxt_navigate_to_early_return()
+
+      const __returned__ = { a }
+      Object.defineProperty(__returned__, '__isScriptSetup', { enumerable: false, value: true })
+      return __returned__
+      }
+
+      }"
+    `)
+  })
+
+  it('transforms `await navigateTo()` within a conditional block', async () => {
+    const result = await transform(`
+<template><div /></template>
+<script setup>
+const a = 1
+if (a) {
+  await navigateTo('/a', { replace: true })
+}
+</script>
+`)
+    expect(result).toContain('return __nuxt_navigate_to_early_return()')
+  })
+
+  it('transforms `await navigateTo()` in an unbraced conditional', async () => {
+    const result = await transform(`
+<template><div /></template>
+<script setup>
+const a = 1
+if (a) await navigateTo('/a')
+</script>
+`)
+    expect(result).toContain('return __nuxt_navigate_to_early_return()')
+  })
+
+  it('does not transform when the result is used', async () => {
+    const result = await transform(`
+<template><div /></template>
+<script setup>
+const x = await navigateTo('/a')
+</script>
+`)
+    expect(result).toBeUndefined()
+  })
+
+  it('does not transform when `open` option is used', async () => {
+    const result = await transform(`
+<template><div /></template>
+<script setup>
+await navigateTo('/a', { open: { target: '_blank' } })
+</script>
+`)
+    expect(result).toBeUndefined()
+  })
+
+  it('does not transform when options cannot be statically analysed', async () => {
+    const result = await transform(`
+<template><div /></template>
+<script setup>
+const opts = { replace: true }
+await navigateTo('/a', opts)
+</script>
+`)
+    expect(result).toBeUndefined()
+  })
+
+  it('does not transform a locally declared `navigateTo`', async () => {
+    const result = await transform(`
+<template><div /></template>
+<script setup>
+function navigateTo (to) { return Promise.resolve(to) }
+await navigateTo('/a')
+</script>
+`)
+    expect(result).toBeUndefined()
+  })
+
+  it('does not transform `navigateTo` imported from another module', async () => {
+    const result = await transform(`
+<template><div /></template>
+<script setup>
+import { navigateTo } from 'some-library'
+await navigateTo('/a')
+</script>
+`)
+    expect(result).toBeUndefined()
+  })
+
+  it('transforms `navigateTo` explicitly imported from nuxt', async () => {
+    const result = await transform(`
+<template><div /></template>
+<script setup>
+import { navigateTo } from '#app'
+await navigateTo('/a')
+</script>
+`)
+    expect(result).toContain('return __nuxt_navigate_to_early_return()')
+  })
+
+  it('does not transform a `setup` method on an object created inside a function', async () => {
+    const result = await transform(`
+<template><div /></template>
+<script>
+export function createThing () {
+  return {
+    async setup () {
+      let __temp, __restore
+      ;(
+        ([__temp,__restore] = _withAsyncContext(() => navigateTo('/'))),
+        await __temp,
+        __restore()
+      )
+    },
+  }
+}
+</script>
+<script setup>
+const a = 1
+</script>
+`)
+    expect(result).toBeUndefined()
+  })
+
+  it('does not transform calls within nested functions', async () => {
+    const result = await transform(`
+<template><div /></template>
+<script setup>
+await Promise.resolve()
+async function redirect () {
+  await navigateTo('/a')
+}
+</script>
+`)
+    expect(result).toBeUndefined()
+  })
+
+  it('transforms inline (production) compiler output', async () => {
+    const source = `
+<template><div /></template>
+<script setup>
+await navigateTo('/a')
+</script>
+`
+    const result = await plugin.transform.handler(compileSFC(source, { inlineTemplate: true }), 'app.vue')
+    const code = typeof result === 'string' ? result : result?.code
+    expect(code).toContain('return __nuxt_navigate_to_early_return()')
+  })
+})
+
+describe('navigateTo early return runtime helper', () => {
+  afterEach(() => {
+    // @ts-expect-error not typed on globalThis
+    globalThis.__TEST_SERVER__ = false
+  })
+
+  it('returns a render function that renders null on the client', () => {
+    const render = _navigateToEarlyReturn()
+    expect(render(undefined, [])).toBeNull()
+  })
+
+  it('pushes a placeholder when called as an inline ssrRender', () => {
+    const render = _navigateToEarlyReturn()
+    const pushed: string[] = []
+    expect(render(undefined, (s: string) => pushed.push(s))).toBeUndefined()
+    expect(pushed).toEqual(['<!---->'])
+  })
+
+  it('bypasses the compiled ssrRender on the server', async () => {
+    // @ts-expect-error not typed on globalThis
+    globalThis.__TEST_SERVER__ = true
+
+    const Comp = defineComponent({
+      setup () {
+        return Promise.resolve(_navigateToEarlyReturn())
+      },
+      ssrRender (_ctx: { a: { b: string } }, push: (s: string) => void) {
+        push(`<div>${ssrInterpolate(_ctx.a.b)}</div>`)
+      },
+    })
+
+    await expect(renderToString(createSSRApp(Comp))).resolves.toBe('<!---->')
+  })
+})

--- a/packages/nuxt/test/navigate-to-early-return.test.ts
+++ b/packages/nuxt/test/navigate-to-early-return.test.ts
@@ -43,16 +43,16 @@ await navigateTo('/b')
 
       let __temp, __restore
 
-      ;if (((
+      ;{ if (((
         ([__temp,__restore] = _withAsyncContext(() => navigateTo('/a'))),
         __temp = await __temp,
         __restore()
       )
-      , __temp) === undefined) return __nuxt_navigate_to_early_return();if (((
+      , __temp) === undefined) return __nuxt_navigate_to_early_return(); }{ if (((
         ([__temp,__restore] = _withAsyncContext(() => navigateTo('/b'))),
         __temp = await __temp,
         __restore()
-      ), __temp) === undefined) return __nuxt_navigate_to_early_return()
+      ), __temp) === undefined) return __nuxt_navigate_to_early_return() }
 
       const __returned__ = { a }
       Object.defineProperty(__returned__, '__isScriptSetup', { enumerable: false, value: true })
@@ -74,6 +74,33 @@ if (a) {
 </script>
 `)
     expect(result).toContain('return __nuxt_navigate_to_early_return()')
+    expect(result).toMatchInlineSnapshot(`
+      "import { _navigateToEarlyReturn as __nuxt_navigate_to_early_return } from '#app/composables/router';
+      import { withAsyncContext as _withAsyncContext } from 'vue'
+      const a = 1
+
+      export default {
+        __name: 'app',
+        async setup(__props, { expose: __expose }) {
+        __expose();
+
+      let __temp, __restore
+
+      if (a) {
+        { if (((
+        ([__temp,__restore] = _withAsyncContext(() => navigateTo('/a', { replace: true }))),
+        __temp = await __temp,
+        __restore()
+      ), __temp) === undefined) return __nuxt_navigate_to_early_return() }
+      }
+
+      const __returned__ = { a }
+      Object.defineProperty(__returned__, '__isScriptSetup', { enumerable: false, value: true })
+      return __returned__
+      }
+
+      }"
+    `)
   })
 
   it('transforms `await navigateTo()` in an unbraced conditional', async () => {
@@ -85,6 +112,69 @@ if (a) await navigateTo('/a')
 </script>
 `)
     expect(result).toContain('return __nuxt_navigate_to_early_return()')
+    expect(result).toMatchInlineSnapshot(`
+      "import { _navigateToEarlyReturn as __nuxt_navigate_to_early_return } from '#app/composables/router';
+      import { withAsyncContext as _withAsyncContext } from 'vue'
+      const a = 1
+
+      export default {
+        __name: 'app',
+        async setup(__props, { expose: __expose }) {
+        __expose();
+
+      let __temp, __restore
+
+      if (a) { if (((
+        ([__temp,__restore] = _withAsyncContext(() => navigateTo('/a'))),
+        __temp = await __temp,
+        __restore()
+      ), __temp) === undefined) return __nuxt_navigate_to_early_return() }
+
+      const __returned__ = { a }
+      Object.defineProperty(__returned__, '__isScriptSetup', { enumerable: false, value: true })
+      return __returned__
+      }
+
+      }"
+    `)
+  })
+
+  it('does not rebind `else` in an unbraced conditional', async () => {
+    const result = await transform(`
+<template><div /></template>
+<script setup>
+const a = 1
+if (a) await navigateTo('/a')
+else console.log('else branch')
+</script>
+`)
+    expect(result).toContain('return __nuxt_navigate_to_early_return()')
+    expect(result).toMatchInlineSnapshot(`
+      "import { _navigateToEarlyReturn as __nuxt_navigate_to_early_return } from '#app/composables/router';
+      import { withAsyncContext as _withAsyncContext } from 'vue'
+      const a = 1
+
+      export default {
+        __name: 'app',
+        async setup(__props, { expose: __expose }) {
+        __expose();
+
+      let __temp, __restore
+
+      if (a) { if (((
+        ([__temp,__restore] = _withAsyncContext(() => navigateTo('/a'))),
+        __temp = await __temp,
+        __restore()
+      ), __temp) === undefined) return __nuxt_navigate_to_early_return() }
+      else console.log('else branch')
+
+      const __returned__ = { a }
+      Object.defineProperty(__returned__, '__isScriptSetup', { enumerable: false, value: true })
+      return __returned__
+      }
+
+      }"
+    `)
   })
 
   it('does not transform when the result is used', async () => {
@@ -198,6 +288,31 @@ await navigateTo('/a')
     const result = await plugin.transform.handler(compileSFC(source, { inlineTemplate: true }), 'app.vue')
     const code = typeof result === 'string' ? result : result?.code
     expect(code).toContain('return __nuxt_navigate_to_early_return()')
+    expect(code).toMatchInlineSnapshot(`
+      "import { _navigateToEarlyReturn as __nuxt_navigate_to_early_return } from '#app/composables/router';
+      import { withAsyncContext as _withAsyncContext } from 'vue'
+      import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+
+      export default {
+        __name: 'app',
+        async setup(__props) {
+
+      let __temp, __restore
+
+      ;{ if (((
+        ([__temp,__restore] = _withAsyncContext(() => navigateTo('/a'))),
+        __temp = await __temp,
+        __restore()
+      ), __temp) === undefined) return __nuxt_navigate_to_early_return() }
+
+      return (_ctx, _cache) => {
+        return (_openBlock(), _createElementBlock("div"))
+      }
+      }
+
+      }"
+    `)
   })
 })
 

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -222,6 +222,11 @@ export default defineResolvers({
     },
     clientNodeCompat: false,
     navigationRepaint: true,
+    navigateToEarlyReturn: {
+      $resolve: async (val, get) => {
+        return typeof val === 'boolean' ? val : (await get('future.compatibilityVersion')) >= 5
+      },
+    },
     buildCache: false,
     normalizeComponentNames: {
       $resolve: (val) => {

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1433,6 +1433,19 @@ export interface ConfigSchema {
     navigationRepaint: boolean
 
     /**
+     * Transform top-level `await navigateTo()` calls in `<script setup>` into an early return
+     * from the compiled `setup()` function when the navigation succeeds.
+     *
+     * This stops execution of the rest of your setup code after a redirect, and renders
+     * a placeholder comment while the navigation proceeds, rather than continuing to run
+     * code (and potentially navigating again) after `navigateTo` has been called.
+     * @default false
+     * @default true with compatibilityVersion >= 5
+     * @see [Nuxt Issue #23698](https://github.com/nuxt/nuxt/issues/23698)
+     */
+    navigateToEarlyReturn: boolean
+
+    /**
      * Cache Nuxt/Nitro build artifacts based on a hash of the configuration and source files.
      *
      * This only works for source files within `srcDir` and `serverDir` for the Vue/Nitro parts of your app.

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1124,6 +1124,24 @@ describe.skipIf(!runsOnceInMatrix)('navigate', () => {
     expect(status).toEqual(301)
   })
 
+  it('stops running setup code after `await navigateTo()`', async () => {
+    const { headers, status } = await fetch('/navigate-to-early-return', { redirect: 'manual' })
+
+    expect(headers.get('location')).toEqual('/')
+    expect(status).toEqual(301)
+  })
+
+  it('stops running setup code after `await navigateTo()` on client-side navigation', async () => {
+    const { page } = await renderPage('/')
+
+    await page.evaluate(() => (window.useNuxtApp!() as unknown as { $router: { push: (to: string) => void } }).$router.push('/navigate-to-early-return'))
+    await page.waitForFunction(() => window.useNuxtApp?.()?._route.fullPath === '/')
+    await page.waitForTimeout(200)
+
+    expect(new URL(page.url()).pathname).toBe('/')
+    await page.close()
+  })
+
   it('respects redirects + headers in middleware', async () => {
     const res = await fetch('/navigate-some-path/', { redirect: 'manual', headers: { 'trailing-slash': 'true' } })
     expect(res.headers.get('location')).toEqual('/navigate-some-path')

--- a/test/fixtures/basic/app/pages/navigate-to-early-return.vue
+++ b/test/fixtures/basic/app/pages/navigate-to-early-return.vue
@@ -1,0 +1,9 @@
+<template>
+  <div>{{ hidden.join(' ') }}</div>
+</template>
+
+<script setup>
+await navigateTo('/', { redirectCode: 301 })
+await navigateTo('/navigate-some-path')
+const hidden = ['you', 'should', 'not', 'see', 'me']
+</script>


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/36087
closes https://github.com/nuxt/nuxt/issues/36087
closes https://github.com/nuxt/nuxt/pull/36097

### 📚 Description

this adds an experimental flag that allows `navigateTo` in `<script setup>` to short circuit the rest of the setup function, for handling safe redirects or 404s without throwing an error due to missing data...