### PR TITLE
feat(kit): add `useTerminal` for host-aware prompts and tasks

### DIFF
--- a/docs/4.api/5.kit/14.logging.md
+++ b/docs/4.api/5.kit/14.logging.md
@@ -73,6 +73,8 @@ export default defineNuxtModule({
     }
 
     const task = terminal.startTask('Installing `my-module`...')
+    // run your actual task
+    await runPackageInstall('my-module')
     task.stop('Installed `my-module`')
   },
 })

--- a/docs/4.api/5.kit/14.logging.md
+++ b/docs/4.api/5.kit/14.logging.md
@@ -61,6 +61,8 @@ Returns a set of primitives for interacting with the user's terminal. When Nuxt 
 ### Usage
 
 ```ts twoslash
+declare function runPackageInstall (name: string): Promise<void>
+// ---cut---
 import { defineNuxtModule, useTerminal } from '@nuxt/kit'
 
 export default defineNuxtModule({

--- a/docs/4.api/5.kit/14.logging.md
+++ b/docs/4.api/5.kit/14.logging.md
@@ -53,3 +53,53 @@ export default defineNuxtModule({
   },
 })
 ```
+
+## `useTerminal`
+
+Returns a set of primitives for interacting with the user's terminal. When Nuxt is running inside an interactive host such as the `nuxt dev` terminal UI, prompts, tasks and notifications are handed to it, so they are answerable and rendered in one place. Otherwise they fall back to logging.
+
+### Usage
+
+```ts twoslash
+import { defineNuxtModule, useTerminal } from '@nuxt/kit'
+
+export default defineNuxtModule({
+  async setup () {
+    const terminal = useTerminal()
+
+    const install = await terminal.prompt('Do you want to install `my-module`?', { type: 'confirm' })
+    if (!install) {
+      return
+    }
+
+    const task = terminal.startTask('Installing `my-module`...')
+    task.stop('Installed `my-module`')
+  },
+})
+```
+
+### Type
+
+```ts
+function useTerminal (): NuxtTerminal
+
+interface NuxtTerminal {
+  readonly interactive: boolean
+  withTerminal: <T>(work: () => Promise<T>) => Promise<T>
+  prompt: (message: string, options?: NuxtPromptOptions) => Promise<any>
+  startTask: (label: string) => NuxtTerminalTask
+  notify: (notification: NuxtTerminalNotification) => NuxtTerminalNotice
+}
+```
+
+### Properties
+
+**`interactive`**: Whether an interactive host is present. When `false`, the primitives below log to the current process streams instead.
+
+**`withTerminal`**: Borrows the terminal for the duration of `work`, suspending any host UI and releasing `stdin`. Use it when you need to write to the terminal or read from `stdin` directly. Concurrent callers are serialised, and a nested call from within a borrow runs immediately.
+
+**`prompt`**: Asks the user a question, borrowing the terminal for as long as the prompt is open. Takes the same options as `logger.prompt`.
+
+**`startTask`**: Starts a long-running task, rendered on the host's status surface where available. Finish it with `task.stop(message?, outcome?)`, or change its label with `task.update(label)`.
+
+**`notify`**: Shows a message and holds it on screen until the user acknowledges it or `notice.dismiss()` is called. `notice.dismissed` settles once the notice is gone.

--- a/packages/kit/src/dependency.ts
+++ b/packages/kit/src/dependency.ts
@@ -2,7 +2,7 @@ import process from 'node:process'
 import { addDependency, addDependencyCommand, detectPackageManager } from 'nypm'
 import { resolveModulePath } from 'exsolve'
 import { hasTTY, isCI, provider } from 'std-env'
-import { logger } from './logger.ts'
+import { useTerminal } from './terminal.ts'
 import { tryUseNuxt } from './context.ts'
 import { buildDiagnostics } from './diagnostics/build.ts'
 import { configDiagnostics } from './diagnostics/config.ts'
@@ -59,12 +59,14 @@ export async function ensureDependencyInstalled (names: string | string[], optio
     return Array.isArray(names) ? missing : false
   }
 
+  const terminal = useTerminal()
+
   if (options.prompt === true || (options.prompt !== false && !isStackblitz)) {
-    if (!hasTTY) {
+    if (!hasTTY && !terminal.interactive) {
       return Array.isArray(names) ? missing : false
     }
 
-    const shouldInstall = await logger.prompt(`Do you want to install ${formattedNames}?`, {
+    const shouldInstall = await terminal.prompt(`Do you want to install ${formattedNames}?`, {
       type: 'confirm',
       initial: true,
     })
@@ -77,16 +79,17 @@ export async function ensureDependencyInstalled (names: string | string[], optio
     return Array.isArray(names) ? missing : false
   }
 
-  logger.start(`Installing ${formattedNames}...`)
+  const task = terminal.startTask(`Installing ${formattedNames}...`)
   try {
     await addDependency(missing, {
       dev: true,
       cwd: rootDir,
       silent: true,
     })
-    logger.success(`Installed ${formattedNames}`)
+    task.stop(`Installed ${formattedNames}`)
     return true
   } catch (err) {
+    task.stop(undefined, 'failure')
     buildDiagnostics.NUXT_B1004({ installCommand: await getAddDependencyCommand(missing, rootDir, { dev: true }), cause: err })
     return Array.isArray(names) ? missing : false
   }

--- a/packages/kit/src/index.ts
+++ b/packages/kit/src/index.ts
@@ -58,6 +58,8 @@ export type { ResolveTypePathsOptions } from './types.ts'
 export { recoverThrottledChanges } from './watch.ts'
 export type { RecoverableWatcher } from './watch.ts'
 export { logger, useLogger } from './logger.ts'
+export { useTerminal } from './terminal.ts'
+export type { NuxtTerminal, NuxtTerminalNotice, NuxtTerminalNotification, NuxtTerminalTask } from './terminal.ts'
 export type { NuxtLogFn, NuxtLogInput, NuxtLogLevel, NuxtLogObject, NuxtLogReporter, NuxtLogType, NuxtLogger, NuxtLoggerOptions, NuxtPromptOptions } from './logger.ts'
 
 // Dependencies

--- a/packages/kit/src/internal/terminal-host.ts
+++ b/packages/kit/src/internal/terminal-host.ts
@@ -1,0 +1,38 @@
+export interface TerminalHostTask {
+  update: (label: string) => void
+  stop: (message?: string, outcome?: 'success' | 'failure') => void
+}
+
+export interface TerminalHostNotification {
+  title?: string
+  message: string
+  level?: 'info' | 'warn'
+}
+
+export interface TerminalHostNotice {
+  dismiss: () => void
+  dismissed: Promise<void>
+}
+
+export interface TerminalHost {
+  version: 1
+  withTerminal: <T>(work: () => Promise<T>) => Promise<T>
+  startTask: (label: string) => TerminalHostTask
+  notify?: (notification: TerminalHostNotification) => TerminalHostNotice
+}
+
+const TERMINAL_HOST_KEY = Symbol.for('nuxt:terminal-host')
+
+/**
+ * Look up the terminal host published by the running CLI, if any.
+ *
+ * The contract is passed on `globalThis` rather than through an import because a single
+ * process routinely contains several copies of `@nuxt/kit` and `@nuxt/cli`.
+ */
+export function useTerminalHost (): TerminalHost | undefined {
+  const host = (globalThis as Record<symbol, unknown>)[TERMINAL_HOST_KEY] as TerminalHost | undefined
+  if (!host || host.version !== 1 || typeof host.withTerminal !== 'function' || typeof host.startTask !== 'function') {
+    return undefined
+  }
+  return host
+}

--- a/packages/kit/src/terminal.test.ts
+++ b/packages/kit/src/terminal.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { logger } from './logger.ts'
+import { useTerminal } from './terminal.ts'
+import type { TerminalHost } from './internal/terminal-host.ts'
+
+const key = Symbol.for('nuxt:terminal-host')
+
+function registerHost (host: Partial<TerminalHost> = {}) {
+  const registered: TerminalHost = {
+    version: 1,
+    withTerminal: work => work(),
+    startTask: () => ({ update: () => {}, stop: () => {} }),
+    ...host,
+  }
+  ;(globalThis as Record<symbol, unknown>)[key] = registered
+  return registered
+}
+
+afterEach(() => {
+  delete (globalThis as Record<symbol, unknown>)[key]
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+})
+
+describe('useTerminal', () => {
+  it('should run work directly when no host is present', async () => {
+    const work = vi.fn().mockResolvedValue('done')
+    await expect(useTerminal().withTerminal(work)).resolves.toBe('done')
+    expect(work).toHaveBeenCalledOnce()
+    expect(useTerminal().interactive).toBe(false)
+  })
+
+  it('should ignore a host with an incompatible version', () => {
+    registerHost({ version: 2 as unknown as 1, withTerminal: vi.fn() })
+    expect(useTerminal().interactive).toBe(false)
+  })
+
+  it('should borrow the terminal from a registered host', async () => {
+    const borrows: number[] = []
+    const withTerminal: TerminalHost['withTerminal'] = (work) => {
+      borrows.push(1)
+      return work()
+    }
+    registerHost({ withTerminal })
+
+    await expect(useTerminal().withTerminal(() => Promise.resolve('done'))).resolves.toBe('done')
+    expect(borrows).toHaveLength(1)
+    expect(useTerminal().interactive).toBe(true)
+  })
+
+  it('should leave nested borrows to the host, which re-enters them', async () => {
+    const borrows: number[] = []
+    const withTerminal: TerminalHost['withTerminal'] = (work) => {
+      borrows.push(1)
+      return work()
+    }
+    registerHost({ withTerminal })
+
+    const terminal = useTerminal()
+    await expect(terminal.withTerminal(() => terminal.withTerminal(() => Promise.resolve('done')))).resolves.toBe('done')
+
+    expect(borrows).toHaveLength(2)
+  })
+
+  describe('prompt', () => {
+    it('should fall back to the logger prompt', async () => {
+      const prompt = vi.spyOn(logger, 'prompt').mockResolvedValue(true)
+
+      await expect(useTerminal().prompt('ok?', { type: 'confirm' })).resolves.toBe(true)
+      expect(prompt).toHaveBeenCalledWith('ok?', { type: 'confirm' })
+    })
+
+    it('should prompt within a borrowed terminal', async () => {
+      const order: string[] = []
+      registerHost({
+        withTerminal: async (work) => {
+          order.push('borrow')
+          const result = await work()
+          order.push('release')
+          return result
+        },
+      })
+      vi.spyOn(logger, 'prompt').mockImplementation(() => { order.push('prompt'); return Promise.resolve(true) })
+
+      await useTerminal().prompt('ok?', { type: 'confirm' })
+      expect(order).toEqual(['borrow', 'prompt', 'release'])
+    })
+
+    it('should route a replaced prompt implementation through the host', async () => {
+      const borrows: number[] = []
+      const withTerminal: TerminalHost['withTerminal'] = (work) => {
+        borrows.push(1)
+        return work()
+      }
+      registerHost({ withTerminal })
+      const replaced = vi.fn().mockResolvedValue(true)
+      const original = logger.options.prompt
+      logger.options.prompt = replaced
+
+      try {
+        await expect(useTerminal().prompt('ok?', { type: 'confirm' })).resolves.toBe(true)
+        expect(replaced).toHaveBeenCalledOnce()
+        expect(borrows).toHaveLength(1)
+      } finally {
+        logger.options.prompt = original
+      }
+    })
+  })
+
+  describe('startTask', () => {
+    it('should log task progress when no host is present', () => {
+      const start = vi.spyOn(logger, 'start').mockImplementation(() => {})
+      const success = vi.spyOn(logger, 'success').mockImplementation(() => {})
+      const fail = vi.spyOn(logger, 'fail').mockImplementation(() => {})
+
+      const task = useTerminal().startTask('installing')
+      task.update('still installing')
+      task.stop('installed')
+      task.stop('installed again')
+
+      expect(start.mock.calls.flat()).toEqual(['installing', 'still installing'])
+      expect(success).toHaveBeenCalledExactlyOnceWith('installed')
+      expect(fail).not.toHaveBeenCalled()
+    })
+
+    it('should log a failed task when no host is present', () => {
+      vi.spyOn(logger, 'start').mockImplementation(() => {})
+      const fail = vi.spyOn(logger, 'fail').mockImplementation(() => {})
+
+      useTerminal().startTask('installing').stop('nope', 'failure')
+
+      expect(fail).toHaveBeenCalledExactlyOnceWith('nope')
+    })
+
+    it('should delegate to the host', () => {
+      const task = { update: vi.fn(), stop: vi.fn() }
+      registerHost({ startTask: vi.fn(() => task) })
+      const start = vi.spyOn(logger, 'start').mockImplementation(() => {})
+
+      useTerminal().startTask('installing').stop('installed')
+
+      expect(task.stop).toHaveBeenCalledWith('installed')
+      expect(start).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('notify', () => {
+    it('should box the notification when no host is present', async () => {
+      const box = vi.spyOn(logger, 'box').mockImplementation(() => {})
+
+      const notice = useTerminal().notify({ title: 'Auth', message: 'code: 1234' })
+      notice.dismiss()
+
+      expect(box).toHaveBeenCalledExactlyOnceWith('Auth\n\ncode: 1234')
+      await expect(notice.dismissed).resolves.toBeUndefined()
+    })
+
+    it('should fall back when the host does not implement notify', () => {
+      registerHost()
+      const box = vi.spyOn(logger, 'box').mockImplementation(() => {})
+
+      useTerminal().notify({ message: 'code: 1234' })
+
+      expect(box).toHaveBeenCalledExactlyOnceWith('code: 1234')
+    })
+
+    it('should delegate to the host when notify is implemented', () => {
+      const notice = { dismiss: vi.fn(), dismissed: Promise.resolve() }
+      const notify = vi.fn(() => notice)
+      registerHost({ notify })
+      const box = vi.spyOn(logger, 'box').mockImplementation(() => {})
+
+      expect(useTerminal().notify({ message: 'code: 1234', level: 'warn' })).toBe(notice)
+      expect(notify).toHaveBeenCalledWith({ message: 'code: 1234', level: 'warn' })
+      expect(box).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/kit/src/terminal.ts
+++ b/packages/kit/src/terminal.ts
@@ -1,0 +1,99 @@
+import { logger } from './logger.ts'
+import type { NuxtPromptOptions } from './logger.ts'
+import { useTerminalHost } from './internal/terminal-host.ts'
+
+/** A unit of long-running work, rendered on the host's status surface where available. */
+export interface NuxtTerminalTask {
+  /** Change the label of the running task. */
+  update: (label: string) => void
+  /** Finish the task, optionally with a closing message. Defaults to a successful outcome. */
+  stop: (message?: string, outcome?: 'success' | 'failure') => void
+}
+
+export interface NuxtTerminalNotification {
+  title?: string
+  message: string
+  level?: 'info' | 'warn'
+}
+
+export interface NuxtTerminalNotice {
+  /** Retract the notice. */
+  dismiss: () => void
+  /** Settles once the notice is gone: acknowledged by the user or retracted. */
+  dismissed: Promise<void>
+}
+
+export interface NuxtTerminal {
+  /**
+   * Whether an interactive host (such as the `nuxt dev` TUI) is present. `false` means the
+   * primitives below fall back to plain logging on the current process streams.
+   */
+  readonly interactive: boolean
+  /**
+   * Borrow the terminal for the duration of `work`: any host UI is suspended and stdin is
+   * released, so `work` may read from stdin and write directly to the terminal.
+   *
+   * Concurrent callers are serialised by the host; a nested call from within a borrow runs
+   * immediately.
+   */
+  withTerminal: <T>(work: () => Promise<T>) => Promise<T>
+  /** Ask the user a question, taking over the terminal for as long as the prompt is open. */
+  prompt: (message: string, options?: NuxtPromptOptions) => Promise<any>
+  /** Start a task, to be finished with `task.stop()`. */
+  startTask: (label: string) => NuxtTerminalTask
+  /** Show a message and hold it on screen until it is acknowledged or retracted. */
+  notify: (notification: NuxtTerminalNotification) => NuxtTerminalNotice
+}
+
+/**
+ * Access the terminal, cooperating with the host UI (such as the `nuxt dev` TUI) when one is
+ * running, and falling back to logging when it is not.
+ *
+ * Use this instead of writing to `process.stdout` or prompting directly, so that prompts are
+ * answerable, tasks are rendered in one place, and nothing is lost to a captured stream.
+ */
+export function useTerminal (): NuxtTerminal {
+  const host = useTerminalHost()
+
+  return {
+    interactive: !!host,
+
+    withTerminal: work => host ? host.withTerminal(work) : work(),
+
+    prompt: (message, options) => host
+      ? host.withTerminal(() => logger.prompt(message, options))
+      : logger.prompt(message, options),
+
+    startTask (label) {
+      if (host) {
+        return host.startTask(label)
+      }
+      logger.start(label)
+      let stopped = false
+      return {
+        update (label) {
+          if (!stopped) {
+            logger.start(label)
+          }
+        },
+        stop (message, outcome) {
+          if (stopped) {
+            return
+          }
+          stopped = true
+          if (message) {
+            logger[outcome === 'failure' ? 'fail' : 'success'](message)
+          }
+        },
+      }
+    },
+
+    notify (notification) {
+      if (host?.notify) {
+        return host.notify(notification)
+      }
+      logger.box([notification.title, notification.message].filter(Boolean).join('\n\n'))
+      return { dismiss: () => {}, dismissed: Promise.resolve() }
+    },
+  }
+}

--- a/packages/nuxt/src/core/features.ts
+++ b/packages/nuxt/src/core/features.ts
@@ -1,8 +1,7 @@
 import { resolvePackageJSON } from 'pkg-types'
-import { getAddDependencyCommand, useNuxt } from '@nuxt/kit'
+import { getAddDependencyCommand, useNuxt, useTerminal } from '@nuxt/kit'
 import { buildDiagnostics, configDiagnostics } from '@nuxt/kit/internal'
 import { isCI, provider } from 'std-env'
-import { logger } from '../utils.ts'
 
 const installPrompts = new Set<string>()
 
@@ -26,8 +25,10 @@ export async function installNuxtModule (name: string, options?: { rootDir?: str
     return false
   }
 
+  const terminal = useTerminal()
+
   if (options?.prompt === true || (options?.prompt !== false && provider !== 'stackblitz')) {
-    const confirm = await logger.prompt(`Do you want to install ${name} package?`, {
+    const confirm = await terminal.prompt(`Do you want to install ${name} package?`, {
       type: 'confirm',
       name: 'confirm',
       initial: true,
@@ -38,13 +39,14 @@ export async function installNuxtModule (name: string, options?: { rootDir?: str
     }
   }
 
-  logger.info(`Installing ${name}...`)
+  const task = terminal.startTask(`Installing ${name}...`)
   try {
     const { runCommand } = await import('@nuxt/cli')
     await runCommand('module', ['add', name, '--cwd', rootDir])
-    logger.success(`Installed ${name}`)
+    task.stop(`Installed ${name}`)
     return true
   } catch (err) {
+    task.stop(undefined, 'failure')
     buildDiagnostics.NUXT_B1004({ installCommand: await getAddDependencyCommand(name, rootDir), cause: err })
     return false
   }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this follows up on https://github.com/nuxt/cli/pull/1488 to expose the terminal host to modules for surfacing prompts, status messages, notifications and tasks-in-progress