### PR TITLE
refactor(kit,nitro,nuxt,schema): migrate more build-time warnings -> nostics

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -231,6 +231,18 @@ export default createConfigForNuxt({
       },
     },
     {
+      files: ['packages/{nuxt,kit,nitro-server,schema,vite,webpack,rspack}/src/**'],
+      ignores: ['packages/nuxt/src/app/**', '**/runtime/**', '**/*.{spec,test}.{js,mjs,ts,mts}'],
+      name: 'local/requires/nostics-diagnostics',
+      rules: {
+        // TODO: migrate remaining violations to nostics and raise to 'error'
+        'no-restricted-syntax': ['warn', {
+          message: 'Use a nostics diagnostic (see packages/kit/src/diagnostics/) instead of logger/console for build-time warnings and errors.',
+          selector: 'CallExpression[callee.object.name=/^(logger|console)$/][callee.property.name=/^(warn|error)$/]',
+        }],
+      },
+    },
+    {
       files: ['packages/nuxt/src/app/**', 'test/**', '**/runtime/**', '**/*.test.ts'],
       name: 'local/disables/client-console',
       rules: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -232,11 +232,12 @@ export default createConfigForNuxt({
     },
     {
       files: ['packages/{nuxt,kit,nitro-server,schema,vite,webpack,rspack}/src/**'],
-      ignores: ['packages/nuxt/src/app/**', '**/runtime/**', '**/*.{spec,test}.{js,mjs,ts,mts}'],
+      // vite-node* files execute inside the nitro dev process rather than the
+      // Nuxt build process, so nostics catalogs do not apply there.
+      ignores: ['packages/nuxt/src/app/**', '**/runtime/**', '**/*.{spec,test}.{js,mjs,ts,mts}', 'packages/vite/src/vite-node*.ts'],
       name: 'local/requires/nostics-diagnostics',
       rules: {
-        // TODO: migrate remaining violations to nostics and raise to 'error'
-        'no-restricted-syntax': ['warn', {
+        'no-restricted-syntax': ['error', {
           message: 'Use a nostics diagnostic (see packages/kit/src/diagnostics/) instead of logger/console for build-time warnings and errors.',
           selector: 'CallExpression[callee.object.name=/^(logger|console)$/][callee.property.name=/^(warn|error)$/]',
         }],

--- a/packages/kit/src/diagnostics/bundler.ts
+++ b/packages/kit/src/diagnostics/bundler.ts
@@ -111,5 +111,10 @@ export const bundlerDiagnostics = /* #__PURE__ */ defineDiagnostics({
       fix: 'Check that no Vite plugin removes or renames the client build manifest in a `generateBundle`/`writeBundle` hook. If this happens with no such plugin, please report it at https://github.com/nuxt/nuxt/issues.',
       docs: false,
     },
+    NUXT_B7022: {
+      why: (p: { existing: string, route: string }) => `Route rules for \`${p.existing}\` and \`${p.route}\` resolve to the same path; \`${p.route}\` takes precedence.`,
+      fix: (p: { canFold: boolean }) => `Disambiguate the keys${p.canFold ? ' or set `router.options.sensitive: true`' : ''}.`,
+      docs: false,
+    },
   },
 })

--- a/packages/kit/src/diagnostics/config.ts
+++ b/packages/kit/src/diagnostics/config.ts
@@ -88,5 +88,20 @@ export const configDiagnostics = /* #__PURE__ */ defineDiagnostics({
       fix: 'Loading it natively is faster, as jiti has to transform the file first. Relative imports need an explicit file extension, and `import.meta.dirname` replaces `__dirname`.',
       docs: false,
     },
+    NUXT_B5024: {
+      why: '`vue.vapor` requires vue `3.6.0` or later, so vapor mode has been disabled.',
+      fix: 'Upgrade to vue `3.6.0` or later, or remove `vue.vapor` from your `nuxt.config`.',
+      docs: false,
+    },
+    NUXT_B5025: {
+      why: (p: { entry: string }) => `\`css\` entries are resolved as module ids, not relative to \`nuxt.config\`, so \`${p.entry}\` may not resolve to the intended file.`,
+      fix: (p: { replacement: string }) => `Replace it with ${p.replacement}.`,
+      docs: false,
+    },
+    NUXT_B5026: {
+      why: (p: { entry: string, resolved?: string }) => `\`css\` entry \`${p.entry}\` could not be found${p.resolved ? ` (resolved to \`${p.resolved}\`)` : ''}.`,
+      fix: 'Ensure the file exists, or remove the entry from `css` in your `nuxt.config`.',
+      docs: false,
+    },
   },
 })

--- a/packages/kit/src/diagnostics/pages.ts
+++ b/packages/kit/src/diagnostics/pages.ts
@@ -111,5 +111,10 @@ export const pageDiagnostics = /* #__PURE__ */ defineDiagnostics({
       fix: 'Avoid modifying `routes` in `router.options`, or disable `experimental.early404`.',
       docs: false,
     },
+    NUXT_B4021: {
+      why: (p: { paths: string }) => `\`ssr: false\` and \`noScripts\` both apply to ${p.paths}, which leaves nothing to render the route: the server emits an empty shell and no client bundle is loaded to fill it.`,
+      fix: 'Remove one of the two rules.',
+      docs: false,
+    },
   },
 })

--- a/packages/kit/src/internal/trace.ts
+++ b/packages/kit/src/internal/trace.ts
@@ -24,6 +24,7 @@ const warnings = new Set<string>()
 
 export function warn (warning: string) {
   if (!warnings.has(warning)) {
+    // eslint-disable-next-line no-restricted-syntax -- deduplicating passthrough; callers compose the message
     console.warn(warning)
     warnings.add(warning)
   }

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -10,7 +10,7 @@ import { joinURL, withTrailingSlash } from 'ufo'
 import nuxtPkg from 'nuxt/package.json' with { type: 'json' }
 import { createNitro, writeTypes } from 'nitro/builder'
 import type { Nitro, NitroConfig, NitroRouteRules } from 'nitro/types'
-import { addPlugin, addTemplate, addVitePlugin, createIsIgnored, ensureDependencyInstalled, findPath, getAddDependencyCommand, getDirectory, getLayerDirectories, logger, resolveAlias, resolveIgnorePatterns, resolveNuxtModule } from '@nuxt/kit'
+import { addPlugin, addTemplate, addVitePlugin, createIsIgnored, ensureDependencyInstalled, findPath, getAddDependencyCommand, getDirectory, getLayerDirectories, resolveAlias, resolveIgnorePatterns, resolveNuxtModule } from '@nuxt/kit'
 import { bundlerDiagnostics } from '@nuxt/kit/internal'
 import escapeRE from 'escape-string-regexp'
 import { defu } from 'defu'
@@ -435,7 +435,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
         // Only the matcher that will actually be used at runtime should report collisions.
         if (fold === caseSensitiveRouteRules || warnedKeyCollisions.has(key)) { return }
         warnedKeyCollisions.add(key)
-        logger.warn(`Route rules for \`${existing}\` and \`${route}\` resolve to the same path; \`${route}\` takes precedence. Disambiguate the keys${fold ? ' or set `router.options.sensitive: true`' : ''}.`)
+        bundlerDiagnostics.NUXT_B7022({ existing, route, canFold: fold })
       })
       const compileOptions: NonNullable<Parameters<typeof sourceRouter.compileToString>[0]> = {
         matchAll: true,

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -821,7 +821,7 @@ async function initNuxt (nuxt: Nuxt) {
       addPlugin(resolve(nuxt.options.appDir, 'plugins/vapor-interop.client'))
     } else {
       nuxt.options.vue.vapor = false
-      logger.warn('`vue.vapor` requires vue `3.6.0` or later; vapor mode has been disabled.')
+      configDiagnostics.NUXT_B5024()
     }
   }
 
@@ -1270,7 +1270,7 @@ function warnUnresolvableGlobalCss (nuxt: Nuxt) {
     if (RELATIVE_CSS_ENTRY_RE.test(entry)) {
       const absolute = resolve(nuxt.options.rootDir, entry)
       const asAlias = '~/' + relative(nuxt.options.srcDir, absolute)
-      logger.warn(`\`css\` entries are resolved as module ids, not relative to \`nuxt.config\`. Replace \`${entry}\` with ${existsSync(absolute) ? `\`${link(absolute, { formatter: () => asAlias })}\`` : 'an aliased or absolute path'}.`)
+      configDiagnostics.NUXT_B5025({ entry, replacement: existsSync(absolute) ? `\`${link(absolute, { formatter: () => asAlias })}\`` : 'an aliased or absolute path' })
       continue
     }
 
@@ -1278,7 +1278,7 @@ function warnUnresolvableGlobalCss (nuxt: Nuxt) {
     // be resolved by builder-specific aliases, so neither can be checked here
     const resolved = resolveAlias(entry, nuxt.options.alias)
     if (isAbsolute(resolved) && !resolved.startsWith(nuxt.options.buildDir) && !existsSync(resolved)) {
-      logger.warn(`\`css\` entry \`${entry}\` could not be found${resolved === entry ? '' : ` (resolved to \`${linkToAlias(resolved, nuxt)}\`)`}.`)
+      configDiagnostics.NUXT_B5026({ entry, resolved: resolved === entry ? undefined : linkToAlias(resolved, nuxt) })
     }
   }
 }

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -785,7 +785,7 @@ export default defineNuxtModule({
       })
 
       if (conflicting.length) {
-        logger.warn(`\`ssr: false\` and \`noScripts\` both apply to ${conflicting.map(path => `\`${path}\``).join(', ')}, which leaves nothing to render the route: the server emits an empty shell and no client bundle is loaded to fill it. Remove one of the two rules.`)
+        pageDiagnostics.NUXT_B4021({ paths: conflicting.map(path => `\`${path}\``).join(', ') })
       }
 
       return restrictedPages

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -355,7 +355,7 @@ export default defineResolvers({
         const builder = await get('builder')
         if (builder !== 'vite' && (builder as string) !== '@nuxt/vite-builder') {
           if (val === true) {
-            console.warn('[nuxt] `experimental.nitroViteEnvironment` is only compatible with `@nuxt/vite-builder`. Disabling.')
+            schemaDiagnostics.NUXT_B5027()
           }
           return false
         }

--- a/packages/schema/src/diagnostics.ts
+++ b/packages/schema/src/diagnostics.ts
@@ -44,5 +44,10 @@ export const schemaDiagnostics = /* #__PURE__ */ defineDiagnostics({
       fix: 'Pass whole status codes between 400 and 599, such as `[404, 500]`. `/200.html` and `/index.html` are SPA fallbacks and cannot be generated as error pages.',
       docs: false,
     },
+    NUXT_B5027: {
+      why: '`experimental.nitroViteEnvironment` is only compatible with `@nuxt/vite-builder`, so it has been disabled.',
+      fix: 'Set `builder: "vite"` in your `nuxt.config`, or remove the option.',
+      docs: false,
+    },
   },
 })

--- a/packages/webpack/src/webpack.ts
+++ b/packages/webpack/src/webpack.ts
@@ -389,8 +389,10 @@ async function compile (compiler: Compiler) {
   if (stats.hasErrors()) {
     const formatted = stats.toString({ errors: true, warnings: false, colors: false, errorDetails: true })
     const compilationErrors = stats.compilation?.errors ?? []
+    // eslint-disable-next-line no-restricted-syntax -- raw compiler output; the diagnostic below carries the errors as `cause`
     logger.error(formatted || '(no formatted errors emitted; see compilation errors below)')
     for (const err of compilationErrors) {
+      // eslint-disable-next-line no-restricted-syntax -- raw compiler output; the diagnostic below carries the errors as `cause`
       logger.error(err)
     }
     throw bundlerDiagnostics.NUXT_B7014({ name: compiler.options.name!, cause: compilationErrors })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this tidies up some missing logger/console calls, and creates an eslint rule to keep us using `nostics` rather than falling back into our old ways