### PR TITLE
fix(nuxt): don't resolve awaited `useAsyncData` with unfetched data on hydration

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -511,7 +511,7 @@ export const createUseAsyncData: CreateUseAsyncData = defineKeyedFunctionFactory
 
         const hasServerData = key.value in nuxtApp.payload.data
 
-        if (fetchOnServer && nuxtApp.isHydrating && (asyncData.error.value || asyncData.data.value !== undefined)) {
+        if (fetchOnServer && nuxtApp.isHydrating && (asyncData.error.value || (asyncData.data.value !== undefined && (hasServerData || asyncData._initialCachedData !== undefined)))) {
           // 1. Hydration (server: true): no fetch
           if (pendingWhenIdle) {
             asyncData.pending.value = false

--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -509,13 +509,15 @@ export const createUseAsyncData: CreateUseAsyncData = defineKeyedFunctionFactory
 
         const isWithinClientOnly = inComponentSetup && (instance?._nuxtClientOnly || inject(clientOnlySymbol, false))
 
+        const hasServerData = key.value in nuxtApp.payload.data
+
         if (fetchOnServer && nuxtApp.isHydrating && (asyncData.error.value || asyncData.data.value !== undefined)) {
           // 1. Hydration (server: true): no fetch
           if (pendingWhenIdle) {
             asyncData.pending.value = false
           }
           asyncData.status.value = asyncData.error.value ? 'error' : 'success'
-        } else if (inComponentSetup && ((!isWithinClientOnly && nuxtApp.payload.serverRendered && nuxtApp.isHydrating) || opts.lazy) && opts.immediate) {
+        } else if (inComponentSetup && ((!isWithinClientOnly && nuxtApp.payload.serverRendered && nuxtApp.isHydrating && (!fetchOnServer || hasServerData)) || opts.lazy) && opts.immediate) {
           // 2. Initial load (server: false): fetch on mounted
           // 3. Initial load or navigation (lazy: true): fetch on mounted
           if (instance) {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -772,6 +772,24 @@ describe('pages', () => {
     await page.close()
   })
 
+  it.skipIf(isDev)('awaited useAsyncData resolves with data when a catch-all remounts during the deferred route restore', async () => {
+    const { page, pageErrors, consoleLogs } = await renderPage('/prerender/catchall/a/b/?test=true')
+
+    await page.waitForFunction(() => window.useNuxtApp?.() && !window.useNuxtApp!().isHydrating)
+
+    const states = await page.evaluate(() => (window as unknown as { __asyncDataStates: Array<{ path: string, status: string, hasData: boolean }> }).__asyncDataStates)
+    expect(states.length).toBeGreaterThan(0)
+    for (const state of states) {
+      expect.soft(state).toMatchObject({ status: 'success', hasData: true })
+    }
+
+    expect(await page.innerText('#catchall-async-data')).toBe('/prerender/catchall/a/b/')
+    expect(pageErrors).toEqual([])
+    expect(consoleLogs.filter(l => l.type === 'error')).toEqual([])
+
+    await page.close()
+  })
+
   it.skipIf(isDev)('enables preview mode on prerendered pages', async () => {
     const { page } = await renderPage('/prerender/preview-mode?preview=true&token=hehe')
 

--- a/test/fixtures/basic/app/pages/prerender/catchall/[...slug].vue
+++ b/test/fixtures/basic/app/pages/prerender/catchall/[...slug].vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+const route = useRoute()
+
+const { data, status } = await useAsyncData(route.path, () => Promise.resolve({ path: route.path }))
+
+if (import.meta.client) {
+  const states = ((window as unknown as { __asyncDataStates?: unknown[] }).__asyncDataStates ||= [])
+  states.push({ path: route.path, status: status.value, hasData: data.value !== undefined })
+}
+
+if (!data.value) {
+  throw createError({ status: 404, statusText: 'Page not found', fatal: true })
+}
+</script>
+
+<template>
+  <div id="catchall-async-data">
+    {{ data!.path }}
+  </div>
+</template>

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -199,6 +199,7 @@ export default withMatrix({
         '/random/b',
         '/random/c',
         '/prefetch/server-components',
+        '/prerender/catchall/a/b',
         '/404.html',
       ],
     },

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -1,6 +1,6 @@
 /// <reference path="../fixtures/basic/.nuxt/nuxt.d.ts" />
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineEventHandler } from 'h3'
 
 import { mountSuspended, registerEndpoint } from '@nuxt/test-utils/runtime'
@@ -1015,6 +1015,104 @@ describe('useAsyncData', () => {
     expect(data.value).toBe('server-renderered')
     expect(status.value).toBe('success')
     useNuxtApp().isHydrating = false
+  })
+
+  // https://github.com/nuxt/nuxt/issues/36111
+  describe('hydration', () => {
+    let previousHydrating: boolean
+    let previousServerRendered: boolean
+
+    beforeEach(() => {
+      const nuxtApp = useNuxtApp()
+      previousHydrating = nuxtApp.isHydrating!
+      previousServerRendered = nuxtApp.payload.serverRendered!
+      nuxtApp.isHydrating = true
+      nuxtApp.payload.serverRendered = true
+    })
+
+    afterEach(() => {
+      const nuxtApp = useNuxtApp()
+      nuxtApp.isHydrating = previousHydrating
+      nuxtApp.payload.serverRendered = previousServerRendered
+    })
+
+    /** Records what an `await useAsyncData()` within component setup sees at first synchronous use. */
+    async function mountAwaitingAsyncData (...args: any[]) {
+      const observed: { status?: string, data?: unknown } = {}
+      const wrapper = await mountSuspended(defineComponent({
+        async setup () {
+          const { data, status } = await useAsyncData(...args as [any])
+          observed.status = status.value
+          observed.data = data.value
+          return () => h('div')
+        },
+      }))
+      return { wrapper, observed }
+    }
+
+    it('should reuse the payload without fetching when the server rendered the key', async () => {
+      useNuxtApp().payload.data[uniqueKey] = 'server'
+      const promiseFn = vi.fn(() => Promise.resolve('client'))
+
+      const { wrapper, observed } = await mountAwaitingAsyncData(uniqueKey, promiseFn)
+
+      expect(observed).toMatchObject({ status: 'success', data: 'server' })
+      expect(promiseFn).not.toHaveBeenCalled()
+      wrapper.unmount()
+    })
+
+    it('should reuse a cached value without fetching when there is no payload entry', async () => {
+      const promiseFn = vi.fn(() => Promise.resolve('client'))
+      const getCachedData = vi.fn(() => 'cached')
+
+      const { wrapper, observed } = await mountAwaitingAsyncData(uniqueKey, promiseFn, { getCachedData })
+
+      expect(observed).toMatchObject({ status: 'success', data: 'cached' })
+      expect(promiseFn).not.toHaveBeenCalled()
+      wrapper.unmount()
+    })
+
+    it('should fetch before resolving when there is no payload entry for the key', async () => {
+      const promiseFn = vi.fn(() => Promise.resolve('client'))
+
+      const { wrapper, observed } = await mountAwaitingAsyncData(uniqueKey, promiseFn)
+
+      expect(observed).toMatchObject({ status: 'success', data: 'client' })
+      expect(promiseFn).toHaveBeenCalledTimes(1)
+      wrapper.unmount()
+    })
+
+    it('should fetch before resolving when a default is set but there is no payload entry for the key', async () => {
+      const promiseFn = vi.fn(() => Promise.resolve('client'))
+
+      const { wrapper, observed } = await mountAwaitingAsyncData(uniqueKey, promiseFn, { default: () => null })
+
+      expect(observed).toMatchObject({ status: 'success', data: 'client' })
+      expect(promiseFn).toHaveBeenCalledTimes(1)
+      wrapper.unmount()
+    })
+
+    it('should still defer the fetch to mount for `server: false`', async () => {
+      const promiseFn = vi.fn(() => Promise.resolve('client'))
+
+      const { wrapper, observed } = await mountAwaitingAsyncData(uniqueKey, promiseFn, { server: false })
+
+      expect(observed).toMatchObject({ status: 'idle', data: undefined })
+      await flushPromises()
+      expect(promiseFn).toHaveBeenCalledTimes(1)
+      wrapper.unmount()
+    })
+
+    it('should still defer the fetch to mount for `lazy: true`', async () => {
+      const promiseFn = vi.fn(() => Promise.resolve('client'))
+
+      const { wrapper, observed } = await mountAwaitingAsyncData(uniqueKey, promiseFn, { lazy: true })
+
+      expect(observed).toMatchObject({ status: 'idle', data: undefined })
+      await flushPromises()
+      expect(promiseFn).toHaveBeenCalledTimes(1)
+      wrapper.unmount()
+    })
   })
 
   it('should retain the old data when a computed key changes', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

related: https://github.com/nuxt/nuxt/issues/36111

### 📚 Description

when a `useAsyncData` key includes some variant of the route, and this route was also prerendered, it's possible for this data to be missing from the payload

of course, users should _avoid_ keying `useAsyncData` on the exact route path (https://github.com/nuxt/nuxt/issues/31556 should be the solution here)

but in this edge case, we should trigger refetching the data rather than resolving to _no data_