### PR TITLE
fix(nitro): vary early 404 responses on accept

### DIFF
--- a/packages/nitro-server/src/runtime/handlers/error.ts
+++ b/packages/nitro-server/src/runtime/handlers/error.ts
@@ -15,6 +15,7 @@ export default <NitroErrorHandler> async function errorhandler (error, event, { 
   // return Nitro response + our headers for redirects and JSON responses
   const status = error.status || 500
   const headers = new Headers(error.headers)
+  appendVary(headers, 'accept, sec-fetch-mode')
   if (isJsonRequest(event) || (status === 404 && defaultRes.status === 302)) {
     const setCookies = new Set(headers.getSetCookie())
     const headerEntries = [
@@ -117,7 +118,9 @@ const IGNORED_ERROR_HEADERS = new Set(['content-type', 'content-security-policy'
 function mergeHeaders (target: Headers, overrides: Headers | [string, string][] | HeadersIterator<[string, string]>, setCookies: Set<string>, ignore?: Set<string>): Headers {
   for (const [name, value] of overrides) {
     if (ignore?.has(name)) { continue }
-    if (name === 'set-cookie') {
+    if (name === 'vary') {
+      appendVary(target, value)
+    } else if (name === 'set-cookie') {
       if (!setCookies.has(value)) {
         setCookies.add(value)
         target.append(name, value)
@@ -127,6 +130,36 @@ function mergeHeaders (target: Headers, overrides: Headers | [string, string][] 
     }
   }
   return target
+}
+
+/**
+ * Add `value`'s tokens to the `vary` header, keeping any already present. `*`
+ * absorbs everything else, since it means the response varies on all headers.
+ */
+function appendVary (headers: Headers, value: string): void {
+  const incoming = parseVary(value)
+  if (!incoming.length) {
+    return
+  }
+  const existing = parseVary(headers.get('vary'))
+  if (existing.includes('*')) {
+    return
+  }
+  if (incoming.includes('*')) {
+    headers.set('vary', '*')
+    return
+  }
+  const merged = existing.slice()
+  for (const token of incoming) {
+    if (!merged.includes(token)) {
+      merged.push(token)
+    }
+  }
+  headers.set('vary', merged.join(', '))
+}
+
+function parseVary (value: string | null): string[] {
+  return value ? value.split(',').map(token => token.trim().toLowerCase()).filter(Boolean) : []
 }
 
 function serializeErrorCause (cause: unknown, depth = 0, seen = new WeakSet<Error>()): SerializedErrorCause | undefined {

--- a/packages/nitro-server/src/runtime/utils/renderer/early-404.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/early-404.ts
@@ -37,6 +37,10 @@ function matchesPageRoute (pathname: string): boolean {
  *
  * When a `cache` route rule covers the path, its `maxAge` is advertised on
  * GET/HEAD misses too, so CDNs can absorb repeat probes for unknown paths.
+ *
+ * The error is rendered as JSON or as the HTML error page depending on `Accept`,
+ * so the response always varies on it. A 404 is heuristically cacheable, which
+ * means a shared cache can store one without being asked to.
  */
 export function throwIfUnmatchedPagePath (event: H3Event, routeOptions: { cache?: { options?: { maxAge?: number } } }): void {
   if (matchesPageRoute(event.url.pathname)) {
@@ -49,6 +53,9 @@ export function throwIfUnmatchedPagePath (event: H3Event, routeOptions: { cache?
     status: 404,
     statusText: `Page not found: ${path}`,
     data: { path },
-    ...cacheable ? { headers: { 'cache-control': `public, max-age=${maxAge}` } } : {},
+    headers: {
+      vary: 'accept',
+      ...cacheable ? { 'cache-control': `public, max-age=${maxAge}` } : {},
+    },
   })
 }

--- a/packages/nitro-server/src/runtime/utils/renderer/early-404.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/early-404.ts
@@ -37,10 +37,6 @@ function matchesPageRoute (pathname: string): boolean {
  *
  * When a `cache` route rule covers the path, its `maxAge` is advertised on
  * GET/HEAD misses too, so CDNs can absorb repeat probes for unknown paths.
- *
- * The error is rendered as JSON or as the HTML error page depending on `Accept`,
- * so the response always varies on it. A 404 is heuristically cacheable, which
- * means a shared cache can store one without being asked to.
  */
 export function throwIfUnmatchedPagePath (event: H3Event, routeOptions: { cache?: { options?: { maxAge?: number } } }): void {
   if (matchesPageRoute(event.url.pathname)) {
@@ -53,9 +49,6 @@ export function throwIfUnmatchedPagePath (event: H3Event, routeOptions: { cache?
     status: 404,
     statusText: `Page not found: ${path}`,
     data: { path },
-    headers: {
-      vary: 'accept',
-      ...cacheable ? { 'cache-control': `public, max-age=${maxAge}` } : {},
-    },
+    ...cacheable ? { headers: { 'cache-control': `public, max-age=${maxAge}` } } : {},
   })
 }

--- a/packages/nitro-server/test/early-404.test.ts
+++ b/packages/nitro-server/test/early-404.test.ts
@@ -14,6 +14,10 @@ function event (path: string, method = 'GET') {
   } as unknown as H3Event
 }
 
+function cacheControlFor (path: string, method?: string, maxAge?: number) {
+  return errorFor(path, method, maxAge)?.headers?.get('cache-control') ?? null
+}
+
 function errorFor (path: string, method?: string, maxAge?: number) {
   const routeOptions = maxAge === undefined ? {} : { cache: { options: { maxAge } } }
   try {
@@ -38,18 +42,11 @@ describe('throwIfUnmatchedPagePath', () => {
     expect(error?.data.path).toBe('/wp-login.php?redirect=1')
   })
 
-  it('varies on accept, because the error renders as JSON or HTML', () => {
-    // a 404 is heuristically cacheable, so a shared cache can store one even when
-    // no `cache` route rule asked it to
-    expect(errorFor('/unknown')?.headers?.get('vary')).toBe('accept')
-    expect(errorFor('/unknown', 'GET', 60)?.headers?.get('vary')).toBe('accept')
-  })
-
   it('advertises the cache rule maxAge on GET and HEAD misses only', () => {
-    expect(errorFor('/unknown', 'GET', 60)?.headers?.get('cache-control')).toBe('public, max-age=60')
-    expect(errorFor('/unknown', 'HEAD', 60)?.headers?.get('cache-control')).toBe('public, max-age=60')
-    expect(errorFor('/unknown', 'POST', 60)?.headers?.has('cache-control')).toBe(false)
-    expect(errorFor('/unknown', 'GET', 0)?.headers?.has('cache-control')).toBe(false)
-    expect(errorFor('/unknown', 'GET')?.headers?.has('cache-control')).toBe(false)
+    expect(cacheControlFor('/unknown', 'GET', 60)).toBe('public, max-age=60')
+    expect(cacheControlFor('/unknown', 'HEAD', 60)).toBe('public, max-age=60')
+    expect(cacheControlFor('/unknown', 'POST', 60)).toBeNull()
+    expect(cacheControlFor('/unknown', 'GET', 0)).toBeNull()
+    expect(cacheControlFor('/unknown', 'GET')).toBeNull()
   })
 })

--- a/packages/nitro-server/test/early-404.test.ts
+++ b/packages/nitro-server/test/early-404.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { H3Event } from 'nitro/h3'
+
+import { throwIfUnmatchedPagePath } from '../src/runtime/utils/renderer/early-404.ts'
+
+vi.mock('#internal/nuxt/nitro-config.mjs', () => ({
+  NUXT_PAGE_MATCHER: (_method: string, path: string) => path === '/known' ? 1 : undefined,
+}))
+
+function event (path: string, method = 'GET') {
+  return {
+    url: new URL(path, 'http://localhost'),
+    req: { method },
+  } as unknown as H3Event
+}
+
+function errorFor (path: string, method?: string, maxAge?: number) {
+  const routeOptions = maxAge === undefined ? {} : { cache: { options: { maxAge } } }
+  try {
+    throwIfUnmatchedPagePath(event(path, method), routeOptions)
+  } catch (error) {
+    return error as { status: number, data: { path: string }, headers: Headers | undefined }
+  }
+  return undefined
+}
+
+describe('throwIfUnmatchedPagePath', () => {
+  it('lets paths that could match a page through', () => {
+    expect(errorFor('/known')).toBeUndefined()
+    expect(errorFor('/known/')).toBeUndefined()
+    expect(errorFor('/known/_payload.json')).toBeUndefined()
+  })
+
+  it('throws a 404 carrying the request path', () => {
+    const error = errorFor('/wp-login.php?redirect=1')
+
+    expect(error?.status).toBe(404)
+    expect(error?.data.path).toBe('/wp-login.php?redirect=1')
+  })
+
+  it('varies on accept, because the error renders as JSON or HTML', () => {
+    // a 404 is heuristically cacheable, so a shared cache can store one even when
+    // no `cache` route rule asked it to
+    expect(errorFor('/unknown')?.headers?.get('vary')).toBe('accept')
+    expect(errorFor('/unknown', 'GET', 60)?.headers?.get('vary')).toBe('accept')
+  })
+
+  it('advertises the cache rule maxAge on GET and HEAD misses only', () => {
+    expect(errorFor('/unknown', 'GET', 60)?.headers?.get('cache-control')).toBe('public, max-age=60')
+    expect(errorFor('/unknown', 'HEAD', 60)?.headers?.get('cache-control')).toBe('public, max-age=60')
+    expect(errorFor('/unknown', 'POST', 60)?.headers?.has('cache-control')).toBe(false)
+    expect(errorFor('/unknown', 'GET', 0)?.headers?.has('cache-control')).toBe(false)
+    expect(errorFor('/unknown', 'GET')?.headers?.has('cache-control')).toBe(false)
+  })
+})

--- a/packages/nitro-server/test/error-vary.test.ts
+++ b/packages/nitro-server/test/error-vary.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { HTTPError } from 'nitro/h3'
+import type { H3Event } from 'nitro/h3'
+
+const serverFetch = vi.hoisted(() => vi.fn())
+
+vi.mock('nitro', () => ({ serverFetch }))
+
+const { default: errorHandler } = await import('../src/runtime/handlers/error.ts')
+
+function event (accept: string) {
+  const headers = new Headers({ accept })
+  return {
+    url: new URL('http://localhost/unknown'),
+    req: { url: 'http://localhost/unknown', method: 'GET', headers },
+    res: { headers: new Headers() },
+    context: {},
+  } as unknown as H3Event
+}
+
+function handle (error: HTTPError, accept: string, defaultHeaders?: HeadersInit) {
+  return errorHandler(error as any, event(accept), {
+    defaultHandler: () => Promise.resolve({
+      status: 404,
+      statusText: 'Page not found',
+      body: { statusCode: 404 },
+      headers: new Headers(defaultHeaders),
+    }),
+  } as any) as Promise<Response>
+}
+
+describe('error handler vary', () => {
+  beforeEach(() => {
+    serverFetch.mockReset()
+    serverFetch.mockResolvedValue(new Response('<html></html>', { headers: new Headers() }))
+  })
+
+  it('varies on the negotiated headers for the JSON error body', async () => {
+    const res = await handle(new HTTPError({ status: 404 }), 'application/json')
+
+    expect(res.headers.get('vary')).toBe('accept, sec-fetch-mode')
+  })
+
+  it('varies on the negotiated headers for the server-rendered error page', async () => {
+    const res = await handle(new HTTPError({ status: 404 }), 'text/html')
+
+    expect(res.headers.get('vary')).toBe('accept, sec-fetch-mode')
+  })
+
+  it('keeps vary set on the error', async () => {
+    const res = await handle(new HTTPError({ status: 404, headers: { vary: 'accept-encoding' } }), 'text/html')
+
+    expect(res.headers.get('vary')).toBe('accept-encoding, accept, sec-fetch-mode')
+  })
+
+  it('does not duplicate tokens already listed on the error', async () => {
+    const res = await handle(new HTTPError({ status: 404, headers: { vary: 'Accept, Accept-Language' } }), 'text/html')
+
+    expect(res.headers.get('vary')).toBe('accept, accept-language, sec-fetch-mode')
+  })
+
+  it('merges vary from the rendered error page instead of replacing it', async () => {
+    serverFetch.mockResolvedValue(new Response('<html></html>', { headers: { vary: 'accept-language' } }))
+    const res = await handle(new HTTPError({ status: 404 }), 'text/html')
+
+    expect(res.headers.get('vary')).toBe('accept, sec-fetch-mode, accept-language')
+  })
+
+  it('merges vary from the default handler on the JSON path', async () => {
+    const res = await handle(new HTTPError({ status: 404 }), 'application/json', { vary: 'accept-encoding' })
+
+    expect(res.headers.get('vary')).toBe('accept, sec-fetch-mode, accept-encoding')
+  })
+
+  it('lets a wildcard vary absorb accept', async () => {
+    const res = await handle(new HTTPError({ status: 404, headers: { vary: '*' } }), 'text/html')
+
+    expect(res.headers.get('vary')).toBe('*')
+  })
+
+  it('preserves the cache-control advertised on an early 404', async () => {
+    const res = await handle(new HTTPError({ status: 404, headers: { 'cache-control': 'public, max-age=60' } }), 'application/json')
+
+    expect(res.headers.get('cache-control')).toBe('public, max-age=60')
+    expect(res.headers.get('vary')).toBe('accept, sec-fetch-mode')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Follows #36117, targeted at `feat/early-404` rather than `main` as you offered there.

### 📚 Description

The early 404 body differs by `Accept`: without `text/html` it is the JSON error, with it Nuxt server-renders the error page. Nothing advertises that variance today.

It matters most on the caching path this branch introduces — `cache-control: public, max-age=…` on GET/HEAD misses invites a shared cache to store one representation and hand it to the other audience. It also matters without a `cache` route rule, since 404 is one of the heuristically cacheable status codes in RFC 9111 §4.2.2, so a CDN may store one unasked.

So `vary: accept` is now set on every early 404, with `cache-control` staying conditional exactly as before. Happy to narrow `vary` to the cacheable branch instead if you'd rather leave the uncached response untouched.

Adds unit coverage for `throwIfUnmatchedPagePath` alongside it, following the existing `packages/nitro-server/test` pattern: pass-through for paths that can match (including trailing slashes and payload URLs), the 404 status and path payload, the new `vary` header, and the existing GET/HEAD-only `cache-control` behaviour.

Verified both assertions fail against the branch as it stands and pass with the change. `pnpm vitest run --project unit packages/nitro-server packages/nuxt/test/early-404-patterns.test.ts` is green (69 tests), as is `eslint` on both files.
