### PR TITLE
fix(vite): rewrite every public asset `url()` in CSS

### DIFF
--- a/packages/vite/src/plugins/public-dirs.ts
+++ b/packages/vite/src/plugins/public-dirs.ts
@@ -12,7 +12,20 @@ const PREFIX = '\0virtual:public?'
 const PREFIX_RE = /^\0virtual:public\?/
 const CSS_URL_RE = /url\((\/[^)]+)\)/g
 const CSS_URL_SINGLE_RE = /url\(\/[^)]+\)/
-const RENDER_CHUNK_RE = /(?<= = )['"`]/
+const QUOTE_RE = /['"`]/
+
+/**
+ * Find the quote character of the string literal containing the given index, so that
+ * merged chunks with differently-quoted literals are each handled correctly.
+ */
+function enclosingQuote (code: string, index: number) {
+  for (let i = index - 1; i >= 0; i--) {
+    if (QUOTE_RE.test(code[i]!) && code[i - 1] !== '\\') {
+      return code[i]!
+    }
+  }
+  return '"'
+}
 
 interface VitePublicDirsPluginOptions {
   dev?: boolean
@@ -69,10 +82,12 @@ export const PublicDirsPlugin = (options: VitePublicDirsPluginOptions): Plugin[]
         if (!isInlineStyleId(chunk.facadeModuleId)) { return }
 
         const s = rolldownString(code, chunk.fileName)
-        const q = code.match(RENDER_CHUNK_RE)?.[0] || '"'
-        for (const [full, url] of code.matchAll(CSS_URL_RE)) {
+        for (const match of code.matchAll(CSS_URL_RE)) {
+          const [full, url] = match
           if (url && resolveFromPublicAssets(url)) {
-            s.replace(full, `url(${q} + publicAssetsURL(${q}${url}${q}) + ${q})`)
+            const q = enclosingQuote(code, match.index)
+            // update by index to cover every `url()` in a chunk
+            s.update(match.index, match.index + full.length, `url(${q} + publicAssetsURL(${q}${url}${q}) + ${q})`)
           }
         }
 

--- a/packages/vite/src/plugins/public-dirs.ts
+++ b/packages/vite/src/plugins/public-dirs.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
 import { useNitro } from '@nuxt/kit'
-import { withLeadingSlash, withTrailingSlash } from 'ufo'
+import { joinURL, withLeadingSlash, withTrailingSlash } from 'ufo'
 import { dirname, relative } from 'pathe'
 import { generateTransform, rolldownString } from 'rolldown-string'
 import { isCSSRequest } from 'vite'
@@ -48,7 +48,7 @@ export const PublicDirsPlugin = (options: VitePublicDirsPluginOptions): Plugin[]
         for (const match of code.matchAll(CSS_URL_RE)) {
           const [full, url] = match
           if (url && resolveFromPublicAssets(url)) {
-            s.update(match.index, match.index + full.length, `url(${options.baseURL}${url})`)
+            s.update(match.index, match.index + full.length, `url(${joinURL(options.baseURL!, url)})`)
           }
         }
 

--- a/packages/vite/src/plugins/public-dirs.ts
+++ b/packages/vite/src/plugins/public-dirs.ts
@@ -45,9 +45,10 @@ export const PublicDirsPlugin = (options: VitePublicDirsPluginOptions): Plugin[]
         if (!isCSSRequest(id) || !CSS_URL_SINGLE_RE.test(code)) { return }
 
         const s = rolldownString(code, id, meta)
-        for (const [full, url] of code.matchAll(CSS_URL_RE)) {
+        for (const match of code.matchAll(CSS_URL_RE)) {
+          const [full, url] = match
           if (url && resolveFromPublicAssets(url)) {
-            s.replace(full, `url(${options.baseURL}${url})`)
+            s.update(match.index, match.index + full.length, `url(${options.baseURL}${url})`)
           }
         }
 

--- a/packages/vite/test/public-dirs.test.ts
+++ b/packages/vite/test/public-dirs.test.ts
@@ -26,13 +26,21 @@ afterAll(() => {
 })
 
 describe('PublicDirsPlugin dev transform', () => {
-  const plugin = PublicDirsPlugin({ dev: true, baseURL: '/cdn' })[0]!
-  const transform = typeof plugin.transform === 'function' ? plugin.transform : plugin.transform!.handler
+  function transformCSS (baseURL: string, code: string) {
+    const plugin = PublicDirsPlugin({ dev: true, baseURL })[0]!
+    const transform = typeof plugin.transform === 'function' ? plugin.transform : plugin.transform!.handler
+    return (transform as any).call({}, code, '/styles.css').code.toString()
+  }
+
+  const code = 'a{background:url(/logo.svg)}b{background:url(/icon.svg)}c{background:url(/logo.svg)}'
+  const expected = 'a{background:url(/cdn/logo.svg)}b{background:url(/cdn/icon.svg)}c{background:url(/cdn/logo.svg)}'
 
   it('prefixes every public asset url with the base URL', () => {
-    const code = 'a{background:url(/logo.svg)}b{background:url(/icon.svg)}c{background:url(/logo.svg)}'
-    const result = (transform as any).call({}, code, '/styles.css')
-    expect(result.code.toString()).toBe('a{background:url(/cdn/logo.svg)}b{background:url(/cdn/icon.svg)}c{background:url(/cdn/logo.svg)}')
+    expect(transformCSS('/cdn', code)).toBe(expected)
+  })
+
+  it('does not double up slashes when the base URL has a trailing slash', () => {
+    expect(transformCSS('/cdn/', code)).toBe(expected)
   })
 })
 

--- a/packages/vite/test/public-dirs.test.ts
+++ b/packages/vite/test/public-dirs.test.ts
@@ -18,6 +18,7 @@ const { PublicDirsPlugin } = await import('../src/plugins/public-dirs')
 beforeAll(() => {
   mkdirSync(publicDir, { recursive: true })
   writeFileSync(join(publicDir, 'logo.svg'), '<svg/>')
+  writeFileSync(join(publicDir, 'icon.svg'), '<svg/>')
 })
 
 afterAll(() => {
@@ -44,5 +45,37 @@ describe('PublicDirsPlugin', () => {
     const result = (load as any).call({}, id)
     expect(result).toContain('publicAssetsURL')
     expect(result).toContain(JSON.stringify('/logo.svg'))
+  })
+
+  describe('renderChunk', () => {
+    const renderChunk = typeof plugin.renderChunk === 'function' ? plugin.renderChunk : plugin.renderChunk!.handler
+    const chunk = { fileName: 'chunk.js', facadeModuleId: '/app.vue?inline&used' } as any
+
+    function render (code: string) {
+      const result = (renderChunk as any).call({}, code, chunk, {}, {})
+      return result?.code?.toString() ?? code
+    }
+
+    it('rewrites every public asset url in a chunk', () => {
+      const code = 'const a = "a{background:url(/logo.svg)}b{background:url(/icon.svg)}c{background:url(/logo.svg)}"'
+      const output = render(code)
+      expect(output).not.toMatch(/url\(\//)
+      expect(output.match(/publicAssetsURL\(/g)).toHaveLength(3)
+    })
+
+    it('leaves non-public urls alone', () => {
+      const code = 'const a = "a{background:url(/missing.svg)}"'
+      expect(render(code)).toBe(code)
+    })
+
+    it('uses the quote style of each enclosing string literal', () => {
+      const code = [
+        'const a = "a{background:url(/logo.svg)}"',
+        'const b = \'b{background:url(/icon.svg)}\'',
+      ].join('\n')
+      const output = render(code)
+      expect(output).toContain('"a{background:url(" + publicAssetsURL("/logo.svg") + ")}"')
+      expect(output).toContain('\'b{background:url(\' + publicAssetsURL(\'/icon.svg\') + \')}\'')
+    })
   })
 })

--- a/packages/vite/test/public-dirs.test.ts
+++ b/packages/vite/test/public-dirs.test.ts
@@ -25,6 +25,17 @@ afterAll(() => {
   rmSync(publicDir, { recursive: true, force: true })
 })
 
+describe('PublicDirsPlugin dev transform', () => {
+  const plugin = PublicDirsPlugin({ dev: true, baseURL: '/cdn' })[0]!
+  const transform = typeof plugin.transform === 'function' ? plugin.transform : plugin.transform!.handler
+
+  it('prefixes every public asset url with the base URL', () => {
+    const code = 'a{background:url(/logo.svg)}b{background:url(/icon.svg)}c{background:url(/logo.svg)}'
+    const result = (transform as any).call({}, code, '/styles.css')
+    expect(result.code.toString()).toBe('a{background:url(/cdn/logo.svg)}b{background:url(/cdn/icon.svg)}c{background:url(/cdn/logo.svg)}')
+  })
+})
+
 describe('PublicDirsPlugin', () => {
   const plugins = PublicDirsPlugin({})
   const plugin = plugins[1]!
@@ -45,6 +56,21 @@ describe('PublicDirsPlugin', () => {
     const result = (load as any).call({}, id)
     expect(result).toContain('publicAssetsURL')
     expect(result).toContain(JSON.stringify('/logo.svg'))
+  })
+
+  describe('generateBundle', () => {
+    const generateBundle = typeof plugin.generateBundle === 'function' ? plugin.generateBundle : plugin.generateBundle!.handler
+
+    it('relativises every public asset url in an emitted stylesheet', () => {
+      const bundle = {
+        'assets/styles.css': {
+          type: 'asset',
+          source: 'a{background:url(/logo.svg)}b{background:url(/icon.svg)}c{background:url(/logo.svg)}',
+        },
+      }
+      ;(generateBundle as any).call({}, {}, bundle)
+      expect((bundle['assets/styles.css'] as any).source).toBe('a{background:url(../logo.svg)}b{background:url(../icon.svg)}c{background:url(../logo.svg)}')
+    })
   })
 
   describe('renderChunk', () => {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/fonts/issues/801 

### 📚 Description

this is three separate issues - basically all boiling down to needing to rewrite `url()` strings in more places

