### PR TITLE
perf(vite): warm the server module graph before the client

### DIFF
--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -300,7 +300,7 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
       return server.close()
     })
     await server.environments.ssr.pluginContainer.buildStart({})
-    startClientWarmup(nuxt, server, entry)
+    startWarmup(nuxt, server, entry, serverEntry)
   }, 'Vite dev server built')
   nuxt._perf?.endPhase('vite:dev-server')
 }
@@ -312,7 +312,7 @@ function warmupEntries (nuxt: Nuxt, entry: string) {
   return nuxt.options.vite.warmupEntry === false ? [] : [entry]
 }
 
-function startClientWarmup (nuxt: Nuxt, server: vite.ViteDevServer, entry: string) {
+function startWarmup (nuxt: Nuxt, server: vite.ViteDevServer, entry: string, serverEntry: string) {
   if (nuxt.options.test || nuxt.options.vite.warmupEntry === false) { return }
 
   let stop = false
@@ -333,19 +333,32 @@ function startClientWarmup (nuxt: Nuxt, server: vite.ViteDevServer, entry: strin
 
   nuxt.hook('close', () => { stop = true })
 
-  const run = async () => {
+  // both crawls share one budget so speculative work cannot outlive it twice over
+  let deadline = Number.POSITIVE_INFINITY
+
+  const crawl = async (label: string, environment: vite.DevEnvironment, entries: string[]) => {
     try {
-      const { modules, visited, duration, stopped } = await warmupViteServer(server.environments.client as vite.DevEnvironment, [entry], {
+      const { modules, visited, duration, stopped } = await warmupViteServer(environment, entries, {
         root: server.config.root,
         base: server.config.base,
         maxModules: WARMUP_MAX_MODULES,
-        maxDuration: WARMUP_MAX_DURATION,
+        maxDuration: Math.max(0, deadline - performance.now()),
         shouldStop: () => stop,
         shouldPause: () => inFlight > 0,
       })
-      logger.debug(`Vite client warmed up ${modules} of ${visited} modules in ${Math.round(duration)}ms${stopped ? ' (abandoned)' : ''}`)
+      logger.debug(`Vite ${label} warmed up ${modules} of ${visited} modules in ${Math.round(duration)}ms${stopped ? ' (abandoned)' : ''}`)
     } catch (error) {
-      logger.debug('Vite client warmup failed with:', error)
+      logger.debug(`Vite ${label} warmup failed with:`, error)
+    }
+  }
+
+  const run = async () => {
+    deadline = performance.now() + WARMUP_MAX_DURATION
+    try {
+      // the first visitor waits on the document before the browser asks for any
+      // client module, so the server graph is warmed first
+      await crawl('server', server.environments.ssr as vite.DevEnvironment, [serverEntry])
+      await crawl('client', server.environments.client as vite.DevEnvironment, [entry])
     } finally {
       const index = server.middlewares.stack.indexOf(observer)
       if (index !== -1) {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this speeds up render of the first page by ~1s, regardless of how long you wait after the dev server is ready