### PR TITLE
perf(nuxt,vite): migrate `isVue` calls into plugin filters

### DIFF
--- a/packages/nuxt/src/compiler/plugins/keyed-functions.ts
+++ b/packages/nuxt/src/compiler/plugins/keyed-functions.ts
@@ -12,7 +12,7 @@ import type { KeyedFunction } from '@nuxt/schema'
 import type { ESTree } from 'rolldown/utils'
 
 import { parseStaticImports } from '../../core/utils/static-imports.ts'
-import { MACRO_QUERY_RE, NUXT_LIB_RE, STYLE_QUERY_RE, isWhitespace, stripExtension } from '../../utils.ts'
+import { MACRO_QUERY_RE, NUXT_LIB_RE, STYLE_QUERY_RE, SUPPORTED_EXT_RE, isWhitespace, stripExtension } from '../../utils.ts'
 import { type FunctionCallMetadata, parseStaticExportIdentifiers, parseStaticFunctionCall, processImports } from '../../core/utils/parse-utils.ts'
 
 interface KeyedFunctionsOptions {
@@ -25,7 +25,6 @@ interface KeyedFunctionsOptions {
 }
 
 const stringTypes: Array<string | undefined> = ['Literal', 'TemplateLiteral']
-const SUPPORTED_EXT_RE = /^[^?]*\.(?:m?[jt]sx?|vue)(?:$|\?)/
 const SCRIPT_RE = /(?<=<script[^>]*>)[\s\S]*?(?=<\/script>)/i
 const NUXT_INJECTED_MARKER = '/* nuxt-injected */'
 

--- a/packages/nuxt/src/components/plugins/component-names.ts
+++ b/packages/nuxt/src/components/plugins/component-names.ts
@@ -2,7 +2,7 @@ import { createUnplugin } from 'unplugin'
 import { generateTransform, rolldownString } from 'rolldown-string'
 import { parseAndWalk } from 'oxc-walker'
 
-import { SX_RE, isVue } from '../../core/utils/index.ts'
+import { SX_RE, VUE_ID_FILTER } from '../../core/utils/index.ts'
 import type { Component } from 'nuxt/schema'
 
 interface NameDevPluginOptions {
@@ -16,13 +16,9 @@ export const ComponentNamePlugin = (options: NameDevPluginOptions) => createUnpl
   return {
     name: 'nuxt:component-name-plugin',
     enforce: 'post',
-    transformInclude (id) {
-      /* v8 ignore next 2 */
-      return isVue(id) || !!id.match(SX_RE)
-    },
     transform: {
       filter: {
-        id: { include: FILENAME_RE },
+        id: { include: [...VUE_ID_FILTER, SX_RE] },
       },
       handler (code, id, meta?: unknown) {
         const filename = id.match(FILENAME_RE)?.[1]

--- a/packages/nuxt/src/components/plugins/lazy-hydration-macro-transform.ts
+++ b/packages/nuxt/src/components/plugins/lazy-hydration-macro-transform.ts
@@ -3,7 +3,7 @@ import { relative } from 'pathe'
 import { resolveAlias } from 'pathe/utils'
 import { generateTransform, rolldownString } from 'rolldown-string'
 import { genImport } from 'knitwork'
-import { isJS, isVue } from '../../core/utils/index.ts'
+import { JS_ID_RE, VUE_SCRIPT_TEMPLATE_ID_FILTER } from '../../core/utils/index.ts'
 import type { ComponentsOptions } from 'nuxt/schema'
 import { parseAndWalk } from 'oxc-walker'
 import type { ESTree } from 'rolldown/utils'
@@ -34,18 +34,12 @@ export const LazyHydrationMacroTransformPlugin = (options: LoaderOptions) => cre
   return {
     name: 'nuxt:lazy-hydration-macro',
     enforce: 'post',
-    transformInclude (id) {
-      if (exclude.some(pattern => pattern.test(id))) {
-        return false
-      }
-      if (include.some(pattern => pattern.test(id))) {
-        return true
-      }
-      return isVue(id, { type: ['template', 'script'] }) || isJS(id)
-    },
-
     transform: {
       filter: {
+        id: {
+          include: [...include, ...VUE_SCRIPT_TEMPLATE_ID_FILTER, JS_ID_RE],
+          exclude,
+        },
         code: {
           include: LAZY_HYDRATION_MACRO_RE,
         },

--- a/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
+++ b/packages/nuxt/src/components/plugins/lazy-hydration-transform.ts
@@ -6,7 +6,7 @@ import { tryUseNuxt } from '@nuxt/kit'
 import { componentDiagnostics } from '@nuxt/kit/internal'
 import { parse, walk } from 'ultrahtml'
 import { ScopeTracker, parseAndWalk } from 'oxc-walker'
-import { isVue } from '../../core/utils/index.ts'
+import { VUE_ID_FILTER } from '../../core/utils/index.ts'
 import { linkToAlias, offsetToPosition } from '../../utils.ts'
 import type { Component, ComponentsOptions } from 'nuxt/schema'
 
@@ -37,17 +37,12 @@ export const LazyHydrationTransformPlugin = (options: LoaderOptions) => createUn
   return {
     name: 'nuxt:components-loader-pre',
     enforce: 'pre',
-    transformInclude (id) {
-      if (exclude.some(pattern => pattern.test(id))) {
-        return false
-      }
-      if (include.some(pattern => pattern.test(id))) {
-        return true
-      }
-      return isVue(id)
-    },
     transform: {
       filter: {
+        id: {
+          include: [...include, ...VUE_ID_FILTER],
+          exclude,
+        },
         code: { include: TEMPLATE_WITH_LAZY_HYDRATION_RE },
       },
 

--- a/packages/nuxt/src/components/plugins/loader.ts
+++ b/packages/nuxt/src/components/plugins/loader.ts
@@ -6,7 +6,7 @@ import { relative } from 'pathe'
 
 import { tryUseNuxt } from '@nuxt/kit'
 import { componentDiagnostics } from '@nuxt/kit/internal'
-import { QUOTE_RE, SX_RE, isVue } from '../../core/utils/index.ts'
+import { QUOTE_RE, SX_RE, VUE_SCRIPT_TEMPLATE_ID_FILTER } from '../../core/utils/index.ts'
 import { installNuxtModule } from '../../core/features.ts'
 import { linkToAlias } from '../../utils.ts'
 import type { Component, ComponentsOptions } from 'nuxt/schema'
@@ -41,134 +41,133 @@ export const LoaderPlugin = (options: LoaderOptions) => createUnplugin(() => {
   return {
     name: 'nuxt:components-loader',
     enforce: 'post',
-    transformInclude (id) {
-      if (exclude.some(pattern => pattern.test(id))) {
-        return false
-      }
-      if (include.some(pattern => pattern.test(id))) {
-        return true
-      }
-      return isVue(id, { type: ['template', 'script'] }) || !!id.match(SX_RE)
-    },
-    transform (code, id, meta?: unknown) {
-      const components = options.getComponents()
+    transform: {
+      filter: {
+        id: {
+          include: [...include, ...VUE_SCRIPT_TEMPLATE_ID_FILTER, SX_RE],
+          exclude,
+        },
+      },
+      handler (code, id, meta?: unknown) {
+        const components = options.getComponents()
 
-      let num = 0
-      const imports = new Set<string>()
-      const map = new Map<Component, string>()
-      const s = rolldownString(code, id, meta)
-      // replace `_resolveComponent("...")` to direct import
-      for (const match of code.matchAll(REPLACE_COMPONENT_TO_DIRECT_IMPORT_RE)) {
-        const groups = match.groups!
-        const lazy = groups.hLazy || groups.lazy || groups.vaporLazy
-        const modifier = groups.hModifier || groups.modifier || groups.vaporModifier
-        const name = groups.hName || groups.name || groups.vaporName
-        const isVapor = groups.vaporQuote !== undefined
-        const normalComponent = findComponent(components, name!, options.mode)
-        const modifierComponent = !normalComponent && modifier ? findComponent(components, modifier + name, options.mode) : null
-        const component = normalComponent || modifierComponent
+        let num = 0
+        const imports = new Set<string>()
+        const map = new Map<Component, string>()
+        const s = rolldownString(code, id, meta)
+        // replace `_resolveComponent("...")` to direct import
+        for (const match of code.matchAll(REPLACE_COMPONENT_TO_DIRECT_IMPORT_RE)) {
+          const groups = match.groups!
+          const lazy = groups.hLazy || groups.lazy || groups.vaporLazy
+          const modifier = groups.hModifier || groups.modifier || groups.vaporModifier
+          const name = groups.hName || groups.name || groups.vaporName
+          const isVapor = groups.vaporQuote !== undefined
+          const normalComponent = findComponent(components, name!, options.mode)
+          const modifierComponent = !normalComponent && modifier ? findComponent(components, modifier + name, options.mode) : null
+          const component = normalComponent || modifierComponent
 
-        if (component) {
-          // TODO: refactor to @nuxt/cli
-          const internalInstall = ((component as any)._internal_install) as string
-          if (internalInstall && nuxt?.options.test === false) {
-            if (!nuxt.options.dev) {
-              throw componentDiagnostics.NUXT_B3004({ file: linkToAlias(id, nuxt), component: component.pascalName, requiredModule: internalInstall })
+          if (component) {
+            // TODO: refactor to @nuxt/cli
+            const internalInstall = ((component as any)._internal_install) as string
+            if (internalInstall && nuxt?.options.test === false) {
+              if (!nuxt.options.dev) {
+                throw componentDiagnostics.NUXT_B3004({ file: linkToAlias(id, nuxt), component: component.pascalName, requiredModule: internalInstall })
+              }
+              installNuxtModule(internalInstall)
             }
-            installNuxtModule(internalInstall)
-          }
-          let identifier = map.get(component) || `__nuxt_component_${num++}`
-          map.set(component, identifier)
+            let identifier = map.get(component) || `__nuxt_component_${num++}`
+            map.set(component, identifier)
 
-          const isServerOnly = !component._raw && component.mode === 'server' &&
-            !components.some(c => c.pascalName === component.pascalName && c.mode === 'client')
-          if (isServerOnly) {
-            imports.add(genImport(options.serverComponentRuntime, [{ name: 'createServerComponent' }]))
-            imports.add(`const ${identifier} = createServerComponent(${JSON.stringify(component.pascalName)})`)
-            if (!options.experimentalComponentIslands) {
-              componentDiagnostics.NUXT_B3003({ component: name! })
+            const isServerOnly = !component._raw && component.mode === 'server' &&
+              !components.some(c => c.pascalName === component.pascalName && c.mode === 'client')
+            if (isServerOnly) {
+              imports.add(genImport(options.serverComponentRuntime, [{ name: 'createServerComponent' }]))
+              imports.add(`const ${identifier} = createServerComponent(${JSON.stringify(component.pascalName)})`)
+              if (!options.experimentalComponentIslands) {
+                componentDiagnostics.NUXT_B3003({ component: name! })
+              }
+              s.overwrite(match.index, match.index + match[0].length, isVapor ? vaporReplacement(imports, identifier) : identifier)
+              continue
             }
-            s.overwrite(match.index, match.index + match[0].length, isVapor ? vaporReplacement(imports, identifier) : identifier)
-            continue
-          }
 
-          const isClientOnly = !component._raw && component.mode === 'client'
-          if (isClientOnly) {
-            imports.add(genImport('#app/components/client-only', [{ name: 'createClientOnly' }]))
-            identifier += '_client'
-          }
+            const isClientOnly = !component._raw && component.mode === 'client'
+            if (isClientOnly) {
+              imports.add(genImport('#app/components/client-only', [{ name: 'createClientOnly' }]))
+              identifier += '_client'
+            }
 
-          if (lazy) {
-            const dynamicImport = `${genDynamicImport(component.filePath, { interopDefault: false })}.then(c => c.${component.export ?? 'default'} || c)`
-            if (modifier && normalComponent) {
-              const relativePath = relative(options.srcDir, component.filePath)
-              switch (modifier) {
-                case 'Visible':
-                case 'visible-':
-                  imports.add(genImport(options.clientDelayedComponentRuntime, [{ name: 'createLazyVisibleComponent' }]))
-                  identifier += '_lazy_visible'
-                  imports.add(`const ${identifier} = createLazyVisibleComponent(${JSON.stringify(relativePath)}, ${dynamicImport})`)
-                  break
-                case 'Interaction':
-                case 'interaction-':
-                  imports.add(genImport(options.clientDelayedComponentRuntime, [{ name: 'createLazyInteractionComponent' }]))
-                  identifier += '_lazy_event'
-                  imports.add(`const ${identifier} = createLazyInteractionComponent(${JSON.stringify(relativePath)}, ${dynamicImport})`)
-                  break
-                case 'Idle':
-                case 'idle-':
-                  imports.add(genImport(options.clientDelayedComponentRuntime, [{ name: 'createLazyIdleComponent' }]))
-                  identifier += '_lazy_idle'
-                  imports.add(`const ${identifier} = createLazyIdleComponent(${JSON.stringify(relativePath)}, ${dynamicImport})`)
-                  break
-                case 'MediaQuery':
-                case 'media-query-':
-                  imports.add(genImport(options.clientDelayedComponentRuntime, [{ name: 'createLazyMediaQueryComponent' }]))
-                  identifier += '_lazy_media'
-                  imports.add(`const ${identifier} = createLazyMediaQueryComponent(${JSON.stringify(relativePath)}, ${dynamicImport})`)
-                  break
-                case 'If':
-                case 'if-':
-                  imports.add(genImport(options.clientDelayedComponentRuntime, [{ name: 'createLazyIfComponent' }]))
-                  identifier += '_lazy_if'
-                  imports.add(`const ${identifier} = createLazyIfComponent(${JSON.stringify(relativePath)}, ${dynamicImport})`)
-                  break
-                case 'Never':
-                case 'never-':
-                  imports.add(genImport(options.clientDelayedComponentRuntime, [{ name: 'createLazyNeverComponent' }]))
-                  identifier += '_lazy_never'
-                  imports.add(`const ${identifier} = createLazyNeverComponent(${JSON.stringify(relativePath)}, ${dynamicImport})`)
-                  break
-                case 'Time':
-                case 'time-':
-                  imports.add(genImport(options.clientDelayedComponentRuntime, [{ name: 'createLazyTimeComponent' }]))
-                  identifier += '_lazy_time'
-                  imports.add(`const ${identifier} = createLazyTimeComponent(${JSON.stringify(relativePath)}, ${dynamicImport})`)
-                  break
+            if (lazy) {
+              const dynamicImport = `${genDynamicImport(component.filePath, { interopDefault: false })}.then(c => c.${component.export ?? 'default'} || c)`
+              if (modifier && normalComponent) {
+                const relativePath = relative(options.srcDir, component.filePath)
+                switch (modifier) {
+                  case 'Visible':
+                  case 'visible-':
+                    imports.add(genImport(options.clientDelayedComponentRuntime, [{ name: 'createLazyVisibleComponent' }]))
+                    identifier += '_lazy_visible'
+                    imports.add(`const ${identifier} = createLazyVisibleComponent(${JSON.stringify(relativePath)}, ${dynamicImport})`)
+                    break
+                  case 'Interaction':
+                  case 'interaction-':
+                    imports.add(genImport(options.clientDelayedComponentRuntime, [{ name: 'createLazyInteractionComponent' }]))
+                    identifier += '_lazy_event'
+                    imports.add(`const ${identifier} = createLazyInteractionComponent(${JSON.stringify(relativePath)}, ${dynamicImport})`)
+                    break
+                  case 'Idle':
+                  case 'idle-':
+                    imports.add(genImport(options.clientDelayedComponentRuntime, [{ name: 'createLazyIdleComponent' }]))
+                    identifier += '_lazy_idle'
+                    imports.add(`const ${identifier} = createLazyIdleComponent(${JSON.stringify(relativePath)}, ${dynamicImport})`)
+                    break
+                  case 'MediaQuery':
+                  case 'media-query-':
+                    imports.add(genImport(options.clientDelayedComponentRuntime, [{ name: 'createLazyMediaQueryComponent' }]))
+                    identifier += '_lazy_media'
+                    imports.add(`const ${identifier} = createLazyMediaQueryComponent(${JSON.stringify(relativePath)}, ${dynamicImport})`)
+                    break
+                  case 'If':
+                  case 'if-':
+                    imports.add(genImport(options.clientDelayedComponentRuntime, [{ name: 'createLazyIfComponent' }]))
+                    identifier += '_lazy_if'
+                    imports.add(`const ${identifier} = createLazyIfComponent(${JSON.stringify(relativePath)}, ${dynamicImport})`)
+                    break
+                  case 'Never':
+                  case 'never-':
+                    imports.add(genImport(options.clientDelayedComponentRuntime, [{ name: 'createLazyNeverComponent' }]))
+                    identifier += '_lazy_never'
+                    imports.add(`const ${identifier} = createLazyNeverComponent(${JSON.stringify(relativePath)}, ${dynamicImport})`)
+                    break
+                  case 'Time':
+                  case 'time-':
+                    imports.add(genImport(options.clientDelayedComponentRuntime, [{ name: 'createLazyTimeComponent' }]))
+                    identifier += '_lazy_time'
+                    imports.add(`const ${identifier} = createLazyTimeComponent(${JSON.stringify(relativePath)}, ${dynamicImport})`)
+                    break
+                }
+              } else {
+                imports.add(genImport('vue', [{ name: 'defineAsyncComponent', as: '__defineAsyncComponent' }]))
+                identifier += '_lazy'
+                imports.add(`const ${identifier} = __defineAsyncComponent(${dynamicImport}${isClientOnly ? '.then(c => createClientOnly(c))' : ''})`)
               }
             } else {
-              imports.add(genImport('vue', [{ name: 'defineAsyncComponent', as: '__defineAsyncComponent' }]))
-              identifier += '_lazy'
-              imports.add(`const ${identifier} = __defineAsyncComponent(${dynamicImport}${isClientOnly ? '.then(c => createClientOnly(c))' : ''})`)
-            }
-          } else {
-            imports.add(genImport(component.filePath, [{ name: component._raw ? 'default' : component.export, as: identifier }]))
+              imports.add(genImport(component.filePath, [{ name: component._raw ? 'default' : component.export, as: identifier }]))
 
-            if (isClientOnly) {
-              imports.add(`const ${identifier}_wrapped = createClientOnly(${identifier})`)
-              identifier += '_wrapped'
+              if (isClientOnly) {
+                imports.add(`const ${identifier}_wrapped = createClientOnly(${identifier})`)
+                identifier += '_wrapped'
+              }
             }
+
+            s.overwrite(match.index, match.index + match[0].length, isVapor ? vaporReplacement(imports, identifier) : identifier)
           }
-
-          s.overwrite(match.index, match.index + match[0].length, isVapor ? vaporReplacement(imports, identifier) : identifier)
         }
-      }
 
-      if (imports.size) {
-        s.prepend([...imports, ''].join('\n'))
-      }
+        if (imports.size) {
+          s.prepend([...imports, ''].join('\n'))
+        }
 
-      return generateTransform(s, id)
+        return generateTransform(s, id)
+      },
     },
   }
 })

--- a/packages/nuxt/src/core/plugins/async-context.ts
+++ b/packages/nuxt/src/core/plugins/async-context.ts
@@ -1,18 +1,16 @@
 import { createUnplugin } from 'unplugin'
 import { generateTransform, rolldownString } from 'rolldown-string'
 import type { Nuxt } from '@nuxt/schema'
-import { isVue } from '../utils/index.ts'
+import { VUE_SCRIPT_TEMPLATE_ID_FILTER } from '../utils/index.ts'
 
 const WITH_ASYNC_CONTEXT_IMPORT_RE = /withAsyncContext as _withAsyncContext,?/
 
 export const AsyncContextInjectionPlugin = (_nuxt: Nuxt) => createUnplugin(() => {
   return {
     name: 'nuxt:vue-async-context',
-    transformInclude (id) {
-      return isVue(id, { type: ['template', 'script'] })
-    },
     transform: {
       filter: {
+        id: { include: VUE_SCRIPT_TEMPLATE_ID_FILTER },
         code: { include: /_withAsyncContext/ },
       },
       handler (code, id, meta?: unknown) {

--- a/packages/nuxt/src/core/plugins/dev-only.ts
+++ b/packages/nuxt/src/core/plugins/dev-only.ts
@@ -2,7 +2,7 @@ import { generateTransform, rolldownString } from 'rolldown-string'
 import { createUnplugin } from 'unplugin'
 import { parse } from 'ultrahtml'
 import type { Node } from 'ultrahtml'
-import { isVue } from '../utils/index.ts'
+import { VUE_TEMPLATE_ID_FILTER } from '../utils/index.ts'
 
 const DEVONLY_COMP_SINGLE_RE = /<(?:dev-only|DevOnly|lazy-dev-only|LazyDevOnly)(?:\s(?:[^>"']|"[^"]*"|'[^']*')*)?>[\s\S]*?<\/(?:dev-only|DevOnly|lazy-dev-only|LazyDevOnly)>/
 const DEVONLY_COMP_RE = /<(?:dev-only|DevOnly|lazy-dev-only|LazyDevOnly)(?:\s(?:[^>"']|"[^"]*"|'[^']*')*)?>[\s\S]*?<\/(?:dev-only|DevOnly|lazy-dev-only|LazyDevOnly)>/g
@@ -11,11 +11,9 @@ export const DevOnlyPlugin = () => createUnplugin(() => {
   return {
     name: 'nuxt:server-devonly:transform',
     enforce: 'pre',
-    transformInclude (id) {
-      return isVue(id, { type: ['template'] })
-    },
     transform: {
       filter: {
+        id: { include: VUE_TEMPLATE_ID_FILTER },
         code: { include: DEVONLY_COMP_SINGLE_RE },
       },
       handler (code, id, meta?: unknown) {

--- a/packages/nuxt/src/core/plugins/extract-async-data-handlers.ts
+++ b/packages/nuxt/src/core/plugins/extract-async-data-handlers.ts
@@ -5,13 +5,11 @@ import type { RolldownString } from 'rolldown-string'
 import { dirname } from 'pathe'
 import { ScopeTracker, parseAndWalk, walk } from 'oxc-walker'
 import type { ESTree } from 'rolldown/utils'
+import { MACRO_QUERY_RE, STYLE_QUERY_RE, SUPPORTED_EXT_RE } from '../../utils.ts'
 
 const functionsToExtract = new Set(['useAsyncData', 'useLazyAsyncData'])
 const FUNCTIONS_RE = /\buse(?:Lazy)?AsyncData\b/
-const SUPPORTED_EXT_RE = /^[^?]*\.(?:m?[jt]sx?|vue)(?:$|\?)/
 const SCRIPT_RE = /(?<=<script[^>]*>)[\s\S]*?(?=<\/script>)/i
-const STYLE_QUERY_RE = /[?&]type=style/
-const MACRO_QUERY_RE = /[?&]macro(?:=|&|$)/
 const ASYNC_DATA_CHUNK_RE = /\/async-data-chunk-\d+\.js$/
 
 export interface ExtractAsyncDataHandlersOptions {

--- a/packages/nuxt/src/core/plugins/layer-aliasing.ts
+++ b/packages/nuxt/src/core/plugins/layer-aliasing.ts
@@ -1,4 +1,5 @@
 import { type UnpluginOptions, createUnplugin } from 'unplugin'
+import escapeStringRegexp from 'escape-string-regexp'
 import { resolveAlias } from '@nuxt/kit'
 import { normalize } from 'pathe'
 import { generateTransform, rolldownString } from 'rolldown-string'
@@ -13,7 +14,7 @@ interface LayerAliasingOptions {
 const ALIAS_RE = /(?<=['"])[~@]{1,2}(?=\/)/g
 const ALIAS_RE_SINGLE = /(?<=['"])[~@]{1,2}(?=\/)/
 const ALIAS_ID_RE = /^[~@]{1,2}\//
-const CSS_LANG_RE = /\.(?:css|less|sass|scss|styl|stylus|pcss|postcss|sss)(?:\?|$)/
+const CSS_LANG_PATTERN = '\\.(?:css|less|sass|scss|styl|stylus|pcss|postcss|sss)(?:\\?|$)'
 
 export const LayerAliasingPlugin = (options: LayerAliasingOptions) => createUnplugin((_options, meta) => {
   const aliases: Record<string, Record<string, string>> = {}
@@ -35,14 +36,12 @@ export const LayerAliasingPlugin = (options: LayerAliasingOptions) => createUnpl
   // resolution skips plugin `resolveId`. Webpack/rspack rely on the textual
   // rewrite for everything.
   const isCssLikeOnly = meta.framework === 'vite'
-  const transformInclude: UnpluginOptions['transformInclude'] = (id) => {
-    const _id = normalize(id)
-    if (!layers.some(dir => _id.startsWith(dir))) { return false }
-    if (isCssLikeOnly && !CSS_LANG_RE.test(id)) { return false }
-    return true
-  }
+  const layerIdREs = layers.map(dir => new RegExp(
+    '^' + escapeStringRegexp(dir).replace(/\//g, '[\\\\/]') + (isCssLikeOnly ? '.*' + CSS_LANG_PATTERN : ''),
+  ))
   const transform: UnpluginOptions['transform'] = {
     filter: {
+      id: { include: layerIdREs },
       code: { include: ALIAS_RE_SINGLE },
     },
     handler (code, id, meta?: unknown) {
@@ -86,7 +85,6 @@ export const LayerAliasingPlugin = (options: LayerAliasingOptions) => createUnpl
     },
 
     // https://github.com/nuxt/nuxt/issues/24427
-    transformInclude,
     transform,
   }
 })

--- a/packages/nuxt/src/core/plugins/prehydrate.ts
+++ b/packages/nuxt/src/core/plugins/prehydrate.ts
@@ -4,16 +4,17 @@ import { hash } from 'ohash'
 
 import { parseAndWalk } from 'oxc-walker'
 import { transformAndMinify } from '../../core/utils/parse.ts'
-import { isJS, isVue } from '../utils/index.ts'
+import { JS_ID_RE, VUE_NON_SCRIPT_BLOCK_RE, VUE_SCRIPT_ID_FILTER } from '../utils/index.ts'
 
 export function PrehydrateTransformPlugin () {
   return createUnplugin(() => ({
     name: 'nuxt:prehydrate-transform',
-    transformInclude (id) {
-      return isJS(id) || isVue(id, { type: ['script'] })
-    },
     transform: {
       filter: {
+        id: {
+          include: [...VUE_SCRIPT_ID_FILTER, JS_ID_RE],
+          exclude: VUE_NON_SCRIPT_BLOCK_RE,
+        },
         code: { include: /onPrehydrate\(/ },
       },
       handler (code, id, meta?: unknown) {

--- a/packages/nuxt/src/core/plugins/tree-shake.ts
+++ b/packages/nuxt/src/core/plugins/tree-shake.ts
@@ -3,7 +3,7 @@ import { createUnplugin } from 'unplugin'
 import { ScopeTracker, parseAndWalk, walk } from 'oxc-walker'
 import escapeStringRegexp from 'escape-string-regexp'
 
-import { isJS, isVue } from '../utils/index.ts'
+import { JS_ID_RE, VUE_NON_SCRIPT_BLOCK_RE, VUE_SCRIPT_ID_FILTER } from '../utils/index.ts'
 
 type ImportPath = string
 
@@ -22,11 +22,12 @@ export const TreeShakeComposablesPlugin = (options: TreeShakeComposablesPluginOp
   return {
     name: 'nuxt:tree-shake-composables:transform',
     enforce: 'post',
-    transformInclude (id) {
-      return isVue(id, { type: ['script'] }) || isJS(id)
-    },
     transform: {
       filter: {
+        id: {
+          include: [...VUE_SCRIPT_ID_FILTER, JS_ID_RE],
+          exclude: VUE_NON_SCRIPT_BLOCK_RE,
+        },
         code: { include: new RegExp(`\\b(?:${[...allComposableNames].map(r => escapeStringRegexp(r)).join('|')})\\b`) },
       },
       handler (code, id, meta?: unknown) {

--- a/packages/nuxt/src/core/plugins/unctx.ts
+++ b/packages/nuxt/src/core/plugins/unctx.ts
@@ -2,7 +2,7 @@ import type { Transformer, TransformerOptions } from 'unctx/transform'
 import { createTransformer, getTransformFilter } from 'unctx/transform'
 import { createUnplugin } from 'unplugin'
 
-import { isJS, isVue } from '../utils/index.ts'
+import { JS_ID_RE, VUE_SCRIPT_TEMPLATE_ID_FILTER } from '../utils/index.ts'
 
 const TRANSFORM_MARKER = '/* _processed_nuxt_unctx_transform */\n'
 const TRANSFORM_MARKER_RE = /^\/\* _processed_nuxt_unctx_transform \*\/\n/
@@ -19,12 +19,9 @@ export const UnctxTransformPlugin = (options: UnctxTransformPluginOptions) => cr
   return {
     name: 'unctx:transform',
     enforce: 'post',
-    transformInclude (id) {
-      return isVue(id, { type: ['template', 'script'] }) || isJS(id)
-    },
     transform: {
       filter: {
-        ...filter,
+        id: { include: [...VUE_SCRIPT_TEMPLATE_ID_FILTER, JS_ID_RE] },
         code: {
           include: filter.code,
           exclude: TRANSFORM_MARKER_RE,

--- a/packages/nuxt/src/core/utils/index.ts
+++ b/packages/nuxt/src/core/utils/index.ts
@@ -1,5 +1,5 @@
 export { getNameFromPath, hasSuffix, resolveComponentNameSegments } from './names.ts'
-export { getLoader, isJS, isVue, parseModuleId } from './plugins.ts'
+export { JS_ID_RE, VUE_ID_FILTER, VUE_NON_SCRIPT_BLOCK_RE, VUE_SCRIPT_ID_FILTER, VUE_SCRIPT_TEMPLATE_ID_FILTER, VUE_TEMPLATE_ID_FILTER, getLoader, isJS, isVue, parseModuleId } from './plugins.ts'
 
 export function uniqueBy<T, K extends keyof T> (arr: T[], key: K) {
   if (arr.length < 2) {

--- a/packages/nuxt/src/core/utils/plugins.ts
+++ b/packages/nuxt/src/core/utils/plugins.ts
@@ -14,51 +14,43 @@ export function parseModuleId (id: string): { pathname: string, search: string }
   return { pathname: id.slice(0, qIndex), search: id.slice(qIndex) }
 }
 
-const NUXT_COMPONENT_RE = /[?&]nuxt_component=/
-const MACRO_RE = /[?&]macro=/
+const VUE_FILE_RE = /\.vue$/
+const MACRO_QUERY_RE = /[?&]macro=/
+const EXACT_MACRO_QUERY_RE = /\?macro=true$/
 const VUE_QUERY_RE = /[?&]vue(?:&|$)/
-const SETUP_QUERY_RE = /[?&]setup(?:=|&|$)/
-const TYPE_QUERY_RE = /[?&]type=([^&]*)/
+const VUE_SCRIPT_BLOCK_RE = /[?&]vue&type=script\b/
+const VUE_TEMPLATE_BLOCK_RE = /[?&]vue&type=template\b/
 
-export function isVue (id: string, opts: { type?: Array<'template' | 'script' | 'style'> } = {}) {
-  const { search } = parseModuleId(id)
+/**
+ * Module id filters for Vue SFC requests, usable directly as `transform.filter.id`
+ * includes. Each array matches whole `.vue` files, page-meta macro requests and the
+ * relevant SFC block requests (`?vue&type=...` from `@vitejs/plugin-vue` and `vue-loader`).
+ */
+export const VUE_ID_FILTER = [VUE_FILE_RE, MACRO_QUERY_RE, VUE_QUERY_RE]
+export const VUE_SCRIPT_ID_FILTER = [VUE_FILE_RE, MACRO_QUERY_RE, VUE_SCRIPT_BLOCK_RE]
+export const VUE_TEMPLATE_ID_FILTER = [VUE_FILE_RE, EXACT_MACRO_QUERY_RE, VUE_TEMPLATE_BLOCK_RE]
+export const VUE_SCRIPT_TEMPLATE_ID_FILTER = [VUE_FILE_RE, MACRO_QUERY_RE, VUE_SCRIPT_BLOCK_RE, VUE_TEMPLATE_BLOCK_RE]
 
-  // Bare `.vue` file (in Vite)
-  if (id.endsWith('.vue') && !search) {
-    return true
-  }
+/**
+ * SFC block requests that never contain user script code but may carry a JS-like
+ * extension in their query (e.g. `?vue&type=template&lang.js`). Use as an `exclude`
+ * when combining `JS_ID_RE` with a filter that should not match template blocks.
+ */
+export const VUE_NON_SCRIPT_BLOCK_RE = /[?&]vue&type=(?:template|style|custom)\b/
 
-  if (!search) {
-    return false
-  }
-
-  // Component async/lazy wrapper
-  if (NUXT_COMPONENT_RE.test(search)) {
-    return false
-  }
-
-  // Macro
-  if (MACRO_RE.test(search) && (search === '?macro=true' || !opts.type || opts.type.includes('script'))) {
-    return true
-  }
-
-  // Non-Vue or Styles
-  if (!VUE_QUERY_RE.test(search)) {
-    return false
-  }
-
-  if (opts.type) {
-    const type = SETUP_QUERY_RE.test(search) ? 'script' : TYPE_QUERY_RE.exec(search)?.[1] as 'script' | 'template' | 'style' | undefined
-    if (!type || !opts.type.includes(type)) {
-      return false
-    }
-  }
-
-  // Query `?vue&type=template` (in Webpack or external template)
-  return true
+export function isVue (id: string, opts: { type?: Array<'template' | 'script'> } = {}) {
+  const filter = opts.type
+    ? opts.type.includes('script')
+      ? opts.type.includes('template') ? VUE_SCRIPT_TEMPLATE_ID_FILTER : VUE_SCRIPT_ID_FILTER
+      : VUE_TEMPLATE_ID_FILTER
+    : VUE_ID_FILTER
+  return filter.some(re => re.test(id))
 }
 
 const JS_RE = /\.(?:[cm]?[jt]s|[jt]sx)$/
+
+/** Like {@link isJS} but usable as an id filter (allows a query string after the extension). */
+export const JS_ID_RE = /\.(?:[cm]?[jt]s|[jt]sx)(?:\?|$)/
 
 /** Matches module IDs for Vue files (ignoring query strings). */
 export const VUE_ID_RE = /\.vue(?:\?|$)/

--- a/packages/nuxt/src/head/plugins/unhead-imports.ts
+++ b/packages/nuxt/src/head/plugins/unhead-imports.ts
@@ -7,8 +7,11 @@ import { genImport } from 'knitwork'
 import { parseAndWalk } from 'oxc-walker'
 import { headDiagnostics } from '@nuxt/kit/internal'
 import { link } from 'clickable-path'
-import { isJS, isVue } from '../../core/utils/index.ts'
+import escapeStringRegexp from 'escape-string-regexp'
+import { JS_ID_RE, VUE_NON_SCRIPT_BLOCK_RE, VUE_SCRIPT_ID_FILTER } from '../../core/utils/index.ts'
 import { distDir } from '../../dirs.ts'
+
+const DIST_DIR_RE = new RegExp('^' + escapeStringRegexp(normalize(distDir)).replace(/\//g, '[\\\\/]'))
 
 interface UnheadImportsPluginOptions {
   rootDir: string
@@ -37,18 +40,12 @@ export const UnheadImportsPlugin = (options: UnheadImportsPluginOptions) => crea
   return {
     name: 'nuxt:head:unhead-imports',
     enforce: 'post',
-    transformInclude (id) {
-      id = normalize(id)
-      return (
-        (isJS(id) || isVue(id, { type: ['script'] })) &&
-        !id.startsWith('virtual:') &&
-        !id.startsWith(normalize(distDir)) &&
-        !UNHEAD_LIB_RE.test(id) &&
-        !NUXT_HEAD_RE.test(id)
-      )
-    },
     transform: {
       filter: {
+        id: {
+          include: [...VUE_SCRIPT_ID_FILTER, JS_ID_RE],
+          exclude: [VUE_NON_SCRIPT_BLOCK_RE, /^virtual:/, DIST_DIR_RE, UNHEAD_LIB_RE, NUXT_HEAD_RE],
+        },
         code: { include: UnheadVueRE },
       },
       handler (code, id, meta?: unknown) {

--- a/packages/nuxt/src/pages/plugins/route-injection.ts
+++ b/packages/nuxt/src/pages/plugins/route-injection.ts
@@ -2,7 +2,7 @@ import { createUnplugin } from 'unplugin'
 import { generateTransform, rolldownString } from 'rolldown-string'
 import type { Nuxt } from '@nuxt/schema'
 import { parseAndWalk } from 'oxc-walker'
-import { isVue } from '../../core/utils/index.ts'
+import { VUE_SCRIPT_TEMPLATE_ID_FILTER } from '../../core/utils/index.ts'
 
 const INJECTION_SINGLE_RE = /\bthis\.\$route\b|\b_ctx\.\$route\b/
 
@@ -10,11 +10,9 @@ export const RouteInjectionPlugin = (_nuxt: Nuxt) => createUnplugin(() => {
   return {
     name: 'nuxt:route-injection-plugin',
     enforce: 'post',
-    transformInclude (id) {
-      return isVue(id, { type: ['template', 'script'] })
-    },
     transform: {
       filter: {
+        id: { include: VUE_SCRIPT_TEMPLATE_ID_FILTER },
         code: {
           include: INJECTION_SINGLE_RE,
           exclude: [

--- a/packages/nuxt/src/utils.ts
+++ b/packages/nuxt/src/utils.ts
@@ -59,6 +59,7 @@ export function isWhitespace (char: number | string | undefined | null): boolean
 }
 
 export const JS_EXT_RE = /^[^?]*\.(?:[jt]sx?|[cm][jt]s)(?:$|\?)/
+export const SUPPORTED_EXT_RE = /^[^?]*\.(?:m?[jt]sx?|vue)(?:$|\?)/
 export const NUXT_LIB_RE = /^[^?]*node_modules\/(?:nuxt|nuxt3|nuxt-nightly|@nuxt)\//
 export const STYLE_QUERY_RE = /[?&]type=style/
 export const MACRO_QUERY_RE = /[?&]macro(?:=|&|$)/

--- a/packages/nuxt/test/component-loader.test.ts
+++ b/packages/nuxt/test/component-loader.test.ts
@@ -55,7 +55,7 @@ import{defineComponent as _defineComponent}from"vue";const _sfc_main=_defineComp
 
 function _tracer(line, column, vnode) { return _tracerRecordPosition("app.vue", line, column, vnode) }
 `
-    const code = await ((plugin.raw({}, { framework: 'vite', versions: {} }) as { transform: (code: string, id: string) => { code: string, map?: unknown } | null }).transform(
+    const code = await ((plugin.raw({}, { framework: 'vite', versions: {} }) as { transform: { handler: (code: string, id: string) => { code: string, map?: unknown } | null } }).transform.handler(
       content,
       '/app.vue',
     ))
@@ -127,7 +127,7 @@ export default {
   }
 };
 `
-    const code = await ((plugin.raw({}, { framework: 'vite', versions: {} }) as { transform: (code: string, id: string) => { code: string } | null }).transform(
+    const code = await ((plugin.raw({}, { framework: 'vite', versions: {} }) as { transform: { handler: (code: string, id: string) => { code: string } | null } }).transform.handler(
       content,
       '/app.vue?vue&type=script&setup=true&lang.jsx',
     ))
@@ -278,7 +278,7 @@ function _sfc_render(_ctx) {
   return n3;
 }
 `
-    const code = await ((plugin.raw({}, { framework: 'vite', versions: {} }) as { transform: (code: string, id: string) => { code: string } | null }).transform(
+    const code = await ((plugin.raw({}, { framework: 'vite', versions: {} }) as { transform: { handler: (code: string, id: string) => { code: string } | null } }).transform.handler(
       content,
       '/pages/index.vue',
     ))

--- a/packages/nuxt/test/layer-aliasing.test.ts
+++ b/packages/nuxt/test/layer-aliasing.test.ts
@@ -3,14 +3,14 @@ import type { UnpluginContextMeta } from 'unplugin'
 import { describe, expect, it } from 'vitest'
 
 import { LayerAliasingPlugin } from '../src/core/plugins/layer-aliasing'
+import { matchesIdFilter } from './utils.ts'
 
 interface TransformHandler {
   (this: unknown, code: string, id: string): { code: string } | undefined
 }
 
 interface RawPlugin {
-  transformInclude?: (id: string) => boolean | null | undefined
-  transform?: { handler: TransformHandler }
+  transform?: { filter: { id: RegExp | RegExp[] | { include?: RegExp | RegExp[], exclude?: RegExp | RegExp[] } }, handler: TransformHandler }
 }
 
 function makeLayer (cwd: string): NuxtConfigLayer {
@@ -22,7 +22,7 @@ function createPlugin (layers: NuxtConfigLayer[], framework: 'vite' | 'webpack' 
   const raw = LayerAliasingPlugin({ root: '/', dev: false, layers }).raw({}, meta)
   const entry = (Array.isArray(raw) ? raw[0] : raw) as RawPlugin
   return {
-    transformInclude: entry.transformInclude!,
+    transformInclude: (id: string) => matchesIdFilter(entry.transform!.filter.id, id),
     transform: (code: string, id: string) => entry.transform!.handler.call({}, code, id),
   }
 }

--- a/packages/nuxt/test/unctx-transform.test.ts
+++ b/packages/nuxt/test/unctx-transform.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { UnctxTransformPlugin } from '../src/core/plugins/unctx.ts'
+import { matchesIdFilter } from './utils.ts'
 
 describe('unctx transform in nuxt', () => {
   it('should transform nuxt plugins', async () => {
@@ -63,5 +64,5 @@ function transform (code: string, id = 'app.vue') {
     },
   }
   const plugin = UnctxTransformPlugin({ sourcemap: false, transformerOptions }).raw({}, {} as any) as any
-  return plugin.transformInclude(id) ? Promise.resolve(plugin.transform.handler(code)).then((r: any) => r?.code.replace(/^ {6}/gm, '').trim()) : null
+  return matchesIdFilter(plugin.transform.filter.id, id) ? Promise.resolve(plugin.transform.handler(code)).then((r: any) => r?.code.replace(/^ {6}/gm, '').trim()) : null
 }

--- a/packages/nuxt/test/unhead-imports.test.ts
+++ b/packages/nuxt/test/unhead-imports.test.ts
@@ -3,17 +3,18 @@ import process from 'node:process'
 import { describe, expect, it } from 'vitest'
 import { compileScript, parse } from '@vue/compiler-sfc'
 import { UnheadImportsPlugin } from '../src/head/plugins/unhead-imports.ts'
+import { matchesIdFilter } from './utils.ts'
 
 describe('UnheadImportsPlugin', () => {
   // Helper function to transform code
   function transform (code: string, id = 'app.vue') {
     const plugin = UnheadImportsPlugin({ rootDir: import.meta.dirname }).raw({}, {} as any) as any
-    return plugin.transformInclude(id) ? Promise.resolve(plugin.transform.handler(code, id)).then((r: any) => r?.code.replace(/^ {6}/gm, '').trim()) : null
+    return matchesIdFilter(plugin.transform.filter.id, id) ? Promise.resolve(plugin.transform.handler(code, id)).then((r: any) => r?.code.replace(/^ {6}/gm, '').trim()) : null
   }
 
-  describe('transformInclude', () => {
-    // @ts-expect-error untyped
-    const transformInclude = UnheadImportsPlugin({ rootDir: process.cwd() }).raw({}, {} as any).transformInclude
+  describe('id filter', () => {
+    const plugin = UnheadImportsPlugin({ rootDir: process.cwd() }).raw({}, {} as any) as any
+    const transformInclude = (id: string) => matchesIdFilter(plugin.transform.filter.id, id)
 
     it('should include JS files', () => {
       expect(transformInclude('/project/components/MyComponent.js')).toBe(true)

--- a/packages/nuxt/test/utils.ts
+++ b/packages/nuxt/test/utils.ts
@@ -6,6 +6,18 @@ export function normalizeLineEndings (str: string, normalized = '\n') {
   return str.replace(/\r?\n/g, normalized)
 }
 
+type IdFilter = RegExp | RegExp[] | { include?: RegExp | RegExp[], exclude?: RegExp | RegExp[] } | undefined
+
+/** Evaluate an unplugin `transform.filter.id` option against a module id, mirroring rolldown's exclude-wins semantics. */
+export function matchesIdFilter (filter: IdFilter, id: string) {
+  if (!filter) { return true }
+  const { include, exclude } = filter instanceof RegExp || Array.isArray(filter) ? { include: filter, exclude: undefined } : filter
+  const toArray = (value?: RegExp | RegExp[]) => value ? Array.isArray(value) ? value : [value] : []
+  if (toArray(exclude).some(re => re.test(id))) { return false }
+  const includes = toArray(include)
+  return includes.length === 0 || includes.some(re => re.test(id))
+}
+
 export function clean (string?: string) {
   const lines = string?.split('\n').filter(l => l.trim()) || []
   const indent = lines.reduce((prev, curr) => {

--- a/packages/vite/src/plugins/decorators.ts
+++ b/packages/vite/src/plugins/decorators.ts
@@ -4,6 +4,7 @@ import { ensureDependencyInstalled, getAddDependencyCommand } from '@nuxt/kit'
 import { bundlerDiagnostics } from '@nuxt/kit/internal'
 import type { Nuxt } from '@nuxt/schema'
 import jsTokens from 'js-tokens'
+import { JS_ID_RE, VUE_NON_SCRIPT_BLOCK_RE, VUE_SCRIPT_ID_FILTER } from '../utils/index.ts'
 
 const BABEL_DECORATOR_DEPS = ['@babel/plugin-proposal-decorators', '@babel/plugin-syntax-jsx'] as const
 
@@ -67,19 +68,8 @@ export function DecoratorsPlugin (nuxt: Nuxt): Plugin {
         code: '@',
 
         id: {
-          // Restrict transform to JavaScript/TypeScript and Vue files only
-          include: [/\.(ts|js|tsx|jsx|vue)$/],
-
-          // Explicitly exclude non-JS assets and Vue sub-blocks
-          // (e.g. <style> or <template> in SFCs)
-          exclude: [
-            /\.css$/,
-            /\.scss$/,
-            /\.sass$/,
-            /\.less$/,
-            /\.styl$/,
-            /\.vue\?.*\btype=(?:style|template)\b/,
-          ],
+          include: [...VUE_SCRIPT_ID_FILTER, JS_ID_RE],
+          exclude: VUE_NON_SCRIPT_BLOCK_RE,
         },
       },
       handler (code, id) {

--- a/packages/vite/src/utils/index.ts
+++ b/packages/vite/src/utils/index.ts
@@ -1,4 +1,4 @@
-export { isVue, parseModuleId } from '../../../nuxt/src/core/utils/plugins.ts'
+export { JS_ID_RE, VUE_NON_SCRIPT_BLOCK_RE, VUE_SCRIPT_ID_FILTER, isVue, parseModuleId } from '../../../nuxt/src/core/utils/plugins.ts'
 export { toVirtualId } from '../../../nuxt/src/core/plugins/virtual.ts'
 
 // Copied from vue-bundle-renderer utils

--- a/packages/vite/test/decorators.test.ts
+++ b/packages/vite/test/decorators.test.ts
@@ -7,7 +7,7 @@ function matchesFilter (
     code?: string
     id?: {
       include?: RegExp[]
-      exclude?: RegExp[]
+      exclude?: RegExp | RegExp[]
     }
   },
   code: string,
@@ -17,11 +17,11 @@ function matchesFilter (
     return false
   }
 
-  if (filter.id?.include?.length && !filter.id.include.some(re => re.test(id))) {
+  if (filter.id?.exclude && [filter.id.exclude].flat().some(re => re.test(id))) {
     return false
   }
 
-  if (filter.id?.exclude?.some(re => re.test(id))) {
+  if (filter.id?.include?.length && !filter.id.include.some(re => re.test(id))) {
     return false
   }
 
@@ -48,7 +48,7 @@ describe('DecoratorsPlugin transform filter', () => {
     code?: string
     id?: {
       include?: RegExp[]
-      exclude?: RegExp[]
+      exclude?: RegExp | RegExp[]
     }
   }
 

--- a/packages/webpack/src/plugins/ssr-styles.ts
+++ b/packages/webpack/src/plugins/ssr-styles.ts
@@ -7,7 +7,7 @@ import { withTrailingSlash } from 'ufo'
 import { genArrayFromRaw, genObjectFromRawEntries } from 'knitwork'
 import type { Nuxt } from '@nuxt/schema'
 import { resolveAlias, setBuildOutput, useNitro } from '@nuxt/kit'
-import { parseModuleId } from '../../../nuxt/src/core/utils/plugins.ts'
+import { VUE_ID_RE, parseModuleId } from '../../../nuxt/src/core/utils/plugins.ts'
 import type { Compilation, Compiler, Module, NormalModule } from 'webpack'
 import type { CssModule } from 'mini-css-extract-plugin'
 import { compileStyle, parse } from '@vue/compiler-sfc'
@@ -16,7 +16,6 @@ import { getVueLoaderHash } from '../builder.ts'
 
 const CSS_URL_RE = /url\((['"]?)(\/[^)]+?)\1\)/g
 
-const isVueFile = (id: string) => /\.vue(?:\?|$)/.test(id)
 const isCSSLike = (name: string) => /\.(?:css|scss|sass|less|styl(?:us)?|postcss|pcss)(?:\?|$)/.test(name)
 
 function normalizePath (nuxt: Nuxt, id?: string | null): string | null {
@@ -303,7 +302,7 @@ export class SSRStylesPlugin {
       for (const module of compilation.modules) {
         const normal = module as NormalModule
         const resource = normal.resource
-        if (!resource || !isVueFile(resource)) { continue }
+        if (!resource || !VUE_ID_RE.test(resource)) { continue }
         const rel = normalizePath(this.nuxt, resource)
         if (!rel) { continue }
         if (collected.has(rel)) { continue }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this refactors our all-encompassing `isVue` function into regexps so we can reduce crossover between rust -> JS in rolldown

measured on a synthetic app (300 pages + 300 components + 100 composables, `nuxt build`, client + server, median of 3 runs), counting how often rolldown had to call into a JS transform hook:

| plugin | JS transform calls before | after |
| - | - | - |
| `nuxt:components-loader` | 7602 | 4820 |
| `nuxt:component-name-plugin` | 7586 | 6632 |
| `nuxt:head:unhead-imports` | 24 | 8 |

the other migrated plugins were already gated by native `code` filters, so their call counts don't change, but it should still be a good simplification