### PR TITLE
refactor(kit): inline minimal nitro v2/v3 types and drop nitro deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "magic-regexp": "catalog:dev",
     "markdownlint-cli": "catalog:dev",
     "nitro": "catalog:nitro-runtime",
+    "nitropack": "catalog:dev",
     "nuxt": "workspace:*",
     "nuxt-content-twoslash": "catalog:dev",
     "ofetch": "catalog:app-runtime",

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -92,8 +92,6 @@
     "hookable": "catalog:app-runtime",
     "jiti": "catalog:build",
     "mlly": "catalog:build",
-    "nitro": "catalog:nitro-runtime",
-    "nitropack": "catalog:dev",
     "oxc-parser": "catalog:build",
     "pkg-types": "catalog:build",
     "rolldown": "catalog:vite",

--- a/packages/kit/src/nitro-types.ts
+++ b/packages/kit/src/nitro-types.ts
@@ -1,19 +1,198 @@
-import type * as NitroV2 from 'nitropack/types'
-import type * as NitroV3 from 'nitro/types'
+/**
+ * Minimal structural types for the nitro majors supported by Nuxt.
+ *
+ * These are inlined (rather than imported from `nitropack`/`nitro`) so that
+ * `@nuxt/kit` does not depend on either package being installed and can be
+ * used unchanged whichever nitro major the host Nuxt provides.
+ */
 
-type isNitroV2 = 'options' extends keyof NitroV2.Nitro
-  ? '___INVALID' extends keyof NitroV2.Nitro
-    ? false
-    : true
-  : false
+type MaybeArray<T> = T | T[]
 
-type isNitroV3 = 'options' extends keyof NitroV3.Nitro
-  ? '___INVALID' extends keyof NitroV3.Nitro
-    ? false
-    : true
-  : false
+export type NitroHandlerMethod = 'GET' | 'HEAD' | 'PATCH' | 'POST' | 'PUT' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'TRACE'
+type NitroHandlerMethodV3 = NitroHandlerMethod | 'QUERY'
 
-export type Nitro = isNitroV2 extends true ? isNitroV3 extends true ? NitroV2.Nitro | NitroV3.Nitro : NitroV2.Nitro : NitroV3.Nitro
-export type NitroDevEventHandler = isNitroV2 extends true ? isNitroV3 extends true ? NitroV2.NitroDevEventHandler | NitroV3.NitroDevEventHandler : NitroV2.NitroDevEventHandler : NitroV3.NitroDevEventHandler
-export type NitroEventHandler = isNitroV2 extends true ? isNitroV3 extends true ? NitroV2.NitroEventHandler | NitroV3.NitroEventHandler : NitroV2.NitroEventHandler : NitroV3.NitroEventHandler
-export type NitroRouteConfig = isNitroV2 extends true ? isNitroV3 extends true ? NitroV2.NitroRouteConfig | NitroV3.NitroRouteConfig : NitroV2.NitroRouteConfig : NitroV3.NitroRouteConfig
+type HandlerEnv = MaybeArray<'dev' | 'prod' | 'prerender' | (string & {})>
+
+interface NitroRouteMeta {
+  openAPI?: Record<string, any>
+}
+
+/** Server handler shape accepted by nitro v2 (`nitropack`). */
+export interface NitroEventHandlerV2 {
+  /**
+   * Path prefix or route
+   *
+   * If an empty string used, will be used as a middleware
+   */
+  route?: string
+  /**
+   * Specifies this is a middleware handler.
+   * Middleware are called on every route and should normally return nothing to pass to the next handlers
+   */
+  middleware?: boolean
+  /**
+   * Use lazy loading to import handler
+   */
+  lazy?: boolean
+  /**
+   * Path to event handler
+   */
+  handler: string
+  /**
+   * Router method matcher
+   */
+  method?: NitroHandlerMethod | Lowercase<NitroHandlerMethod>
+  /**
+   * Meta
+   */
+  meta?: NitroRouteMeta
+  env?: HandlerEnv
+}
+
+/** Server handler shape accepted by nitro v3 (`nitro`). */
+export interface NitroEventHandlerV3 {
+  /**
+   * HTTP pathname pattern to match.
+   *
+   * @example "/test", "/api/:id", "/blog/**"
+   */
+  route: string
+  /**
+   * HTTP method to match.
+   */
+  method?: NitroHandlerMethodV3 | Lowercase<NitroHandlerMethodV3>
+  /**
+   * Run handler as a middleware before other route handlers.
+   */
+  middleware?: boolean
+  /**
+   * Route metadata (e.g. OpenAPI operation info).
+   */
+  meta?: NitroRouteMeta
+  /**
+   * Use lazy loading to import handler.
+   */
+  lazy?: boolean
+  /**
+   * Path to event handler.
+   */
+  handler: string
+  /**
+   * Event handler type.
+   *
+   * Default is `"web"`. If set to `"node"`, the handler will be converted into a web compatible handler.
+   */
+  format?: 'web' | 'node'
+  /**
+   * Environments to include and bundle this handler.
+   */
+  env?: HandlerEnv
+}
+
+export type NitroEventHandler = NitroEventHandlerV2 | NitroEventHandlerV3
+
+/** Development-only server handler shape accepted by nitro v2 (`nitropack`). */
+export interface NitroDevEventHandlerV2 {
+  /**
+   * Path prefix or route
+   */
+  route?: string
+  /**
+   * Event handler
+   */
+  handler: (...args: any[]) => any
+}
+
+/** Development-only server handler shape accepted by nitro v3 (`nitro`). */
+export interface NitroDevEventHandlerV3 {
+  /**
+   * HTTP pathname pattern to match.
+   */
+  route: string
+  /**
+   * HTTP method to match.
+   */
+  method?: NitroHandlerMethodV3 | Lowercase<NitroHandlerMethodV3>
+  /**
+   * Run handler as a middleware before other route handlers.
+   */
+  middleware?: boolean
+  /**
+   * Route metadata (e.g. OpenAPI operation info).
+   */
+  meta?: NitroRouteMeta
+  /**
+   * Event handler function, or a fetchable object such as an `H3` app instance.
+   */
+  handler: ((...args: any[]) => any) | { fetch: (...args: any[]) => any } | Record<string, any>
+}
+
+export type NitroDevEventHandler = NitroDevEventHandlerV2 | NitroDevEventHandlerV3
+
+export interface NitroRouteConfig {
+  cache?: Record<string, any> | false
+  headers?: Record<string, string>
+  redirect?: string | { to: string, status?: number, statusCode?: number }
+  prerender?: boolean
+  proxy?: string | ({ to: string } & Record<string, any>)
+  isr?: number | boolean | Record<string, any>
+  cors?: boolean
+  swr?: boolean | number
+  static?: boolean | number
+  basicAuth?: Record<string, any> | false
+  /** Additional route options, including framework-specific route rules. */
+  [key: string]: any
+}
+
+export interface NitroOptions {
+  handlers: NitroEventHandler[]
+  devHandlers: NitroDevEventHandler[]
+  runtimeConfig: Record<string, any>
+  plugins: string[]
+  alias: Record<string, string>
+  virtual: Record<string, any>
+  publicAssets: Array<Record<string, any>>
+  prerender: Record<string, any>
+  output: Record<string, any>
+  storage?: Record<string, any>
+  devStorage?: Record<string, any>
+  static?: boolean
+  node?: boolean
+  baseURL?: string
+  preset?: string
+}
+
+export interface Nitro {
+  meta: {
+    version: string
+    majorVersion: number
+  }
+  options: NitroOptions
+  scannedHandlers: NitroEventHandler[]
+  vfs: Record<string, string> | Map<string, { render: () => string | Promise<string> }>
+  hooks: {
+    hook: (...args: any[]) => () => void
+    hookOnce: (...args: any[]) => () => void
+    callHook: (...args: any[]) => void | Promise<any>
+    addHooks: (...args: any[]) => () => void
+    removeHook: (...args: any[]) => void
+  }
+  logger: {
+    log: (...args: any[]) => void
+    info: (...args: any[]) => void
+    warn: (...args: any[]) => void
+    error: (...args: any[]) => void
+  } & Record<string, any>
+  /** Only available on nitro v3. */
+  fetch?: (input: Request) => Response | Promise<Response>
+  /** Only available on nitro v3. */
+  routing?: {
+    sync: () => void
+    routeRules: { routes: Array<{ route: string, data: Record<string, any> }> }
+  } & Record<string, any>
+  /** Only available on nitro v2. */
+  storage?: unknown
+  unimport?: unknown
+  updateConfig: (config: Record<string, any>) => void | Promise<void>
+  close: () => Promise<void>
+}

--- a/packages/kit/test/nitro-types.spec.ts
+++ b/packages/kit/test/nitro-types.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import type * as UpstreamV2 from 'nitropack/types'
+import type * as UpstreamV3 from 'nitro/types'
+
+import type { Nitro, NitroDevEventHandlerV2, NitroDevEventHandlerV3, NitroEventHandlerV2, NitroEventHandlerV3, NitroOptions, NitroRouteConfig } from '../src/nitro-types.ts'
+
+type KnownKeys<T> = keyof { [K in keyof T as string extends K ? never : number extends K ? never : K]: 0 }
+
+// `method` accepts both casings and `handler` shapes are widened on purpose;
+// those fields are checked one-way (upstream must stay assignable to kit).
+type Strict<T> = Omit<T, 'method' | 'handler'>
+
+describe('inlined nitro v2 types', () => {
+  it('matches the upstream `NitroEventHandler`', () => {
+    expectTypeOf<keyof NitroEventHandlerV2>().toEqualTypeOf<keyof UpstreamV2.NitroEventHandler>()
+    expectTypeOf<UpstreamV2.NitroEventHandler>().toExtend<NitroEventHandlerV2>()
+    expectTypeOf<Strict<NitroEventHandlerV2>>().toExtend<Strict<UpstreamV2.NitroEventHandler>>()
+    expectTypeOf<NitroEventHandlerV2['handler']>().toExtend<UpstreamV2.NitroEventHandler['handler']>()
+    expectTypeOf<UpstreamV2.NitroEventHandler['method']>().toExtend<NitroEventHandlerV2['method']>()
+  })
+
+  it('matches the upstream `NitroDevEventHandler`', () => {
+    expectTypeOf<keyof NitroDevEventHandlerV2>().toEqualTypeOf<keyof UpstreamV2.NitroDevEventHandler>()
+    expectTypeOf<UpstreamV2.NitroDevEventHandler>().toExtend<NitroDevEventHandlerV2>()
+    expectTypeOf<Strict<NitroDevEventHandlerV2>>().toExtend<Strict<UpstreamV2.NitroDevEventHandler>>()
+  })
+
+  it('accepts the upstream `NitroRouteConfig`', () => {
+    expectTypeOf<UpstreamV2.NitroRouteConfig>().toExtend<NitroRouteConfig>()
+  })
+
+  it('accepts the upstream `Nitro` instance and options', () => {
+    expectTypeOf<UpstreamV2.Nitro>().toExtend<Nitro>()
+    expectTypeOf<UpstreamV2.NitroOptions>().toExtend<NitroOptions>()
+  })
+})
+
+describe('inlined nitro v3 types', () => {
+  it('matches the upstream `NitroEventHandler`', () => {
+    expectTypeOf<keyof NitroEventHandlerV3>().toEqualTypeOf<keyof UpstreamV3.NitroEventHandler>()
+    expectTypeOf<UpstreamV3.NitroEventHandler>().toExtend<NitroEventHandlerV3>()
+    expectTypeOf<Strict<NitroEventHandlerV3>>().toExtend<Strict<UpstreamV3.NitroEventHandler>>()
+    expectTypeOf<NitroEventHandlerV3['handler']>().toExtend<UpstreamV3.NitroEventHandler['handler']>()
+    expectTypeOf<UpstreamV3.NitroEventHandler['method']>().toExtend<NitroEventHandlerV3['method']>()
+  })
+
+  it('matches the upstream `NitroDevEventHandler`', () => {
+    expectTypeOf<keyof NitroDevEventHandlerV3>().toEqualTypeOf<keyof UpstreamV3.NitroDevEventHandler>()
+    expectTypeOf<UpstreamV3.NitroDevEventHandler>().toExtend<NitroDevEventHandlerV3>()
+    expectTypeOf<Strict<NitroDevEventHandlerV3>>().toExtend<Strict<UpstreamV3.NitroDevEventHandler>>()
+    expectTypeOf<UpstreamV3.NitroDevEventHandler['handler']>().toExtend<NitroDevEventHandlerV3['handler']>()
+  })
+
+  it('accepts the upstream `NitroRouteConfig`', () => {
+    expectTypeOf<UpstreamV3.NitroRouteConfig>().toExtend<NitroRouteConfig>()
+  })
+
+  it('accepts the upstream `Nitro` instance and options', () => {
+    expectTypeOf<UpstreamV3.Nitro>().toExtend<Nitro>()
+    expectTypeOf<UpstreamV3.NitroOptions>().toExtend<NitroOptions>()
+  })
+})
+
+describe('inlined `Nitro` shapes', () => {
+  it('declare no members that are missing from both upstream majors', () => {
+    expectTypeOf<keyof Nitro>().toExtend<keyof UpstreamV2.Nitro | keyof UpstreamV3.Nitro>()
+    expectTypeOf<keyof NitroOptions>().toExtend<keyof UpstreamV2.NitroOptions | keyof UpstreamV3.NitroOptions>()
+  })
+})
+
+describe('inlined `NitroRouteConfig`', () => {
+  // upstream keys may be a superset here because nuxt augments `nitro/types`
+  // within this repo; extra upstream keys are absorbed by the index signature
+  it('declares no keys that are missing upstream', () => {
+    expectTypeOf<KnownKeys<NitroRouteConfig>>().toExtend<keyof UpstreamV2.NitroRouteConfig | keyof UpstreamV3.NitroRouteConfig>()
+  })
+})

--- a/packages/kit/tsdown.config.ts
+++ b/packages/kit/tsdown.config.ts
@@ -23,8 +23,6 @@ export default defineConfig({
       'dotenv',
       'jiti',
       '@nuxt/schema',
-      'nitro/types',
-      'nitropack/types',
       /^rolldown(\/|$)/,
       'oxc-parser',
       'mlly',

--- a/packages/nuxt/src/imports/module.ts
+++ b/packages/nuxt/src/imports/module.ts
@@ -5,6 +5,7 @@ import { isAbsolute, join, normalize, relative, resolve } from 'pathe'
 import type { Import, InlinePreset, Unimport } from 'unimport'
 import { createUnimport, scanDirExports, toExports, toTypeDeclarationFile, toTypeReExports } from 'unimport'
 import escapeRE from 'escape-string-regexp'
+import type { Nitro } from 'nitro/types'
 import { klona } from 'klona'
 import { resolveModulePath } from 'exsolve'
 
@@ -296,7 +297,7 @@ function addDeclarationTemplates (ctx: Pick<Unimport, 'getImports' | 'generateTy
       if (!options.autoImport) {
         return GENERATED_BY_COMMENT + AUTO_IMPORTS_DISABLED_COMMENT
       }
-      const nitro = useNitro()
+      const nitro = useNitro() as Nitro
 
       const nuxtImports = await ctx.getImports()
 

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -498,7 +498,7 @@ export default defineNuxtModule({
     })
 
     nuxt.hook('app:resolve', (app) => {
-      const nitro = useNitro()
+      const nitro = useNitro() as Nitro
       if (nitro.options.prerender.crawlLinks || ('routing' in nitro && nitro.routing.routeRules.routes.some(r => r.data.prerender))) {
         app.plugins.push({
           src: resolve(runtimeDir, 'plugins/prerender.server'),
@@ -655,7 +655,7 @@ export default defineNuxtModule({
     nuxt.hook('pages:extend', (routes) => {
       const nitro = useNitro()
       let resolvedRoutes: string[]
-      for (const route of 'routing' in nitro ? nitro.routing.routeRules.routes : []) {
+      for (const route of nitro.routing?.routeRules.routes ?? []) {
         if (!route.data.redirect) { continue }
         resolvedRoutes ||= routes.flatMap(route => resolveRoutePaths(route))
         // skip if there's already a route matching this path

--- a/packages/vite/src/plugins/vite-node.ts
+++ b/packages/vite/src/plugins/vite-node.ts
@@ -13,6 +13,7 @@ import { setBuildOutput, tryUseNuxt, useNitro } from '@nuxt/kit'
 import { bundlerDiagnostics } from '@nuxt/kit/internal'
 import type { EnvironmentModuleNode, ModuleNode, PluginContainer, ViteDevServer, Plugin as VitePlugin } from 'vite'
 import type { FetchResult } from 'vite-node'
+import type { Nitro } from 'nitro/types'
 import { normalizeViteManifest } from 'vue-bundle-renderer'
 import type { Manifest } from 'vue-bundle-renderer'
 import type { Nuxt } from '@nuxt/schema'
@@ -186,7 +187,7 @@ export function ViteNodePlugin (nuxt: Nuxt): VitePlugin | undefined {
     }
   }
 
-  const nitro = useNitro()
+  const nitro = useNitro() as Nitro
 
   const runnerResolvedPath = resolveModulePath('#vite-node-runner', { from: import.meta.url })
   const serverResolvedPath = resolveModulePath('#vite-node-entry', { from: import.meta.url })

--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -37,7 +37,7 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
   /** Remove Nitro rollup plugin for handling dynamic imports from webpack chunks */
   if (!nuxt.options.dev) {
     const nitro = useNitro()
-    nitro.hooks.hook('rollup:before', (_nitro, config) => {
+    nitro.hooks.hook('rollup:before', (_nitro: unknown, config: { plugins?: unknown }) => {
       const plugins = config.plugins as InputPluginOption[]
 
       const existingPlugin = plugins.findIndex(i => i && 'name' in i && i.name === 'dynamic-require')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -576,8 +576,8 @@ catalogs:
 
 overrides:
   '@nuxt/kit': workspace:*
-  '@types/node': 24.13.3
   '@nuxt/schema': workspace:*
+  '@types/node': 24.13.3
   nuxt: workspace:*
   oxc-parser: 0.144.0
   rolldown: 1.2.4
@@ -716,6 +716,9 @@ importers:
       nitro:
         specifier: catalog:nitro-runtime
         version: 3.0.260610-beta(patch_hash=9273407579edf95350876c36b226440ebe6482463a007ad87c2f535365e21162)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(lru-cache@11.5.2)(rollup@4.62.4)(vite@8.2.1)
+      nitropack:
+        specifier: catalog:dev
+        version: 2.13.4(patch_hash=14fc1a0de87a798e71fa108469f4b19797146bf7e82bee35ba801b43c2919ab8)(@parcel/watcher@2.6.0)(@rspack/core@2.1.10(@swc/helpers@0.5.23))(oxc-parser@0.144.0)(rolldown@1.2.4)(srvx@0.11.22)(supports-color@10.2.2)(vite@8.2.1)(webpack@5.109.2(cssnano@8.0.6(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       nuxt:
         specifier: workspace:*
         version: link:packages/nuxt
@@ -869,12 +872,6 @@ importers:
       mlly:
         specifier: catalog:build
         version: 1.8.2
-      nitro:
-        specifier: catalog:nitro-runtime
-        version: 3.0.260610-beta(patch_hash=9273407579edf95350876c36b226440ebe6482463a007ad87c2f535365e21162)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(lru-cache@11.5.2)(rollup@4.62.4)(vite@8.2.1)
-      nitropack:
-        specifier: catalog:dev
-        version: 2.13.4(patch_hash=14fc1a0de87a798e71fa108469f4b19797146bf7e82bee35ba801b43c2919ab8)(@parcel/watcher@2.6.0)(@rspack/core@2.1.10(@swc/helpers@0.5.23))(oxc-parser@0.144.0)(rolldown@1.2.4)(srvx@0.11.22)(supports-color@10.2.2)(vite@8.2.1)(webpack@5.109.2(cssnano@8.0.6(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       oxc-parser:
         specifier: 0.144.0
         version: 0.144.0


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this inlines types for both nitropack v2 and nitro v3 for use within kit.

this means nuxt/kit v4 can support adding nitro v3 handlers with type accuracy, for example, and removes the last external types kit depended on.