### PR TITLE
fix(nuxt): resolve layout name override in layout `isCurrent` check

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-layout.ts
+++ b/packages/nuxt/src/app/components/nuxt-layout.ts
@@ -70,6 +70,8 @@ export default defineComponent({
 
     provide(LayoutSymbol, layout)
 
+    const resolveRouteLayout = (routeToCheck: RouteLocationNormalizedLoaded) => resolveLayoutName(routeToCheck, props.name)
+
     const layoutRef = shallowRef()
     context.expose({ layoutRef })
 
@@ -131,6 +133,7 @@ export default defineComponent({
               key: layout.value || undefined,
               name: layout.value,
               shouldProvide: !props.name,
+              resolveRouteLayout,
               isRenderingNewLayout: (name?: string | boolean) => {
                 return (name !== previouslyRenderedLayout && name === layout.value)
               },
@@ -162,6 +165,10 @@ const LayoutProvider = defineComponent({
       type: Function as unknown as () => (name?: string | boolean) => boolean,
       required: true,
     },
+    resolveRouteLayout: {
+      type: Function as unknown as () => (route: RouteLocationNormalizedLoaded) => string | false,
+      required: true,
+    },
   },
   setup (props, context) {
     // Prevent reactivity when the page will be rerendered in a different suspense fork
@@ -170,7 +177,7 @@ const LayoutProvider = defineComponent({
     if (props.shouldProvide) {
       provide(LayoutMetaSymbol, {
         // When name=false, always return true so NuxtPage doesn't skip rendering
-        isCurrent: (route: RouteLocationNormalizedLoaded) => name === false || name === resolveLayoutName(route),
+        isCurrent: (route: RouteLocationNormalizedLoaded) => name === false || name === props.resolveRouteLayout(route),
       })
     }
 

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -103,7 +103,7 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs'], serverDir, pagesRootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"317k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"318k"`)
 
     const packages = getVendorPackages(await glob(['_libs/**/*'], { cwd: serverDir }))
     expect(packages).toMatchInlineSnapshot(`

--- a/test/nuxt/nuxt-layout.test.ts
+++ b/test/nuxt/nuxt-layout.test.ts
@@ -215,6 +215,26 @@ describe('NuxtLayout', () => {
     expect.soft(nestedEl.find('h3').text()).toBe('Current route: /layout-2')
   })
 
+  it('should not block navigation when name is overridden to the current meta layout', async () => {
+    const override = ref<string | undefined>(undefined)
+    const overrideEl = await mountSuspended({
+      // @ts-expect-error dynamically-added layout is not typed
+      setup: () => () => h(NuxtLayout, { name: override.value }, { default: () => h(NuxtPage) }),
+    })
+
+    await navigateTo('/layout-1')
+    await flushPromises()
+    expect.soft(overrideEl.find('h3').text()).toBe('Current route: /layout-1')
+
+    override.value = 'layout-1'
+    await nextTick()
+
+    await navigateTo('/no-layout')
+    await flushPromises()
+    expect.soft(overrideEl.find('h1').text()).toBe(`'layout-1' layout`)
+    expect.soft(overrideEl.find('h3').text()).toBe('Current route: /no-layout')
+  })
+
   it.todo('should not change layout before child page resolves', async () => {
     await navigateTo('/layout-1')
     await flushPromises()


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/36131

### 📚 Description

introduced in #21450, the issue here is that `resolveLayoutName` looks only at route meta and route rules, and not the `name` override.