### PR TITLE
fix(nuxt): resolve non-ASCII aliases during SSR

### DIFF
--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -1,6 +1,6 @@
 import { isReadonly, reactive, shallowReactive, shallowRef } from 'vue'
 import type { Ref, VNode } from 'vue'
-import type { RouteLocationNormalizedLoadedGeneric, Router, RouterScrollBehavior } from 'vue-router'
+import type { RouteLocationNormalizedLoadedGeneric, RouteRecordRaw, Router, RouterScrollBehavior } from 'vue-router'
 import { START_LOCATION, createMemoryHistory, createRouter, createWebHashHistory, createWebHistory } from 'vue-router'
 import { isSamePath, withoutBase } from 'ufo'
 
@@ -23,6 +23,26 @@ import { pageIslandRoutes } from '#build/components.islands.mjs'
 
 // matches a trailing slash on the path only, leaving query and hash significant
 const PATH_TRAILING_SLASH_RE = /\/(?=$|[?#])/
+const NON_ASCII_RE = /\P{ASCII}+/gu
+
+function encodeRouteAliases (routes: readonly RouteRecordRaw[]): RouteRecordRaw[] {
+  return routes.map((route) => {
+    const encodedRoute = { ...route }
+    if (route.alias) {
+      encodedRoute.alias = typeof route.alias === 'string'
+        ? encodeNonAscii(route.alias)
+        : route.alias.map(encodeNonAscii)
+    }
+    if (route.children) {
+      encodedRoute.children = encodeRouteAliases(route.children)
+    }
+    return encodedRoute
+  })
+}
+
+function encodeNonAscii (path: string): string {
+  return path.replace(NON_ASCII_RE, encodeURIComponent)
+}
 
 // https://github.com/vuejs/router/blob/4a0cc8b9c1e642cdf47cc007fa5bbebde70afc66/packages/router/src/history/html5.ts#L37
 function createCurrentLocation (
@@ -62,7 +82,7 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
       : createMemoryHistory(routerBase)
     )
 
-    const routes = routerOptions.routes ? await routerOptions.routes(_routes) ?? _routes : _routes
+    const routes = encodeRouteAliases(routerOptions.routes ? await routerOptions.routes(_routes) ?? _routes : _routes)
 
     let startPosition: Parameters<RouterScrollBehavior>[2] | null
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -194,6 +194,31 @@ describe('pages', () => {
     expect(html).toContain('Hello Nuxt 3!')
   })
 
+  // Regression for https://github.com/nuxt/nuxt/issues/34042 and https://github.com/nuxt/nuxt/pull/34043
+  it('respects non-ASCII aliases during SSR and hydration', async () => {
+    const path = '/товары/日本語'
+    const html = await $fetch<string>(path)
+    expect(html).toContain('Random page: <b')
+    expect(html).toContain('>日本語</b>')
+
+    const page = await createPage()
+    const pageErrors: Error[] = []
+    const consoleWarnings: string[] = []
+    page.on('pageerror', error => pageErrors.push(error))
+    page.on('console', (message) => {
+      if (message.type() === 'warning') {
+        consoleWarnings.push(message.text())
+      }
+    })
+    await page.goto(url(path))
+    await page.waitForFunction(() => window.useNuxtApp?.() && !window.useNuxtApp().isHydrating)
+    expect(await page.evaluate(() => window.useNuxtApp?.()._route.matched.length)).toBe(1)
+    expect(await page.innerText('body')).toContain('Random page: 日本語')
+    expect(pageErrors).toEqual([])
+    expect(consoleWarnings).not.toContainEqual(expect.stringContaining('No match found for location'))
+    await page.close()
+  })
+
   it('respects redirects in page metadata', async () => {
     const { headers } = await fetch('/redirect', { redirect: 'manual' })
     expect(headers.get('location')).toEqual('/')

--- a/test/fixtures/basic/app/pages/random/[id].vue
+++ b/test/fixtures/basic/app/pages/random/[id].vue
@@ -53,6 +53,10 @@
 </template>
 
 <script setup lang="ts">
+definePageMeta({
+  alias: '/товары/:id',
+})
+
 const route = useRoute('random-id')
 
 const pageKey = 'rand_' + route.params.id


### PR DESCRIPTION
### 🔗 Linked issue

This is a regression related to #34042, previously fixed for client-side navigation in #34043.

### 📚 Description

Non-ASCII aliases defined with `definePageMeta` no longer match during SSR. For example:

```ts
definePageMeta({ alias: '/товары/:id' })
```

A direct request to `/товары/日本語` returns a 404, while the canonical route still renders.

The regression appeared after SSR context URLs and generated file-based route paths were aligned with Vue Router's encoding. Generated paths are encoded, but user-provided aliases remain decoded, so the encoded request cannot match the alias route record.

This PR encodes only non-ASCII runs in alias route records before creating Vue Router. It leaves Vue Router's ASCII route syntax and sub-delimiters untouched, including dynamic parameters, regex syntax, `&`, and `+`. Nested aliases and aliases returned from custom `router.options.routes` are handled as well.

The integration regression uses a dynamic Cyrillic alias with a non-ASCII parameter and verifies:

- a direct SSR request renders the aliased route;
- hydration retains a matched route;
- no browser runtime errors occur;
- Vue Router does not emit a `No match found for location` warning.

This complements the route-generation and client-side coverage added in #34043.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added or updated documentation (not needed for this regression fix).
