### PR TITLE
feat(nuxt): serve unmatched public asset paths on client-side navigation

### DIFF
--- a/docs/3.guide/6.going-further/1.experimental-features.md
+++ b/docs/3.guide/6.going-further/1.experimental-features.md
@@ -253,6 +253,36 @@ export default defineNuxtConfig({
 })
 ```
 
+## serverPathFallback
+
+Hands a client-side navigation that matches no page route back to the browser when the path is one the server answers itself: a static file (anything in `public/`, or another `nitro.publicAssets` directory) or a `GET` server route in `server/routes/**` or `server/api/**`. Any other path renders the 404 error page as before, without a request.
+
+This makes `<NuxtLink to="/brochure.pdf">` and `<NuxtLink to="/rss.xml">` behave on click the way they behave on a hard load.
+
+Those paths are compiled into a Bloom filter at build time and shipped to the client (around 9.6 bits per path, so about 1 kB gzipped for a site with 500 of them). The filter answers whether a path is a member, and nothing can be read back out of it. Its false positives cost a single document load, which ends on the error page. In development there is no filter, so an unmatched path is checked against the dev server with a request whose response body is discarded.
+
+A server route with a parameter or a wildcard (`server/routes/og/[slug].ts`) goes into a second, separate filter, as its *shape*: the parameter is replaced by a placeholder, and a lookup tests every shape the path being navigated to could have. So `/og/hello` matches without `/og/[slug]` ever being described to the client. That filter is tested many times per lookup, so it carries more bits per entry (24), which is affordable because an app has far fewer parameterised routes than files. An app with none ships neither the filter nor the shape lookup. Paths more than eight segments deep are only tested against their wildcard prefixes, to bound the work.
+
+::note
+Routes for other methods (`server/routes/submit.post.ts`) are excluded, since a navigation is a `GET`, as is a root-level catch-all handler (`/**`), which covers every path and so would make every unmatched navigation load a document.
+::
+
+::note
+Files written into a public asset directory during the build itself, after the client bundle is generated, are not in the filter, so navigating to them on the client renders the error page. A hard load still serves them.
+::
+
+This flag is enabled when `future.compatibilityVersion` is set to `5` or higher, but you can also enable it explicitly:
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  experimental: {
+    serverPathFallback: true,
+  },
+})
+```
+
+The option has no effect when `hashMode` is enabled.
+
 ## early404
 
 Responds with an early 404 error for requests whose path cannot match any page route, without loading the Vue app, its plugins or middleware on the server.

--- a/packages/nuxt/src/pages/build.d.ts
+++ b/packages/nuxt/src/pages/build.d.ts
@@ -6,6 +6,11 @@ declare module '#build/router.options.mjs' {
   export default _default
 }
 
+declare module '#build/server-path-filter.mjs' {
+  export const serverPathFallback: boolean
+  export const mightBeServerPath: (path: string) => boolean
+}
+
 declare module '#build/routes' {
   import type { RouterOptions } from '@nuxt/schema'
   import type { Router, RouterOptions as VueRouterOptions } from 'vue-router'

--- a/packages/nuxt/src/pages/module.ts
+++ b/packages/nuxt/src/pages/module.ts
@@ -7,7 +7,7 @@ import { genImport, genInlineTypeImport, genObjectFromRawEntries, genObjectKey, 
 import { joinURL } from 'ufo'
 import { resolveModulePath } from 'exsolve'
 import type { EditableTreeNode, Options as TypedRouterOptions } from 'vue-router/unplugin'
-import type { Nitro, NitroRouteConfig } from 'nitro/types'
+import type { Nitro, NitroEventHandler, NitroRouteConfig } from 'nitro/types'
 import { defu } from 'defu'
 import { isEqual } from 'ohash'
 import { distDir } from '../dirs.ts'
@@ -19,6 +19,7 @@ import type { PagesContext } from './utils.ts'
 import { globRouteRulesFromPages, removePagesRules } from './route-rules.ts'
 import { markPagesCoveredByRouteRule } from './route-coverage.ts'
 import { collectStaticPageRoutes, getAssetPathsForRoute } from './public-assets.ts'
+import { collectPublicAssetPaths, collectServerRoutes, createServerPathFilter, renderServerPathFilterModule } from './server-path-filter.ts'
 import { PageMetaPlugin } from './plugins/page-meta.ts'
 import { toVirtualId } from '../core/plugins/virtual.ts'
 import { createNormalizedRouteRulesRouter, normalizeRouteRulePath } from '../core/utils/route-rules.ts'
@@ -542,12 +543,14 @@ export default defineNuxtModule({
 
     const warnedConflicts = new Set<string>()
     let publicAssets: Nitro['options']['publicAssets'] = []
+    let serverHandlers: NitroEventHandler[] = []
     nuxt.hook('nitro:init', (nitro) => {
       const clientBuildDir = resolve(nuxt.options.buildDir, 'dist/client')
       publicAssets = nitro.options.publicAssets.filter((asset) => {
         const dir = resolve(asset.dir)
         return dir !== clientBuildDir && !dir.startsWith(clientBuildDir + '/')
       })
+      serverHandlers = [...nitro.scannedHandlers, ...nitro.options.handlers]
     })
 
     const warnPublicAssetConflicts = () => {
@@ -806,6 +809,31 @@ export default defineNuxtModule({
           overrideMeta: !!nuxt.options.experimental.scanPageMeta,
         })
         return ROUTES_HMR_CODE + [...imports, `export default ${routes}`].join('\n')
+      },
+    })
+
+    // A client-side navigation that matches no page route is handed back to the server when
+    // the path is (probably) one the server answers itself: a static file or a `GET` server
+    // route. In dev, files appear in `public/` long after this is generated, so the filter
+    // matches everything there and the app asks the dev server instead.
+    addTemplate({
+      filename: 'server-path-filter.mjs',
+      dependsOn: [],
+      getContents: () => {
+        if (!nuxt.options.experimental.serverPathFallback) {
+          return renderServerPathFilterModule(false)
+        }
+        if (nuxt.options.dev) {
+          return renderServerPathFilterModule(undefined)
+        }
+        const baseURL = nuxt.options.app.baseURL
+        const assetPaths = collectPublicAssetPaths(publicAssets, {
+          clientBuildDir: resolve(nuxt.options.buildDir, 'dist/client'),
+          buildAssetsDir: nuxt.options.app.buildAssetsDir,
+          baseURL,
+        })
+        const serverRoutes = collectServerRoutes(serverHandlers, { baseURL })
+        return renderServerPathFilterModule(createServerPathFilter([...assetPaths, ...serverRoutes.paths], serverRoutes.shapes))
       },
     })
 

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -2,7 +2,7 @@ import { isReadonly, reactive, shallowReactive, shallowRef } from 'vue'
 import type { Ref, VNode } from 'vue'
 import type { RouteLocationNormalizedLoadedGeneric, Router, RouterScrollBehavior } from 'vue-router'
 import { START_LOCATION, createMemoryHistory, createRouter, createWebHashHistory, createWebHistory } from 'vue-router'
-import { isSamePath, withoutBase } from 'ufo'
+import { isSamePath, withBase, withoutBase } from 'ufo'
 
 import type { NuxtApp, Plugin } from '#app/nuxt'
 import type { RouteMiddleware } from '#app/composables/router'
@@ -17,6 +17,7 @@ import { navigationDiagnostics } from '../../../app/diagnostics/navigation'
 
 import _routes, { handleHotUpdate } from '#build/routes'
 import _routeRulesMatcher from '#build/route-rules.mjs'
+import { mightBeServerPath, serverPathFallback } from '#build/server-path-filter.mjs'
 import routerOptions, { hashMode } from '#build/router.options.mjs'
 import { globalMiddleware, namedMiddleware } from '#build/middleware'
 import { pageIslandRoutes } from '#build/components.islands.mjs'
@@ -110,6 +111,11 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
     const initialURL = import.meta.server
       ? nuxtApp.ssrContext!.url
       : createCurrentLocation(routerBase, window.location, nuxtApp.payload.path)
+
+    // The path in the address bar when this document loaded, for the reload guard below. Read
+    // from `window.location` rather than `initialURL`, which is the path the document was
+    // *rendered* for and can differ from the path it was served for.
+    const documentPath = import.meta.client && serverPathFallback ? withoutBase(window.location.pathname, routerBase) : ''
 
     // Allows suspending the route object until page navigation completes
     const _route = shallowRef(router.currentRoute.value)
@@ -345,7 +351,7 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
 
     router.afterEach((to) => {
       if (to.matched.length === 0 && !error.value) {
-        return nuxtApp.runWithContext(() => showError(createError({
+        const showNotFound = () => nuxtApp.runWithContext(() => showError(createError({
           status: 404,
           fatal: false,
           statusText: `Page not found: ${to.fullPath}`,
@@ -353,6 +359,42 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
             path: to.fullPath,
           },
         })))
+
+        // Nothing in the app answers for this path, but the server may serve it as a static
+        // file, so load it as a document if the build-time filter says it is probably a public
+        // asset. Anything else renders the error page immediately.
+        //
+        // Reloading is only safe when this document was served for a *different* path: a host
+        // that answers unknown paths with an SPA fallback shell serves the app again, which
+        // matches no route again, so a second pass at the same path must render the error page
+        // rather than reload forever.
+        if (import.meta.client && serverPathFallback && !hashMode && !nuxtApp.isHydrating && !isSamePath(to.path, documentPath) && mightBeServerPath(to.path)) {
+          const href = withBase(to.fullPath, routerBase)
+          // The filter matches everything in dev, so ask the dev server what the path is
+          // rather than turning every unmatched navigation into a document load. The body is
+          // discarded, but the request has to be a `GET`: a `server/routes/*.get.ts` handler
+          // answers no other method.
+          if (import.meta.dev) {
+            fetch(href)
+              .then((res) => {
+                res.body?.cancel()
+                return res.ok && !res.headers.get('content-type')?.startsWith('text/html')
+              })
+              .catch(() => false)
+              .then((isFile) => {
+                if (router.currentRoute.value.fullPath !== to.fullPath) { return }
+                if (isFile) {
+                  window.location.assign(href)
+                } else {
+                  showNotFound()
+                }
+              })
+            return
+          }
+          window.location.assign(href)
+          return
+        }
+        return showNotFound()
       }
     })
 

--- a/packages/nuxt/src/pages/server-path-filter.ts
+++ b/packages/nuxt/src/pages/server-path-filter.ts
@@ -1,0 +1,237 @@
+import { readdirSync } from 'node:fs'
+import type { Dirent } from 'node:fs'
+import { relative, resolve } from 'pathe'
+import { joinURL, withLeadingSlash, withTrailingSlash, withoutBase } from 'ufo'
+import type { NitroEventHandler } from 'nitro/types'
+
+/**
+ * Bloom filter over the paths the server answers itself, so a client-side navigation that
+ * matches no page route can tell "probably served, ask the server" from "certainly a 404". A
+ * false positive costs one document load that still ends on the error page.
+ *
+ * A server route with a parameter (`/og/:slug`) is stored as its shape, with the parameter
+ * replaced by {@link PARAM}, and a lookup tests every shape the path could have. Membership is
+ * the only thing shipped, so a route is never described to the client.
+ */
+
+/** A route parameter (`:slug`), in a shape. Cannot appear in a path. */
+const PARAM = '\u0001'
+/** The rest of the path, after a route wildcard (`**`), in a shape. */
+const REST = '\u0002'
+
+/** A path is tested once, so ~1% false positives costs 9.6 bits and 7 hashes per entry. */
+const PATH_BITS_PER_ENTRY = 9.6
+const PATH_HASH_COUNT = 7
+
+/**
+ * A lookup tests up to `2 ** (MAX_SHAPE_DEPTH + 1)` shapes, and each is an independent chance
+ * of a false positive, so the per-shape rate has to be far lower: 24 bits and 17 hashes per
+ * entry puts it at ~1 in 130,000. Only routes with a parameter are in this filter, and an app
+ * has far fewer of those than files, so the bits are cheap here.
+ */
+const SHAPE_BITS_PER_ENTRY = 24
+const SHAPE_HASH_COUNT = 17
+/** Beyond this depth only the path itself and its wildcard prefixes are tested. */
+const MAX_SHAPE_DEPTH = 8
+
+/**
+ * The bit positions a path occupies in a filter of `bitCount` bits.
+ *
+ * This is emitted verbatim into the client with `Function.prototype.toString()`, so it must
+ * stay self-contained: no imports, no module-scope references.
+ */
+export function serverPathFilterLocations (path: string, hashCount: number, bitCount: number): number[] {
+  let h1 = 2166136261
+  let h2 = 5381
+  for (let i = 0; i < path.length; i++) {
+    const c = path.charCodeAt(i)
+    h1 = Math.imul(h1 ^ c, 16777619)
+    h2 = Math.imul(h2, 33) ^ c
+  }
+  h1 >>>= 0
+  h2 = (h2 >>> 0) | 1
+  const locations = []
+  for (let i = 0; i < hashCount; i++) {
+    locations.push(((h1 + Math.imul(i, h2)) >>> 0) % bitCount)
+  }
+  return locations
+}
+
+export interface BloomFilter {
+  entries: number
+  bitCount: number
+  hashCount: number
+  bits: Uint8Array
+}
+
+function createBloomFilter (values: Iterable<string>, bitsPerEntry: number, hashCount: number): BloomFilter {
+  const unique = new Set(values)
+  const bitCount = Math.max(8, Math.ceil(unique.size * bitsPerEntry))
+  const bits = new Uint8Array(Math.ceil(bitCount / 8))
+  for (const value of unique) {
+    for (const n of serverPathFilterLocations(value, hashCount, bitCount)) {
+      bits[n >> 3]! |= 1 << (n & 7)
+    }
+  }
+  return { entries: unique.size, bitCount, hashCount, bits }
+}
+
+/**
+ * Paths and route shapes are separate filters, because a path is tested once per lookup and a
+ * shape up to `2 ** (MAX_SHAPE_DEPTH + 1)` times. Sharing one filter would mean paying the
+ * shapes' bit budget on every file in `public/`.
+ */
+export interface ServerPathFilter {
+  paths: BloomFilter
+  shapes: BloomFilter
+}
+
+export function createServerPathFilter (paths: Iterable<string>, shapes: Iterable<string> = []): ServerPathFilter {
+  return {
+    paths: createBloomFilter(paths, PATH_BITS_PER_ENTRY, PATH_HASH_COUNT),
+    shapes: createBloomFilter(shapes, SHAPE_BITS_PER_ENTRY, SHAPE_HASH_COUNT),
+  }
+}
+
+export interface PublicAssetDir {
+  dir: string
+  baseURL?: string
+}
+
+/**
+ * Every path nitro serves as a static file that an app could navigate to, as the router sees
+ * it: leading slash, per-asset `baseURL` applied, app `baseURL` removed (it is applied again
+ * by `router.resolve()`, and can be overridden at runtime through `NUXT_APP_BASE_URL`).
+ */
+export function collectPublicAssetPaths (publicAssets: PublicAssetDir[], options: { clientBuildDir: string, buildAssetsDir: string, baseURL: string }): Set<string> {
+  const paths = new Set<string>()
+  const clientBuildDir = resolve(options.clientBuildDir)
+  const buildAssetsDir = withTrailingSlash(withLeadingSlash(withoutBase(options.buildAssetsDir, options.baseURL)))
+  for (const asset of publicAssets) {
+    const dir = resolve(asset.dir)
+    if (dir === clientBuildDir || dir.startsWith(clientBuildDir + '/')) { continue }
+    const assetBase = withTrailingSlash(withLeadingSlash(withoutBase(asset.baseURL || '/', options.baseURL)))
+    // build assets and the app manifest are never navigated to
+    if (assetBase.startsWith(buildAssetsDir)) { continue }
+    let entries: Dirent[]
+    try {
+      entries = readdirSync(dir, { recursive: true, withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      if (!entry.isFile()) { continue }
+      const file = relative(dir, resolve(entry.parentPath, entry.name))
+      paths.add(withLeadingSlash(withoutBase(joinURL(asset.baseURL || '/', file), options.baseURL)))
+    }
+  }
+  return paths
+}
+
+/**
+ * The shape of a route: itself when it is static, and otherwise with each parameter segment
+ * replaced by {@link PARAM} and everything from a wildcard segment on by {@link REST}.
+ */
+function toRouteShape (route: string): string {
+  const segments = route.split('/')
+  let shape = ''
+  for (let i = 1; i < segments.length; i++) {
+    const segment = segments[i]!
+    if (segment.startsWith('*')) { return shape + '/' + REST }
+    shape += '/' + (segment.startsWith(':') ? PARAM : segment)
+  }
+  return shape
+}
+
+/**
+ * The server routes a `GET` navigation could reach: `server/routes/**` and `server/api/**`
+ * handlers with no method suffix or a `.get` one, as the router sees them. Static routes are
+ * returned as `paths` and the rest as `shapes`.
+ *
+ * A root-level catch-all (`/**`, as used by the Nuxt renderer itself and by middleware) covers
+ * every path, so it is ignored: it would make the filter match everything.
+ */
+export function collectServerRoutes (handlers: NitroEventHandler[], options: { baseURL: string }): { paths: Set<string>, shapes: Set<string> } {
+  const paths = new Set<string>()
+  const shapes = new Set<string>()
+  for (const handler of handlers) {
+    if (handler.middleware || !handler.route || handler.route === '/**') { continue }
+    if (handler.method && handler.method.toLowerCase() !== 'get') { continue }
+    const route = withLeadingSlash(withoutBase(handler.route, options.baseURL))
+    const shape = toRouteShape(route)
+    if (shape === route) {
+      paths.add(route)
+    } else {
+      shapes.add(shape)
+    }
+  }
+  return { paths, shapes }
+}
+
+/**
+ * `#build/server-path-filter.mjs`.
+ *
+ * `serverPathFallback` is a literal so a disabled build drops the import, the filter data and
+ * the lookup. `undefined` means enabled with a path list that cannot be trusted (dev) and
+ * matches everything.
+ */
+export function renderServerPathFilterModule (filter: ServerPathFilter | undefined | false): string {
+  // nothing to fall back to, so nothing is shipped
+  if (filter === false || (filter && !filter.paths.entries && !filter.shapes.entries)) {
+    return [
+      'export const serverPathFallback = false',
+      'export const mightBeServerPath = () => false',
+      '',
+    ].join('\n')
+  }
+  if (!filter) {
+    return [
+      'export const serverPathFallback = true',
+      'export const mightBeServerPath = () => true',
+      '',
+    ].join('\n')
+  }
+  const lines = [
+    'export const serverPathFallback = true',
+    `const locations = ${serverPathFilterLocations.toString()}`,
+    ...renderBloomFilter(filter.paths, 'path'),
+    ...renderBloomFilter(filter.shapes, 'shape'),
+  ]
+  if (!filter.shapes.entries) {
+    lines.push('export const mightBeServerPath = testPath')
+    return [...lines, ''].join('\n')
+  }
+  lines.push(
+    // every shape the path could have: each segment either itself or a route parameter, and
+    // every prefix of those followed by a route wildcard
+    `const shapeOf = (segments, length, mask) => {`,
+    `  let shape = ''`,
+    `  for (let i = 1; i <= length; i++) { shape += '/' + ((mask >> (i - 1)) & 1 ? ${JSON.stringify(PARAM)} : segments[i]) }`,
+    `  return shape`,
+    `}`,
+    `const maskCount = length => length > ${MAX_SHAPE_DEPTH} ? 1 : 1 << length`,
+    `export const mightBeServerPath = (path) => {`,
+    ...filter.paths.entries ? ['  if (testPath(path)) { return true }'] : [],
+    `  const segments = path.split('/')`,
+    `  const depth = segments.length - 1`,
+    `  for (let mask = 1; mask < maskCount(depth); mask++) {`,
+    `    if (testShape(shapeOf(segments, depth, mask))) { return true }`,
+    `  }`,
+    `  for (let length = depth - 1; length > 0; length--) {`,
+    `    for (let mask = 0; mask < maskCount(length); mask++) {`,
+    `      if (testShape(shapeOf(segments, length, mask) + '/' + ${JSON.stringify(REST)})) { return true }`,
+    `    }`,
+    `  }`,
+    `  return false`,
+    `}`,
+  )
+  return [...lines, ''].join('\n')
+}
+
+function renderBloomFilter (filter: BloomFilter, name: 'path' | 'shape'): string[] {
+  if (!filter.entries) { return [] }
+  return [
+    `const ${name}Bits = Uint8Array.from(atob(${JSON.stringify(Buffer.from(filter.bits).toString('base64'))}), c => c.charCodeAt(0))`,
+    `const test${name === 'path' ? 'Path' : 'Shape'} = value => locations(value, ${filter.hashCount}, ${filter.bitCount}).every(n => ${name}Bits[n >> 3] & (1 << (n & 7)))`,
+  ]
+}

--- a/packages/nuxt/test/server-path-filter.test.ts
+++ b/packages/nuxt/test/server-path-filter.test.ts
@@ -1,0 +1,233 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterAll, describe, expect, it } from 'vitest'
+import { rm } from 'node:fs/promises'
+
+import type { BloomFilter } from '../src/pages/server-path-filter'
+import { collectPublicAssetPaths, collectServerRoutes, createServerPathFilter, renderServerPathFilterModule, serverPathFilterLocations } from '../src/pages/server-path-filter'
+
+function testFilter (filter: BloomFilter, value: string): boolean {
+  return serverPathFilterLocations(value, filter.hashCount, filter.bitCount)
+    .every(n => filter.bits[n >> 3]! & (1 << (n & 7)))
+}
+
+const root = mkdtempSync(join(tmpdir(), 'nuxt-server-path-filter-'))
+afterAll(() => rm(root, { recursive: true, force: true }))
+
+function createDir (name: string, files: string[]) {
+  const dir = join(root, name)
+  for (const file of files) {
+    mkdirSync(dirname(join(dir, file)), { recursive: true })
+    writeFileSync(join(dir, file), 'x')
+  }
+  return dir
+}
+
+async function loadGeneratedModule (source: string) {
+  return await import(/* @vite-ignore */ 'data:text/javascript,' + encodeURIComponent(source)) as {
+    serverPathFallback: boolean
+    mightBeServerPath: (path: string) => boolean
+  }
+}
+
+describe('collectPublicAssetPaths', () => {
+  const clientBuildDir = join(root, '.nuxt/dist/client')
+
+  it('collects nested files from every asset directory', () => {
+    const project = createDir('project-public', ['proposal.pdf', 'images/logo.svg'])
+    const layer = createDir('layer-public', ['layer.txt'])
+
+    const paths = collectPublicAssetPaths([{ dir: project, baseURL: '/' }, { dir: layer, baseURL: '/' }], { clientBuildDir, buildAssetsDir: '/_nuxt/', baseURL: '/' })
+
+    expect([...paths].sort()).toEqual(['/images/logo.svg', '/layer.txt', '/proposal.pdf'])
+  })
+
+  it('honours a per-asset baseURL, as used by module-contributed directories', () => {
+    const moduleAssets = createDir('module-assets', ['inter.woff2', 'subset/latin.woff2'])
+
+    const paths = collectPublicAssetPaths([{ dir: moduleAssets, baseURL: '/fonts' }], { clientBuildDir, buildAssetsDir: '/_nuxt/', baseURL: '/' })
+
+    expect([...paths].sort()).toEqual(['/fonts/inter.woff2', '/fonts/subset/latin.woff2'])
+  })
+
+  it('stores paths as the router sees them, with the app baseURL removed', () => {
+    const project = createDir('based-public', ['proposal.pdf'])
+
+    const paths = collectPublicAssetPaths([{ dir: project, baseURL: '/base/' }], { clientBuildDir, buildAssetsDir: '/_nuxt/', baseURL: '/base/' })
+
+    expect([...paths]).toEqual(['/proposal.pdf'])
+  })
+
+  it('skips the client build output', () => {
+    const project = createDir('with-build-output', ['proposal.pdf'])
+    const buildDir = createDir('.nuxt/dist/client', ['_nuxt/entry.js'])
+
+    const paths = collectPublicAssetPaths([{ dir: project }, { dir: buildDir, baseURL: '/_nuxt/' }], { clientBuildDir, buildAssetsDir: '/_nuxt/', baseURL: '/' })
+
+    expect([...paths]).toEqual(['/proposal.pdf'])
+  })
+
+  it('skips build assets and the app manifest, which are never navigated to', () => {
+    const project = createDir('with-manifest', ['proposal.pdf'])
+    const manifest = createDir('manifest', ['latest.json', 'meta/build-id.json'])
+
+    const paths = collectPublicAssetPaths([{ dir: project }, { dir: manifest, baseURL: '/_nuxt/builds' }], { clientBuildDir, buildAssetsDir: '/_nuxt/', baseURL: '/' })
+
+    expect([...paths]).toEqual(['/proposal.pdf'])
+  })
+
+  it('ignores a directory that does not exist', () => {
+    expect(collectPublicAssetPaths([{ dir: join(root, 'nope') }], { clientBuildDir, buildAssetsDir: '/_nuxt/', baseURL: '/' }).size).toBe(0)
+  })
+})
+
+describe('collectServerRoutes', () => {
+  const handler = (route: string, method?: string) => ({ route, method, handler: 'handler.ts' } as Parameters<typeof collectServerRoutes>[0][number])
+
+  it('collects `GET` and method-less routes, and skips other methods', () => {
+    const { paths } = collectServerRoutes([
+      handler('/rss.xml', 'get'),
+      handler('/sitemap.xml'),
+      handler('/subscribe', 'post'),
+      handler('/api/items', 'delete'),
+    ], { baseURL: '/' })
+
+    expect([...paths].sort()).toEqual(['/rss.xml', '/sitemap.xml'])
+  })
+
+  it('skips middleware and a root-level catch-all, which cover every path', () => {
+    const { paths, shapes } = collectServerRoutes([
+      { route: '/**', middleware: true, handler: 'middleware.ts' },
+      handler('/**'),
+      handler('/rss.xml'),
+    ], { baseURL: '/' })
+
+    expect([...paths]).toEqual(['/rss.xml'])
+    expect([...shapes]).toEqual([])
+  })
+
+  it('replaces a parameter, and everything after a wildcard, with a placeholder', () => {
+    const { shapes } = collectServerRoutes([
+      handler('/og/:slug'),
+      handler('/api/users/:id/avatar'),
+      handler('/files/**'),
+      handler('/files/**:path'),
+    ], { baseURL: '/' })
+
+    expect([...shapes]).toEqual(['/og/\u0001', '/api/users/\u0001/avatar', '/files/\u0002'])
+  })
+
+  it('removes the app baseURL', () => {
+    const { paths, shapes } = collectServerRoutes([handler('/base/feed.xml'), handler('/base/og/:slug')], { baseURL: '/base/' })
+
+    expect([...paths]).toEqual(['/feed.xml'])
+    expect([...shapes]).toEqual(['/og/\u0001'])
+  })
+})
+
+describe('server path filter', () => {
+  const paths = Array.from({ length: 500 }, (_, i) => `/assets/file-${i}.png`)
+  const filter = createServerPathFilter(paths)
+
+  it('never rejects a path that is in it', async () => {
+    const { mightBeServerPath } = await loadGeneratedModule(renderServerPathFilterModule(filter))
+
+    expect(paths.filter(path => !mightBeServerPath(path))).toEqual([])
+  })
+
+  it('agrees with the build-time filter on every path', async () => {
+    const { mightBeServerPath } = await loadGeneratedModule(renderServerPathFilterModule(filter))
+    const probes = [...paths, ...Array.from({ length: 5000 }, (_, i) => `/probe-${i.toString(36)}/${(i * 7919).toString(36)}`)]
+
+    const disagreements = probes.filter(path => mightBeServerPath(path) !== testFilter(filter.paths, path))
+
+    expect(disagreements).toEqual([])
+  })
+
+  it('keeps false positives within the configured rate, over the shapes each lookup tests', async () => {
+    const { mightBeServerPath } = await loadGeneratedModule(renderServerPathFilterModule(filter))
+    const probes = Array.from({ length: 20000 }, (_, i) => `/not/an/asset/${i.toString(36)}/${(i * 7919).toString(36)}`)
+
+    const positives = probes.filter(path => mightBeServerPath(path)).length
+
+    expect(positives / probes.length).toBeLessThan(0.03)
+  })
+
+  it('matches a path against the shape of a route with a parameter or a wildcard', async () => {
+    const { shapes } = collectServerRoutes([
+      { route: '/og/:slug', handler: 'og.ts' },
+      { route: '/api/users/:id/avatar', handler: 'avatar.ts' },
+      { route: '/files/**', handler: 'files.ts' },
+    ], { baseURL: '/' })
+    const { mightBeServerPath } = await loadGeneratedModule(renderServerPathFilterModule(createServerPathFilter([], shapes)))
+
+    expect(mightBeServerPath('/og/hello')).toBe(true)
+    expect(mightBeServerPath('/api/users/17/avatar')).toBe(true)
+    expect(mightBeServerPath('/files/nested/deeply/file.txt')).toBe(true)
+    expect(mightBeServerPath('/og/hello/nested')).toBe(false)
+    expect(mightBeServerPath('/api/users/17')).toBe(false)
+  })
+
+  it('stays small', () => {
+    expect(renderServerPathFilterModule(filter).length).toBeLessThan(1600)
+  })
+
+  it('ships no shape machinery when no route needs it', () => {
+    const source = renderServerPathFilterModule(filter)
+
+    expect(source).not.toContain('shapeOf')
+  })
+
+  it('ships no path or route shape, so neither can be recovered from it', () => {
+    const { shapes } = collectServerRoutes([{ route: '/api/users/:id/avatar', handler: 'avatar.ts' }], { baseURL: '/' })
+    const source = renderServerPathFilterModule(createServerPathFilter(['/rss.xml'], shapes))
+
+    expect(source).not.toContain('rss')
+    expect(source).not.toContain('users')
+  })
+})
+
+describe('generated module', () => {
+  it('matches nothing, and can be dropped from the bundle, when disabled', async () => {
+    const source = renderServerPathFilterModule(false)
+    const { serverPathFallback, mightBeServerPath } = await loadGeneratedModule(source)
+
+    expect(serverPathFallback).toBe(false)
+    expect(mightBeServerPath('/proposal.pdf')).toBe(false)
+    expect(source).not.toContain('atob')
+  })
+
+  it('matches everything when the file list cannot be trusted, as in dev', async () => {
+    const { serverPathFallback, mightBeServerPath } = await loadGeneratedModule(renderServerPathFilterModule(undefined))
+
+    expect(serverPathFallback).toBe(true)
+    expect(mightBeServerPath('/anything-at-all')).toBe(true)
+  })
+
+  it('disables itself when there is nothing to fall back to', async () => {
+    const { serverPathFallback, mightBeServerPath } = await loadGeneratedModule(renderServerPathFilterModule(createServerPathFilter([])))
+
+    expect(serverPathFallback).toBe(false)
+    expect(mightBeServerPath('/proposal.pdf')).toBe(false)
+  })
+})
+
+describe('e2e fixture assumptions', () => {
+  // `test/fixtures/server-path-fallback` needs `/changelog` to be a false positive of
+  // the filter built from its `public/` directory and server routes. If this fails, pick a new
+  // colliding path for the fixture.
+  it('keeps the collision the e2e fixture depends on', async () => {
+    const routes = collectServerRoutes([
+      { route: '/rss.xml', method: 'GET', handler: 'rss.ts' },
+      { route: '/og/:slug', handler: 'og.ts' },
+      { route: '/subscribe', method: 'POST', handler: 'subscribe.ts' },
+    ], { baseURL: '/' })
+    const filter = createServerPathFilter([...routes.paths, '/proposal.pdf', '/proposal.txt'], routes.shapes)
+    const { mightBeServerPath } = await loadGeneratedModule(renderServerPathFilterModule(filter))
+
+    expect(mightBeServerPath('/changelog')).toBe(true)
+    expect(mightBeServerPath('/definitely-not-a-route')).toBe(false)
+    expect(mightBeServerPath('/subscribe')).toBe(false)
+  })
+})

--- a/packages/schema/src/config/experimental.ts
+++ b/packages/schema/src/config/experimental.ts
@@ -178,6 +178,14 @@ export default defineResolvers({
         return (await get('future.compatibilityVersion')) >= 5
       },
     },
+    serverPathFallback: {
+      $resolve: async (val, get) => {
+        if (typeof val === 'boolean') {
+          return val
+        }
+        return (await get('future.compatibilityVersion')) >= 5
+      },
+    },
     appManifest: true,
     checkOutdatedBuildInterval: 1000 * 60 * 60,
     watcher: {

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1262,6 +1262,31 @@ export interface ConfigSchema {
     typedPages: boolean
 
     /**
+     * Hand a client-side navigation that matches no page route back to the browser when the
+     * path is one the server answers itself: a static file (anything under `public/`, or
+     * another `nitro.publicAssets` directory) or a `GET` server route. Any other path renders
+     * the 404 error page as before.
+     *
+     * This makes `<NuxtLink to="/brochure.pdf">` and `<NuxtLink to="/rss.xml">` behave on
+     * click the way they behave on a hard load.
+     *
+     * Enabling this ships a small Bloom filter of those paths to the client (around 9.6 bits
+     * per path, so about 1 kB gzipped for a site with 500 of them). Nothing can be read back
+     * out of it. Routes with a parameter go into a second filter as their shape, so
+     * `/og/hello` matches without `/og/[slug]` being described to the client, and an app with
+     * no such route ships neither that filter nor its lookup.
+     *
+     * Files written to a public asset directory during the build, after the client bundle is
+     * generated, are not in the filter and still render the error page on a client-side
+     * navigation, though they are still served on a hard load.
+     *
+     * This is enabled by default with compatibility version 5.
+     *
+     * @default false
+     */
+    serverPathFallback: boolean
+
+    /**
      * Use app manifests to respect route rules on client-side.
      *
      * @default true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2034,6 +2034,26 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/nuxt
 
+  test/fixtures/server-path-fallback:
+    dependencies:
+      nuxt:
+        specifier: workspace:*
+        version: link:../../../packages/nuxt
+    devDependencies:
+      typescript:
+        specifier: catalog:dev
+        version: 6.0.3
+
+  test/fixtures/server-path-fallback-disabled:
+    dependencies:
+      nuxt:
+        specifier: workspace:*
+        version: link:../../../packages/nuxt
+    devDependencies:
+      typescript:
+        specifier: catalog:dev
+        version: 6.0.3
+
   test/fixtures/spa:
     dependencies:
       nuxt:

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -178,6 +178,37 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
   })
 })
 
+describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM_CI)('server path fallback', () => {
+  const rootDir = fileURLToPath(new URL('./fixtures/server-path-fallback', import.meta.url))
+  const disabledRootDir = fileURLToPath(new URL('./fixtures/server-path-fallback-disabled', import.meta.url))
+  // the FNV offset basis in the lookup shipped by `#build/server-path-filter.mjs`
+  const filterMarker = '2166136261'
+
+  let enabled: string
+  let disabled: string
+
+  beforeAll(async () => {
+    await Promise.all([
+      exec('pnpm', ['nuxt', 'build', rootDir]),
+      exec('pnpm', ['nuxt', 'build', disabledRootDir]),
+    ])
+    enabled = await readClientBundle(join(rootDir, '.output/public'))
+    disabled = await readClientBundle(join(disabledRootDir, '.output/public'))
+  }, 240 * 1000)
+
+  it('ships the filter and the fallback when enabled', () => {
+    expect(enabled).toContain(filterMarker)
+    // the `noScripts` document load, plus this one
+    expect(enabled.match(/location\.assign/g)).toHaveLength(2)
+  })
+
+  it('ships nothing at all when disabled', () => {
+    expect(disabled).not.toContain(filterMarker)
+    expect(disabled).not.toContain('mightBeServerPath')
+    expect(disabled.match(/location\.assign/g)).toHaveLength(1)
+  })
+})
+
 describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM_CI)('ssr: false route rules', () => {
   const rootDir = fileURLToPath(new URL('./fixtures/spa-only', import.meta.url))
 
@@ -288,4 +319,10 @@ function allForms (value: string) {
 
 function roundToKilobytes (bytes: number) {
   return (bytes / 1024).toFixed(bytes > (100 * 1024) ? 0 : 1) + 'k'
+}
+
+async function readClientBundle (dir: string) {
+  const files = await glob(['**/*.js'], { cwd: dir })
+  const contents = await Promise.all(files.map(file => fsp.readFile(join(dir, file), 'utf8')))
+  return contents.join('\n')
 }

--- a/test/e2e/server-path-fallback.test.ts
+++ b/test/e2e/server-path-fallback.test.ts
@@ -1,0 +1,131 @@
+import { fileURLToPath } from 'node:url'
+import { isWindows } from 'std-env'
+import { expect, test } from './test-utils'
+
+const fixtureDir = fileURLToPath(new URL('../fixtures/server-path-fallback', import.meta.url))
+
+// one Nuxt instance at a time: parallel dev servers race on the fixture's `.nuxt` directory
+test.describe.configure({ mode: 'serial' })
+
+test.use({
+  nuxt: {
+    rootDir: fixtureDir,
+    server: true,
+    browser: true,
+    setupTimeout: (isWindows ? 360 : 120) * 1000,
+  },
+})
+
+/** Document requests the browser makes after the initial page load. */
+function trackDocumentLoads (page: import('@playwright/test').Page) {
+  const loads: string[] = []
+  page.on('request', (request) => {
+    if (request.isNavigationRequest()) {
+      loads.push(new URL(request.url()).pathname)
+    }
+  })
+  return loads
+}
+
+test.describe('server path fallback', () => {
+  test('loads a file from `public/` as a document instead of showing the error page', async ({ page, goto }) => {
+    await goto('/')
+    const loads = trackDocumentLoads(page)
+
+    await page.click('#asset')
+    await expect.poll(() => page.textContent('body')).toContain('proposal contents')
+
+    expect(loads).toEqual(['/proposal.txt'])
+    expect(page.url()).toContain('/proposal.txt')
+  })
+
+  test('still navigates to a real route on the client', async ({ page, goto }) => {
+    await goto('/')
+    const loads = trackDocumentLoads(page)
+
+    await page.click('#page')
+    await expect.poll(() => page.url()).toContain('/about')
+
+    expect(loads).toEqual([])
+    expect(await page.textContent('#about-page')).toContain('About page')
+  })
+
+  test('loads a `GET` server route as a document', async ({ page, goto }) => {
+    await goto('/')
+    const loads = trackDocumentLoads(page)
+
+    await page.click('#server-route')
+    await expect.poll(() => page.textContent('body')).toContain('feed contents')
+
+    expect(loads).toEqual(['/rss.xml'])
+    expect(page.url()).toContain('/rss.xml')
+  })
+
+  test('loads a server route with a parameter as a document', async ({ page, goto }) => {
+    await goto('/')
+    const loads = trackDocumentLoads(page)
+
+    await page.click('#dynamic-server-route')
+    await expect.poll(() => page.textContent('body')).toContain('og image for hello')
+
+    expect(loads).toEqual(['/og/hello'])
+    expect(page.url()).toContain('/og/hello')
+  })
+
+  test('renders the error page for a server route of another method', async ({ page, goto }) => {
+    await goto('/')
+    const loads = trackDocumentLoads(page)
+
+    await page.click('#post-only-server-route')
+    await expect.poll(() => page.textContent('body')).toContain('Page not found: /subscribe')
+
+    expect(loads).toEqual([])
+  })
+
+  test('renders the error page for an unmatched path, without loading a document', async ({ page, goto }) => {
+    await goto('/')
+    const loads = trackDocumentLoads(page)
+
+    await page.click('#missing')
+    await expect.poll(() => page.textContent('body')).toContain('Page not found: /definitely-not-a-route')
+
+    expect(loads).toEqual([])
+  })
+
+  test.describe('built', () => {
+    test.skip(({ isDev }) => isDev, 'the filter is only built for a production build')
+
+    test('reloads at most once when a false positive is served the SPA fallback shell', async ({ page, goto, baseURL }) => {
+      // an SPA-fallback host answers an unknown path with `200.html` at status 200, so the
+      // app matches no route again
+      const shell = await page.request.get(new URL('/200.html', baseURL).href).then(res => res.text())
+      await goto('/')
+      const loads = trackDocumentLoads(page)
+
+      await page.route('**/changelog', route => route.request().isNavigationRequest()
+        ? route.fulfill({ status: 200, contentType: 'text/html', body: shell })
+        : route.continue())
+
+      await page.click('#collision')
+      await expect.poll(() => page.textContent('body')).toContain('Page not found: /changelog')
+
+      expect(loads).toEqual(['/changelog'])
+    })
+
+    test('reloads at most once when a false positive is rewritten to a rendered page', async ({ page, goto, baseURL }) => {
+      // other hosts rewrite unknown paths to `index.html`, i.e. a document rendered for `/`
+      const index = await page.request.get(new URL('/', baseURL).href).then(res => res.text())
+      await goto('/')
+      const loads = trackDocumentLoads(page)
+
+      await page.route('**/changelog', route => route.request().isNavigationRequest()
+        ? route.fulfill({ status: 200, contentType: 'text/html', body: index })
+        : route.continue())
+
+      await page.click('#collision')
+      await page.waitForTimeout(2000)
+
+      expect(loads).toEqual(['/changelog'])
+    })
+  })
+})

--- a/test/fixtures/server-path-fallback-disabled/nuxt.config.ts
+++ b/test/fixtures/server-path-fallback-disabled/nuxt.config.ts
@@ -1,0 +1,7 @@
+export default defineNuxtConfig({
+  // the same app as `server-path-fallback`, with the feature off, so `test/bundle.test.ts`
+  // can compare the two client bundles
+  extends: ['../server-path-fallback'],
+  experimental: { serverPathFallback: false },
+  compatibilityDate: 'latest',
+})

--- a/test/fixtures/server-path-fallback-disabled/package.json
+++ b/test/fixtures/server-path-fallback-disabled/package.json
@@ -1,0 +1,17 @@
+{
+  "private": true,
+  "type": "module",
+  "name": "fixture-server-path-fallback-disabled",
+  "scripts": {
+    "build": "nuxt build"
+  },
+  "dependencies": {
+    "nuxt": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "catalog:dev"
+  },
+  "engines": {
+    "node": "^22.19.0 || ^24.11.0 || >=26.0.0"
+  }
+}

--- a/test/fixtures/server-path-fallback-disabled/tsconfig.json
+++ b/test/fixtures/server-path-fallback-disabled/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./.nuxt/tsconfig.app.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.server.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.node.json"
+    }
+  ]
+}

--- a/test/fixtures/server-path-fallback/app/pages/about.vue
+++ b/test/fixtures/server-path-fallback/app/pages/about.vue
@@ -1,0 +1,5 @@
+<template>
+  <div id="about-page">
+    About page
+  </div>
+</template>

--- a/test/fixtures/server-path-fallback/app/pages/index.vue
+++ b/test/fixtures/server-path-fallback/app/pages/index.vue
@@ -1,0 +1,37 @@
+<template>
+  <div>
+    <h1>Server path fallback</h1>
+    <NuxtLink
+      id="asset"
+      to="/proposal.txt"
+    >asset</NuxtLink>
+    <NuxtLink
+      id="page"
+      to="/about"
+    >about</NuxtLink>
+    <NuxtLink
+      id="missing"
+      to="/definitely-not-a-route"
+    >missing</NuxtLink>
+    <NuxtLink
+      id="server-route"
+      to="/rss.xml"
+    >server route</NuxtLink>
+    <NuxtLink
+      id="dynamic-server-route"
+      to="/og/hello"
+    >dynamic server route</NuxtLink>
+    <NuxtLink
+      id="post-only-server-route"
+      to="/subscribe"
+    >post-only server route</NuxtLink>
+    <!--
+      `/changelog` is a false positive of the filter built from this fixture, asserted in
+      `packages/nuxt/test/server-path-filter.test.ts`.
+    -->
+    <NuxtLink
+      id="collision"
+      to="/changelog"
+    >collision</NuxtLink>
+  </div>
+</template>

--- a/test/fixtures/server-path-fallback/nuxt.config.ts
+++ b/test/fixtures/server-path-fallback/nuxt.config.ts
@@ -1,0 +1,8 @@
+export default defineNuxtConfig({
+  devtools: { enabled: false },
+  compatibilityDate: 'latest',
+  nitro: {
+    // `test/e2e/server-path-fallback.test.ts` serves this to emulate SPA-fallback hosting
+    prerender: { routes: ['/200.html'] },
+  },
+})

--- a/test/fixtures/server-path-fallback/package.json
+++ b/test/fixtures/server-path-fallback/package.json
@@ -1,0 +1,17 @@
+{
+  "private": true,
+  "type": "module",
+  "name": "fixture-server-path-fallback",
+  "scripts": {
+    "build": "nuxt build"
+  },
+  "dependencies": {
+    "nuxt": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "catalog:dev"
+  },
+  "engines": {
+    "node": "^22.19.0 || ^24.11.0 || >=26.0.0"
+  }
+}

--- a/test/fixtures/server-path-fallback/public/proposal.pdf
+++ b/test/fixtures/server-path-fallback/public/proposal.pdf
@@ -1,0 +1,1 @@
+%PDF-1.4 not really a pdf

--- a/test/fixtures/server-path-fallback/public/proposal.txt
+++ b/test/fixtures/server-path-fallback/public/proposal.txt
@@ -1,0 +1,1 @@
+proposal contents

--- a/test/fixtures/server-path-fallback/server/routes/og/[slug].ts
+++ b/test/fixtures/server-path-fallback/server/routes/og/[slug].ts
@@ -1,0 +1,7 @@
+import { defineEventHandler } from 'h3'
+
+export default defineEventHandler((event) => {
+  return new Response(`og image for ${event.context.params?.slug}`, {
+    headers: { 'content-type': 'text/plain' },
+  })
+})

--- a/test/fixtures/server-path-fallback/server/routes/rss.xml.get.ts
+++ b/test/fixtures/server-path-fallback/server/routes/rss.xml.get.ts
@@ -1,0 +1,7 @@
+import { defineEventHandler } from 'h3'
+
+export default defineEventHandler(() => {
+  return new Response('<rss>feed contents</rss>', {
+    headers: { 'content-type': 'application/xml' },
+  })
+})

--- a/test/fixtures/server-path-fallback/server/routes/subscribe.post.ts
+++ b/test/fixtures/server-path-fallback/server/routes/subscribe.post.ts
@@ -1,0 +1,3 @@
+import { defineEventHandler } from 'h3'
+
+export default defineEventHandler(() => ({ ok: true }))

--- a/test/fixtures/server-path-fallback/tsconfig.json
+++ b/test/fixtures/server-path-fallback/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./.nuxt/tsconfig.app.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.server.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.node.json"
+    }
+  ]
+}


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

sometimes users link to public files. they 'should' use the `external` attribute to opt out of client-side routing, but sometimes this isn't intuitive or workable (e.g. [with nuxt/content in markdown](https://github.com/nuxt/content/issues/3831))

the best behaviour would be for this to be detected _statically_ and an `<a>` link to be rendered (watch this space!) but in the intervening time we can 'fall through' to a hard reload when vue router is unaware of any such link

we can use a bloom filter to reduce false positives (thanks to the great @samwho for [this amazing explainer](https://samwho.dev/bloom-filters))

**key question**: I would love feedback on how we decide to do a hard-reload vs show a client-side 404 error:
1. this approach (bloom filter)
2. always making a HEAD request (find if a file exists)
3. just always do a hard-reload

a bloom filter is most complex but is a best effort at better user experience.

... the latter two options are simpler but means at least 1 network round-trip. (on the other hand, links to client-side 404s are rare, so potentially the simplicity is worth it?)