### PR TITLE
chore: send test results to Flakiness.io dashboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,7 @@ jobs:
     permissions:
       actions: write
       contents: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -277,12 +278,21 @@ jobs:
 
           - name: Test (nuxt runtime)
             run: vp run test:runtime
+            env:
+              FLAKINESS_OUTPUT_DIR: flakiness-report/runtime
+              FLAKINESS_TITLE: Nuxt runtime
 
           - name: Test (unit)
             run: vp run test:unit
+            env:
+              FLAKINESS_OUTPUT_DIR: flakiness-report/unit
+              FLAKINESS_TITLE: Unit
 
           - name: Test (no jiti)
             run: vp run test:no-jiti
+            env:
+              FLAKINESS_OUTPUT_DIR: flakiness-report/no-jiti
+              FLAKINESS_TITLE: No jiti
 
       - name: Cancel workflow on failure
         if: failure() && github.event_name == 'merge_group'
@@ -334,6 +344,7 @@ jobs:
     permissions:
       actions: write
       contents: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -385,6 +396,7 @@ jobs:
     permissions:
       actions: write
       contents: read
+      id-token: write
 
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
@@ -450,6 +462,7 @@ jobs:
     permissions:
       actions: write
       contents: read
+      id-token: write
 
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}

--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ playwright-report
 temp
 
 packages/ui-templates/node-compile-cache/
+flakiness-report/

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "@codspeed/core": "catalog:dev",
     "@codspeed/vitest-plugin": "catalog:dev",
     "@eslint/markdown": "catalog:dev",
+    "@flakiness/playwright": "catalog:dev",
+    "@flakiness/vitest": "catalog:dev",
     "@nuxt/cli": "catalog:build",
     "@nuxt/eslint-config": "catalog:dev",
     "@nuxt/kit": "workspace:*",

--- a/packages/nuxt/test/auto-imports.test.ts
+++ b/packages/nuxt/test/auto-imports.test.ts
@@ -232,12 +232,12 @@ describe('imports:nuxt/scripts', async () => {
     'useScriptGoogleTagManager',
     'useScriptGoogleAnalytics',
   ])
-  it.each(scriptsStubsPreset.imports)(`should register %s from @nuxt/scripts`, (name) => {
+  it.each(scriptsStubsPreset.imports)(`stubbed %s should exist in the @nuxt/scripts registry`, (name) => {
     if (globalScripts.has(name)) { return }
 
     expect(scripts).toContain(name)
   })
-  it.each(scripts)(`should register %s from @nuxt/scripts`, (name) => {
+  it.each(scripts)(`%s from the @nuxt/scripts registry should be stubbed`, (name) => {
     expect(scriptsStubsPreset.imports).toContain(name)
   })
 })

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -1344,6 +1344,7 @@ definePageMeta({
   describe('strip extracted metadata', () => {
     it.each([
       {
+        description: 'when it is the last key, with a trailing comma and an inline closing brace',
         input: `
 <script setup>
 definePageMeta({
@@ -1353,6 +1354,7 @@ definePageMeta({
       `,
       },
       {
+        description: 'when it is the first key and another key follows on the same line',
         input: `
 <script setup>
 definePageMeta({
@@ -1361,6 +1363,7 @@ definePageMeta({
       `,
       },
       {
+        description: 'when it is the only key, with a trailing comma',
         input: `
 <script setup>
 definePageMeta({
@@ -1370,6 +1373,7 @@ definePageMeta({
       `,
       },
       {
+        description: 'when it is the only key, without a trailing comma',
         input: `
 <script setup>
 definePageMeta({
@@ -1378,7 +1382,7 @@ definePageMeta({
 </script>
       `,
       },
-    ])(`should strip extracted metadata from the script block`, ({ input }) => {
+    ])(`should strip extracted metadata from the script block $description`, ({ input }) => {
       const res = compileScript(parse(input).descriptor, { id: 'component.vue' })
       const result = transformPlugin.transform.handler(res.content, 'component.vue?macro=true')?.code
       expect.soft(result).not.contain('extracted')

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -328,17 +328,17 @@ describe('pages:generateRouteKey', () => {
     output?: string | false
     it?: TestAPI
   }> = [
-    { description: 'should handle overrides', override: 'key', route: getRouteProps(), output: 'key' },
-    { description: 'should handle overrides', override: route => route.meta.key as string, route: getRouteProps(), output: 'route-meta-key' },
+    { description: 'should use a string override as the key', override: 'key', route: getRouteProps(), output: 'key' },
+    { description: 'should use the result of a function override as the key', override: route => route.meta.key as string, route: getRouteProps(), output: 'route-meta-key' },
     {
-      description: 'should handle overrides',
+      description: 'should return `false` for a `false` override',
       // @ts-expect-error testing behaviour with invalid prop
       override: false,
       route: getRouteProps(),
       output: false,
     },
     {
-      description: 'should key dynamic routes without keys',
+      description: 'should key an unkeyed dynamic route by its param value',
       route: getRouteProps({
         path: '/test/:id',
         meta: {},
@@ -346,7 +346,7 @@ describe('pages:generateRouteKey', () => {
       output: '/test/foo',
     },
     {
-      description: 'should key dynamic routes without keys',
+      description: 'should key an unkeyed dynamic route with a custom matcher by its param value',
       route: getRouteProps({
         path: '/test/:id(\\d+)',
         meta: {},
@@ -354,7 +354,7 @@ describe('pages:generateRouteKey', () => {
       output: '/test/foo',
     },
     {
-      description: 'should key dynamic routes with optional params',
+      description: 'should key an optional param by its value',
       route: getRouteProps({
         path: '/test/:optional?',
         meta: {},
@@ -362,7 +362,7 @@ describe('pages:generateRouteKey', () => {
       output: '/test/bar',
     },
     {
-      description: 'should key dynamic routes with optional params',
+      description: 'should key an optional param with a custom matcher by its value',
       route: getRouteProps({
         path: '/test/:optional(\\d+)?',
         meta: {},
@@ -370,7 +370,7 @@ describe('pages:generateRouteKey', () => {
       output: '/test/bar',
     },
     {
-      description: 'should key dynamic routes with optional params',
+      description: 'should key an unmatched optional param as an empty segment',
       route: getRouteProps({
         path: '/test/:undefined(\\d+)?',
         meta: {},
@@ -378,7 +378,7 @@ describe('pages:generateRouteKey', () => {
       output: '/test/',
     },
     {
-      description: 'should key dynamic routes with array params',
+      description: 'should join the values of a one-or-more repeatable param',
       route: getRouteProps({
         path: '/:array+',
         meta: {},
@@ -386,7 +386,7 @@ describe('pages:generateRouteKey', () => {
       output: '/a,b',
     },
     {
-      description: 'should key dynamic routes with array params',
+      description: 'should join the values of a zero-or-more repeatable param',
       route: getRouteProps({
         path: '/test/:array*',
         meta: {},
@@ -394,7 +394,7 @@ describe('pages:generateRouteKey', () => {
       output: '/test/a,b',
     },
     {
-      description: 'should key dynamic routes with array params',
+      description: 'should key an unmatched zero-or-more repeatable param as an empty segment',
       route: getRouteProps({
         path: '/test/:other*',
         meta: {},

--- a/packages/nuxt/test/plugin-metadata.test.ts
+++ b/packages/nuxt/test/plugin-metadata.test.ts
@@ -11,7 +11,7 @@ describe('plugin-metadata', () => {
     setup: () => { return { provide: { jsx: '[JSX]' } } },
     order: 1,
   })
-  it.each(properties)('should extract metadata from object-syntax plugins', (k, value) => {
+  it.each(properties)('should extract metadata from object-syntax plugins when `%s` is declared last', (k, value) => {
     const obj = [...properties.filter(([key]) => key !== k), [k, value]]
 
     const meta = extractMetadata([

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,3 +1,4 @@
+import process from 'node:process'
 import { defineConfig, devices } from '@playwright/test'
 import type { ConfigOptions } from '@nuxt/test-utils/playwright'
 import { isCI, isWindows } from 'std-env'
@@ -58,7 +59,10 @@ export default defineConfig<E2eConfigOptions>({
   forbidOnly: !!isCI,
   retries: isCI ? 2 : 0,
   workers: isCI ? 1 : undefined,
-  reporter: 'html',
+  reporter: [
+    ['html'],
+    ['@flakiness/playwright', { flakinessProject: 'nuxt/nuxt' }],
+  ],
   projects: [
     {
       name: 'setup fixtures',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,3 @@
-import process from 'node:process'
 import { defineConfig, devices } from '@playwright/test'
 import type { ConfigOptions } from '@nuxt/test-utils/playwright'
 import { isCI, isWindows } from 'std-env'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,6 +281,12 @@ catalogs:
     '@eslint/markdown':
       specifier: 8.0.3
       version: 8.0.3
+    '@flakiness/playwright':
+      specifier: 2.0.2
+      version: 2.0.2
+    '@flakiness/vitest':
+      specifier: 1.9.1
+      version: 1.9.1
     '@nuxt/eslint-config':
       specifier: 1.17.0
       version: 1.17.0
@@ -608,6 +614,12 @@ importers:
       '@eslint/markdown':
         specifier: catalog:dev
         version: 8.0.3(supports-color@10.2.2)
+      '@flakiness/playwright':
+        specifier: catalog:dev
+        version: 2.0.2
+      '@flakiness/vitest':
+        specifier: catalog:dev
+        version: 1.9.1
       '@nuxt/cli':
         specifier: catalog:build
         version: '@nuxt/cli-nightly@4.0.0-20260817-085717-0bb4e52(@nuxt/schema@packages+schema)(cac@7.0.0)(commander@15.0.0)(jiti@2.7.0)(oxc-parser@0.144.0)(rolldown@1.2.4)'
@@ -2739,6 +2751,15 @@ packages:
   '@eslint/plugin-kit@0.7.2':
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@flakiness/playwright@2.0.2':
+    resolution: {integrity: sha512-HYcItgyZQ10UwpCPdePZgxK6gP0ow26oQfqrH4vAJtmXrmsB9NP3yfY7D/5X0DkKAlR86QWX94Ql2nIsO5V+xQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  '@flakiness/vitest@1.9.1':
+    resolution: {integrity: sha512-BQBekpxKD8Be58M+mPmtvh4FGDBJzStzPBJWW2+QDC6ax2ZqKxRTE2O/wHjeZERyOs5Et9mgaXjL51AY1NSoVg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   '@floating-ui/core@1.8.0':
     resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
@@ -11025,6 +11046,10 @@ snapshots:
     dependencies:
       '@eslint/core': 1.2.1
       levn: 0.4.1
+
+  '@flakiness/playwright@2.0.2': {}
+
+  '@flakiness/vitest@1.9.1': {}
 
   '@floating-ui/core@1.8.0':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -216,6 +216,8 @@ catalogs:
     '@codspeed/core': 5.7.1
     '@codspeed/vitest-plugin': 5.7.1
     '@eslint/markdown': 8.0.3
+    '@flakiness/playwright': 2.0.2
+    '@flakiness/vitest': 1.9.1
     '@nuxt/eslint-config': 1.17.0
     '@nuxt/scripts': 1.3.6
     '@nuxt/test-utils': 4.1.0

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import process from 'node:process'
 import { resolve } from 'pathe'
 import { defineVitestProject as _defineVitestProject } from '@nuxt/test-utils/config'
 import { configDefaults, coverageConfigDefaults, defaultExclude, defineConfig } from 'vitest/config'
-import { isCI, isWindows } from 'std-env'
+import { isCI, isWindows, provider } from 'std-env'
 import { getV8Flags } from '@codspeed/core'
 import codspeedPlugin from '@codspeed/vitest-plugin'
 import type { NuxtConfig } from 'nuxt/schema'
@@ -110,12 +110,14 @@ const fixtureExclude = [...configDefaults.exclude, 'test/e2e/**', 'e2e/**', 'nux
 
 export default defineConfig({
   test: {
-    includeTaskLocation: true,
+    // required for the flakiness.io reporter to record test locations
+    includeTaskLocation: isCI,
     onConsoleLog (log) {
       if (log.includes('<Suspense> is an experimental feature')) { return false }
     },
     reporters: [
       'default',
+      ...provider === 'github_actions' ? ['github-actions' as const] : [],
       ['@flakiness/vitest', { flakinessProject: 'nuxt/nuxt' }],
     ],
     coverage: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -116,7 +116,7 @@ export default defineConfig({
     },
     reporters: [
       'default',
-      ['@flakiness/vitest', { flakinessProject: 'nuxt/nuxt' }]
+      ['@flakiness/vitest', { flakinessProject: 'nuxt/nuxt' }],
     ],
     coverage: {
       exclude: [...coverageConfigDefaults.exclude, 'playground', '**/test/', 'scripts'],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -110,9 +110,14 @@ const fixtureExclude = [...configDefaults.exclude, 'test/e2e/**', 'e2e/**', 'nux
 
 export default defineConfig({
   test: {
+    includeTaskLocation: true,
     onConsoleLog (log) {
       if (log.includes('<Suspense> is an experimental feature')) { return false }
     },
+    reporters: [
+      'default',
+      ['@flakiness/vitest', { flakinessProject: 'nuxt/nuxt' }]
+    ],
     coverage: {
       exclude: [...coverageConfigDefaults.exclude, 'playground', '**/test/', 'scripts'],
     },


### PR DESCRIPTION
This starts sending the test results to the https://flakiness.io/nuxt/nuxt project.

A few comments:
- The `id-token: write` is needed for Github OIDC to work: https://docs.flakiness.io/ci/github-actions-setup/
- The `FLAKINESS_OUTPUT_DIR` customization is to make sure that parallel jobs don't fight writing to the same location
- A few vitest tests had duplicate names. This patch also changes these so that the dashboard can build separate histories for them.
