### PR TITLE
fix(vite): apply `baseURL` to public assets in inlined styles

### DIFF
--- a/packages/vite/src/plugins/public-dirs.ts
+++ b/packages/vite/src/plugins/public-dirs.ts
@@ -6,6 +6,8 @@ import { generateTransform, rolldownString } from 'rolldown-string'
 import { isCSSRequest } from 'vite'
 import type { Plugin } from 'vite'
 
+import { isInlineStyleId } from '../utils/inline-styles.ts'
+
 const PREFIX = '\0virtual:public?'
 const PREFIX_RE = /^\0virtual:public\?/
 const CSS_URL_RE = /url\((\/[^)]+)\)/g
@@ -64,7 +66,7 @@ export const PublicDirsPlugin = (options: VitePublicDirsPluginOptions): Plugin[]
         },
       },
       renderChunk (code, chunk) {
-        if (!chunk.facadeModuleId?.includes('?inline&used')) { return }
+        if (!isInlineStyleId(chunk.facadeModuleId)) { return }
 
         const s = rolldownString(code, chunk.fileName)
         const q = code.match(RENDER_CHUNK_RE)?.[0] || '"'

--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -10,6 +10,7 @@ import { generateTransform, rolldownString } from 'rolldown-string'
 import genericNames from 'generic-names'
 
 import { IS_CSS_RE, isCSS, isVue, parseModuleId } from '../utils/index.ts'
+import { withInlineQuery } from '../utils/inline-styles.ts'
 import { resolveClientEntry } from '../utils/config.ts'
 import escapeStringRegexp from 'escape-string-regexp'
 
@@ -60,19 +61,6 @@ export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
   const clientCSSMap: Record<string, Set<string>> = {}
 
   const stripQuery = (id: string) => id.replace(QUERY_RE, '')
-
-  // Add the `inline&used` params used to extract a module's CSS for SSR
-  // inlining. Vite/plugin-vue keep the `lang.<ext>` marker last so the id ends
-  // in a CSS extension, which is what vite's `isCSSRequest` and user plugins
-  // gate on. Insert the params *before* that trailing marker so the id keeps its
-  // CSS suffix and stays visible to extension-gated transforms. (#29232)
-  const withInlineQuery = (id: string) => {
-    const match = id.match(/([?&])lang\.[^&?]+$/)
-    if (match) {
-      return id.slice(0, match.index) + match[1] + 'inline&used&' + id.slice(match.index! + 1)
-    }
-    return id + (id.includes('?') ? '&' : '?') + 'inline&used'
-  }
 
   // For each CSS source module id (with `?...` query stripped) whose styles are
   // inlined into the SSR response, the `cssMap` keys of the components it is

--- a/packages/vite/src/utils/inline-styles.test.ts
+++ b/packages/vite/src/utils/inline-styles.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { isInlineStyleId, withInlineQuery } from './inline-styles.ts'
+
+describe('withInlineQuery', () => {
+  it('appends the query when there is no trailing lang marker', () => {
+    expect(withInlineQuery('/app/assets/global.css')).toBe('/app/assets/global.css?inline&used')
+    expect(withInlineQuery('/app/assets/global.css?direct')).toBe('/app/assets/global.css?direct&inline&used')
+  })
+
+  it('inserts the query before a trailing lang marker', () => {
+    expect(withInlineQuery('/app/app.vue?vue&type=style&index=0&scoped=7d7f4a5d&lang.css'))
+      .toBe('/app/app.vue?vue&type=style&index=0&scoped=7d7f4a5d&inline&used&lang.css')
+  })
+})
+
+describe('isInlineStyleId', () => {
+  it.each([
+    '/app/assets/global.css?inline&used',
+    '/app/assets/global.css?direct&inline&used',
+    '/app/app.vue?vue&type=style&index=0&inline&used&lang.css',
+  ])('matches %s', (id) => {
+    expect(isInlineStyleId(id)).toBe(true)
+  })
+
+  it.each([
+    null,
+    undefined,
+    '/app/assets/global.css',
+    '/app/app.vue?vue&type=style&index=0&lang.css',
+    '/app/assets/global.css?inline&usedx',
+  ])('does not match %s', (id) => {
+    expect(isInlineStyleId(id)).toBe(false)
+  })
+})

--- a/packages/vite/src/utils/inline-styles.ts
+++ b/packages/vite/src/utils/inline-styles.ts
@@ -1,0 +1,27 @@
+const LANG_MARKER_RE = /([?&])lang\.[^&?]+$/
+
+/**
+ * Add the `inline&used` params used to extract a module's CSS for SSR inlining.
+ *
+ * Vite/plugin-vue keep the `lang.<ext>` marker last so the id ends in a CSS
+ * extension, which is what vite's `isCSSRequest` and user plugins gate on.
+ * Insert the params *before* that trailing marker so the id keeps its CSS
+ * suffix and stays visible to extension-gated transforms. (#29232)
+ */
+export function withInlineQuery (id: string): string {
+  const match = id.match(LANG_MARKER_RE)
+  if (match) {
+    return id.slice(0, match.index) + match[1] + 'inline&used&' + id.slice(match.index! + 1)
+  }
+  return id + (id.includes('?') ? '&' : '?') + 'inline&used'
+}
+
+const INLINE_STYLE_ID_RE = /[?&]inline&used(?:&|$)/
+
+/**
+ * Whether an id was created by {@link withInlineQuery}, i.e. it is a CSS module
+ * whose contents are inlined into the server-rendered response.
+ */
+export function isInlineStyleId (id: string | null | undefined): boolean {
+  return !!id && INLINE_STYLE_ID_RE.test(id)
+}

--- a/test/dynamic-paths.test.ts
+++ b/test/dynamic-paths.test.ts
@@ -118,6 +118,20 @@ describe.skipIf(!runsOncePerBuilderInMatrix)('dynamic paths', () => {
     }
   })
 
+  // https://github.com/nuxt/nuxt/issues/36133
+  it.skipIf(isWebpack)('should apply base URL to public assets referenced from inlined SFC styles', async () => {
+    await startServer({
+      env: {
+        NUXT_APP_BASE_URL: '/foo/',
+      },
+    })
+
+    const html = await $fetch<string>('/foo/inline-styles')
+    const inlineStyles = Array.from(html.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g), m => m[1]!).join('\n')
+    expect(inlineStyles).toContain('url(/foo/public.svg)')
+    expect(inlineStyles).not.toContain('url(/public.svg)')
+  })
+
   it('should use baseURL when redirecting', async () => {
     await startServer({
       env: {

--- a/test/fixtures/dynamic-paths/app/pages/inline-styles.vue
+++ b/test/fixtures/dynamic-paths/app/pages/inline-styles.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="inline-styled">
+    inline styles
+  </div>
+</template>
+
+<style scoped>
+.inline-styled {
+  background-image: url('/public.svg');
+}
+</style>


### PR DESCRIPTION
### 🔗 Linked issue

spotted when updating nuxt/fonts to latest nuxt

### 📚 Description

regression from #35714... by moving `inline&used&` into the query instead of appending it, we stopped the match from being properly detected