### PR TITLE
fix(nitro): keep the payload script when a non-Vue error kills the stream

### DIFF
--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -11,7 +11,7 @@ import { createBootstrapScript, renderSSRHeadSuspenseChunk, renderShell } from '
 import { streamingIifeCode } from '@unhead/vue/stream/iife'
 import type { Link, Script } from '@unhead/vue/types'
 import { getRouteRules, useNitroHooks } from 'nitro/app'
-import { NUXT_ERROR_SIGNATURE, SSR_ERROR_PARAM, decodeSSRError, stringifyErrorData } from '../utils/error'
+import { NUXT_ERROR_SIGNATURE, SSR_ERROR_PARAM, decodeSSRError, stringifyErrorData, toPayloadError } from '../utils/error'
 import type { SSRError } from '../utils/error'
 import { relative } from 'pathe'
 
@@ -887,7 +887,9 @@ async function renderStreamedResponse (ctx: {
         // well-formed closing so HTML parsing doesn't choke.
         await Promise.resolve(ssrContext.nuxt?.hooks.callHook('app:error', error)).catch(() => {})
         ssrContext.payload ||= {} as NuxtPayload
-        ssrContext.payload.error ||= error as any
+        // flatten the error: Vue errors arrive normalised, anything else
+        // would fail payload serialisation and lose the error page
+        ssrContext.payload.error ||= toPayloadError(error, ssrContext.url)
         try {
           if (!NO_SCRIPTS) {
             ssrContext.head.push({

--- a/packages/nitro-server/src/runtime/utils/error.ts
+++ b/packages/nitro-server/src/runtime/utils/error.ts
@@ -85,6 +85,37 @@ export function stringifyErrorData (data: unknown): unknown {
 }
 
 /**
+ * Flatten an error the streaming renderer caught into payload-safe data.
+ *
+ * Errors from outside Vue (a nitro hook, a util) skip the app-side
+ * normalisation that Vue errors get, so a raw `Error` reaches the payload as
+ * a non-POJO and devalue refuses it. Losing that race loses the payload
+ * script, the client's only path to the error page once the shell committed
+ * the status.
+ *
+ * The result mirrors `decodeSSRError` output: a plain object carrying the
+ * nuxt error signature, which the payload reducers leave to ordinary
+ * serialisation.
+ *
+ * @internal
+ */
+export function toPayloadError (error: unknown, url: string): SSRError {
+  const source = (error || {}) as Partial<Error> & { status?: unknown, statusCode?: unknown, statusText?: unknown, statusMessage?: unknown, data?: unknown }
+  const status = Number(source.status ?? source.statusCode)
+  return {
+    [NUXT_ERROR_SIGNATURE]: true,
+    message: source.message || (typeof error === 'string' ? error : String(source.statusText || source.statusMessage || 'Unknown error')),
+    stack: (import.meta.dev && source.stack) || undefined,
+    status: Number.isInteger(status) && status >= 100 && status <= 599 ? status : 500,
+    statusText: typeof source.statusText === 'string' ? source.statusText : undefined,
+    fatal: true,
+    unhandled: true,
+    data: source.data,
+    url,
+  }
+}
+
+/**
  * Nitro internal functions extracted from https://github.com/nitrojs/nitro/blob/v2/src/runtime/internal/utils.ts
  */
 

--- a/test/e2e/ssr-streaming.test.ts
+++ b/test/e2e/ssr-streaming.test.ts
@@ -271,6 +271,29 @@ test.describe('SSR Streaming', () => {
     expect(html.trimEnd()).toMatch(/<\/body><\/html>$/)
   })
 
+  // A failure outside Vue (here a module's `render:html:chunk` hook
+  // throwing) reaches the renderer's catch as a raw Error, without the
+  // app-side normalisation Vue errors get. The payload script is the
+  // client's only path to the error page once the shell committed the
+  // status, so it must survive the error.
+  test('a non-Vue error mid-stream keeps the payload script', async ({ fetch }) => {
+    const res = await fetch('/chunk-error')
+    const html = await res.text()
+
+    expect(res.status).toBe(200)
+    expect(html).toContain('chunk error shell content')
+    expect(html).toMatch(/<script[^>]*id="__NUXT_DATA__"[^>]*>/)
+    expect(html).toContain('chunk hook failure')
+    expect(html.trimEnd()).toMatch(/<\/body><\/html>$/)
+  })
+
+  test('client renders the error page after a non-Vue mid-stream error', async ({ page, goto }) => {
+    await goto('/chunk-error')
+
+    await expect(page.locator('body')).toContainText('chunk hook failure')
+    await expect(page.locator('[data-testid="shell-text"]')).toHaveCount(0)
+  })
+
   test('client renders the error page after a mid-stream error', async ({ page, goto }) => {
     await goto('/error-during')
 

--- a/test/fixtures/ssr-streaming/pages/chunk-error.vue
+++ b/test/fixtures/ssr-streaming/pages/chunk-error.vue
@@ -1,0 +1,23 @@
+<template>
+  <div>
+    <p data-testid="shell-text">
+      chunk error shell content
+    </p>
+    <Suspense>
+      <AsyncBlock
+        name="hook"
+        :delay="120"
+        :progress="100"
+      />
+      <template #fallback>
+        <div data-testid="fallback">
+          loading...
+        </div>
+      </template>
+    </Suspense>
+  </div>
+</template>
+
+<script setup lang="ts">
+useHead({ title: 'Chunk Error' })
+</script>

--- a/test/fixtures/ssr-streaming/server/plugins/chunk-error.ts
+++ b/test/fixtures/ssr-streaming/server/plugins/chunk-error.ts
@@ -1,0 +1,17 @@
+import { definePlugin as defineNitroPlugin } from 'nitro'
+
+// Simulates any non-Vue failure that kills the stream mid-response (here a
+// module's `render:html:chunk` hook throwing). The error reaches the
+// renderer's catch without the app's error normalisation, exercising the
+// raw-error path of the streamed payload. See pages/chunk-error.vue.
+export default defineNitroPlugin((nitro) => {
+  const decoder = new TextDecoder()
+  nitro.hooks.hook('render:html:chunk', (ctx, { event }) => {
+    if (event.url.pathname !== '/chunk-error') { return }
+    // kill on the chunk that proves the boundary resolved, so the shell and
+    // fallback have already flushed
+    if (decoder.decode(ctx.chunk).includes('hook (resolved after')) {
+      throw new Error('chunk hook failure')
+    }
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

found while testing #36120, independent of it

### 📚 Description

When SSR streaming is enabled, an error thrown after the shell has flushed can only reach the client through the payload script: the response status is already committed, so the browser renders the error page during hydration.

Vue errors arrive in the streaming catch already normalised by app-side error handling, so `payload.error` serialises fine. Errors thrown outside Vue (a nitro hook such as `render:html:chunk`, a module util) arrive raw. devalue refuses non-POJOs, so `renderPayloadJsonScript` throws, the closing catch drops the payload script, and the client never learns about the error: it keeps the partial HTML forever.

This flattens the caught error into the plain-object form `decodeSSRError` already produces: a plain object carrying the `__nuxt_error` signature, which the payload reducers deliberately leave to ordinary serialisation (see the `NuxtError` reducer in `revive-payload.server.ts`). Vue-normalised errors keep winning the `||=`, so behaviour there is unchanged.

### 🔎 Under the hood

- `toPayloadError` mirrors the `SSRError` shape: status (validated to [100..599], else 500), statusText, message, dev-only stack, `fatal`/`unhandled`, `data` and the request url.
- e2e: a fixture nitro plugin throws a raw `Error` from `render:html:chunk` once the stream has started; tests assert the payload script survives, carries the message, and the client renders the error page.