### PR TITLE
fix(nuxt): bridge `AppConfigInput` augmentations into `nuxt/schema`

### DIFF
--- a/packages/nuxt/schema.d.ts
+++ b/packages/nuxt/schema.d.ts
@@ -1,5 +1,6 @@
 import type {
   AppConfig as _AppConfig,
+  AppConfigInput as _AppConfigInput,
   ConfigSchema as _ConfigSchema,
   CustomAppConfig as _CustomAppConfig,
   ModuleDependencies as _ModuleDependencies,
@@ -23,6 +24,8 @@ declare module 'nuxt/schema' {
   interface ConfigSchema extends _ConfigSchema { hooks: NuxtHooks }
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type
   interface AppConfig extends _AppConfig {}
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  interface AppConfigInput extends _AppConfigInput {}
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type
   interface CustomAppConfig extends _CustomAppConfig {}
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type


### PR DESCRIPTION
### 🔗 Linked issue

Reported downstream in nuxt/ui#6791

Standalone reproduction without `@nuxt/ui`: https://github.com/benjamincanac/nuxt-appconfig-input-repro

### 📚 Description

The bridge in `packages/nuxt/schema.d.ts` anchors `AppConfig`, `CustomAppConfig`, `NuxtConfig`, etc. in `nuxt/schema`'s module identity so augmentations on `@nuxt/schema` reach both surfaces, but `AppConfigInput` is not in the list.

When a user follows the [app config docs](https://nuxt.com/docs/4.x/directory-structure/app/app-config#typing-app-config) and augments `AppConfigInput` on `nuxt/schema`, there is no anchored declaration to merge with. Resolution becomes order dependent and module augmentations of `AppConfigInput` on `@nuxt/schema` can stop reaching the `nuxt/schema` surface, which is what `defineAppConfig` reads.

For `@nuxt/ui` the optional `ui?` input key disappears and the required `ui` from our `CustomAppConfig` augmentation shows through, so `defineAppConfig({})` errors with "Property 'ui' is missing". Repro: in a project with `@nuxt/ui`, add a `.d.ts` with:

```ts
declare module 'nuxt/schema' {
  interface AppConfigInput {}
}

export {}
```

The `ui` key in `app.config.ts` becomes required. I verified locally (nuxt 4.5.2) that this change keeps it optional.

`RuntimeConfig` and `PublicRuntimeConfig` are also absent from the bridge, happy to add them here too if you think they need the same treatment.

