### PR TITLE
fix(nitro): apply `baseURL` to server routing

### DIFF
--- a/docs/4.api/2.composables/use-request-url.md
+++ b/docs/4.api/2.composables/use-request-url.md
@@ -17,6 +17,10 @@ When utilizing [Hybrid Rendering](/docs/4.x/guide/concepts/rendering#hybrid-rend
 You can define the [`cache.varies` option](https://nitro.build/guide/cache#options) to specify headers that will be considered when caching and serving the responses, such as `host` and `x-forwarded-host` for multi-tenant environments.
 ::
 
+::note
+If you have set [`app.baseURL`](/docs/4.x/api/nuxt-config#baseurl), the path returned on the server is relative to it, so `/base/about` is served as `/about`. On the client, `useRequestURL` reads `window.location`, which includes the base URL.
+::
+
 ::code-group
 
 ```vue [app/pages/about.vue]

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -115,6 +115,10 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     })
   }
 
+  // When the base URL is only known at runtime, the `base-url` middleware strips it from incoming
+  // requests, so nitro's routes must stay unprefixed for the internally re-dispatched request to
+  // match them.
+  const nitroBaseURL = nuxt.options.experimental.runtimeBaseURL ? '/' : nuxt.options.app.baseURL
   if (nuxt.options.experimental.runtimeBaseURL) {
     nuxt.options.serverHandlers.unshift({
       route: '',
@@ -218,7 +222,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     renderer: {
       handler: resolve(distDir, 'runtime/handlers/renderer'),
     },
-    baseURL: nuxt.options.app.baseURL,
+    baseURL: nitroBaseURL,
     virtual: {
       '#internal/nuxt.config.mjs': () => nuxt.vfs['#build/nuxt.config.mjs'] || '',
       '#internal/nuxt/app-config': () => nuxt.vfs['#build/app.config.mjs']?.replace(/\/\*\* client \*\*\/[\s\S]*\/\*\* client-end \*\*\//, '') || '',
@@ -559,7 +563,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
 
     nitroConfig.prerender ||= {}
     nitroConfig.prerender.ignore ||= []
-    nitroConfig.prerender.ignore.push(joinURL(nuxt.options.app.baseURL, manifestPrefix))
+    nitroConfig.prerender.ignore.push(joinURL(nitroBaseURL, manifestPrefix))
 
     nitroConfig.publicAssets!.unshift(
       // build manifest

--- a/packages/nitro-server/src/runtime/handlers/error.ts
+++ b/packages/nitro-server/src/runtime/handlers/error.ts
@@ -6,6 +6,7 @@ import { serverFetch } from 'nitro'
 
 import type { SSRErrorInput } from '../utils/error'
 import { SSR_ERROR_PARAM, encodeSSRError, isJsonRequest } from '../utils/error'
+import { withBaseURL } from '../utils/base'
 import { generateErrorOverlayHTML } from '../utils/dev'
 
 export default <NitroErrorHandler> async function errorhandler (error, event, { defaultHandler }) {
@@ -61,7 +62,7 @@ export default <NitroErrorHandler> async function errorhandler (error, event, { 
 
   // HTML response (via SSR)
   const res = !isRenderingError && await serverFetch(
-    withQuery('/__nuxt_error', { [SSR_ERROR_PARAM]: encodeSSRError(errorObject) }),
+    withQuery(withBaseURL('/__nuxt_error'), { [SSR_ERROR_PARAM]: encodeSSRError(errorObject) }),
     {
       headers: event.req.headers,
       redirect: 'manual',

--- a/packages/nitro-server/src/runtime/handlers/island.ts
+++ b/packages/nitro-server/src/runtime/handlers/island.ts
@@ -1,7 +1,8 @@
 import { useNitroHooks } from 'nitro/app'
 import type { Link, SerializableHead } from '@unhead/vue/types'
 import { destr } from 'destr'
-import { H3Event, HTTPError, getQuery } from 'nitro/h3'
+import { HTTPError, getQuery } from 'nitro/h3'
+import type { H3Event } from 'nitro/h3'
 import { VueResolver, walkResolver } from '@unhead/vue/utils'
 import { getRequestDependencies } from 'vue-bundle-renderer/runtime'
 import { getQuery as getURLQuery } from 'ufo'
@@ -14,6 +15,7 @@ import { traceAsync } from '#app/internal/tracing'
 import { runtimeCompiler, tracingChannelNuxt } from '#internal/nuxt.config.mjs'
 import { serverDiagnostics } from '../diagnostics'
 import { createSSRContext, rethrowWithResponseHeaders, returnRenderResponse } from '../utils/renderer/app'
+import { createEvent, urlHash } from '../utils/base'
 import { getSSRRenderer } from '../utils/renderer/build-files'
 import { renderInlineStyles } from '../utils/renderer/inline-styles'
 import { getClientIslandResponse, getServerComponentHTML, getSlotIslandResponse } from '../utils/renderer/islands'
@@ -43,7 +45,7 @@ const inFlightIslands: Map<string, Promise<IslandRenderResult>> | null = import.
 
 export default {
   async fetch (request: Request): Promise<Response> {
-    const event = new H3Event(request)
+    const event = createEvent(request)
     try {
       event.res.headers.set('content-type', 'application/json;charset=utf-8')
       event.res.headers.set('x-powered-by', 'Nuxt')
@@ -100,7 +102,7 @@ function prerenderIsland (event: H3Event, islandPath: string): Promise<IslandRen
     if (!('raw' in result)) {
       await islandCache!.setItem(islandPath, result)
       // without the props entry, a later request for the bare path hashes empty props and is rejected
-      await islandPropCache!.setItem(islandPath, islandPath + event.url.search + event.url.hash)
+      await islandPropCache!.setItem(islandPath, islandPath + event.url.search + urlHash(event.url))
     }
     return result
   }).finally(() => {
@@ -262,7 +264,7 @@ async function readGuardedIslandBody (event: H3Event): Promise<NuxtIslandContext
 }
 
 async function getIslandContext (event: H3Event): Promise<NuxtIslandContext> {
-  let url = event.url.pathname + event.url.search + event.url.hash
+  let url = event.url.pathname + event.url.search + urlHash(event.url)
   const islandPath = event.url.pathname
   if (import.meta.prerender && await islandPropCache!.hasItem(islandPath)) {
     // for prerender, the original request URL (with query) is rehydrated from cache

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -2,7 +2,8 @@ import { AsyncLocalStorage } from 'node:async_hooks'
 import { getPrefetchLinks, getPreloadLinks, getRequestDependencies, renderResourceHeaders } from 'vue-bundle-renderer/runtime'
 import { renderToWebStream } from 'vue/server-renderer'
 import type { ServerRequest } from 'nitro/types'
-import { H3Event, HTTPError, getQuery, writeEarlyHints } from 'nitro/h3'
+import { HTTPError, getQuery, writeEarlyHints } from 'nitro/h3'
+import type { H3Event } from 'nitro/h3'
 import { FastResponse } from 'srvx'
 import { getQuery as getURLQuery, joinURL } from 'ufo'
 import { propsToString, renderSSRHead } from '@unhead/vue/server'
@@ -40,6 +41,7 @@ import entryIds from 'nuxt/entry-ids'
 import { entryFileName } from 'nuxt/entry-chunk'
 import { iifeChunkFileName } from '#internal/streaming-iife-chunk.mjs'
 import { buildAssetsURL, publicAssetsURL } from '../utils/paths'
+import { createEvent, withBaseURL } from '../utils/base'
 
 // @ts-expect-error private property consumed by vite-generated url helpers
 globalThis.__buildAssetsURL = buildAssetsURL
@@ -66,7 +68,7 @@ const SSR_BOT_RE: RegExp = NUXT_SSR_STREAMING_BOT_RE
 
 export default {
   fetch (request: ServerRequest) {
-    const event = new H3Event(request)
+    const event = createEvent(request)
 
     if (componentIslands && event.url.pathname.startsWith('/__nuxt_island/')) {
       return import('#internal/nuxt/island-renderer.mjs').then(r => r.default.fetch(request))
@@ -162,7 +164,8 @@ async function renderRoute (event: H3Event, ssrError?: (NuxtPayload['error'] & {
   }
 
   // Get route options (for `ssr: false`, `isr`, `cache` and `noScripts`)
-  const routeOptions = getRouteRules(event.req.method, event.url.pathname).routeRules || {}
+  // nitro registers route rules under the base URL, which `createEvent` has removed
+  const routeOptions = getRouteRules(event.req.method, withBaseURL(event.url.pathname)).routeRules || {}
 
   if (!routeOptions?.ssr) {
     ssrContext.noSSR = true

--- a/packages/nitro-server/src/runtime/middleware/base-url.ts
+++ b/packages/nitro-server/src/runtime/middleware/base-url.ts
@@ -1,6 +1,8 @@
 import { HTTPError, defineEventHandler } from 'nitro/h3'
 import { useRuntimeConfig } from 'nitro/runtime-config'
 
+import { urlHash } from '../utils/base'
+
 import '../context'
 import { serverFetch } from 'nitro'
 
@@ -9,7 +11,9 @@ const baseURL = config.app.baseURL?.replace(/\/$/, '') || '/'
 const hasBaseURL = baseURL !== '/' && !/^\.(?:$|\/)/.test(baseURL)
 
 const handler: ReturnType<typeof defineEventHandler> = defineEventHandler((event) => {
-  if (!hasBaseURL) {
+  // Prerendered routes are requested (and written out) without the base URL, as the output is
+  // deployed at the base rather than served from it.
+  if (!hasBaseURL || import.meta.prerender) {
     return
   }
 
@@ -19,7 +23,7 @@ const handler: ReturnType<typeof defineEventHandler> = defineEventHandler((event
   }
 
   if (event.url.pathname === baseURL || event.url.pathname.startsWith(baseURL + '/')) {
-    const newURL = (event.url.pathname.slice(baseURL.length) || '/') + event.url.search + event.url.hash
+    const newURL = (event.url.pathname.slice(baseURL.length) || '/') + event.url.search + urlHash(event.url)
 
     return serverFetch(newURL, event.req, {
       nuxt: {

--- a/packages/nitro-server/src/runtime/utils/base.ts
+++ b/packages/nitro-server/src/runtime/utils/base.ts
@@ -1,0 +1,73 @@
+import { H3Event } from 'nitro/h3'
+import { FastURL } from 'srvx'
+import type { ServerRequest } from 'srvx'
+import { withoutTrailingSlash } from 'ufo'
+
+/**
+ * The base URL nitro registers its routes under, inlined at build time.
+ *
+ * A relative base (`./`) is resolved in the browser and never reaches a request path, and a base set
+ * at runtime is handled by the `base-url` middleware instead, so in both cases this is empty.
+ */
+const BASE_URL = /* @__PURE__ */ (() => {
+  const base = import.meta.baseURL
+  return !base || base === '/' || /^\.(?:$|\/)/.test(base) ? '' : withoutTrailingSlash(base)
+})()
+
+const BASE_URL_PREFIX = BASE_URL + '/'
+
+/**
+ * `FastURL` also accepts the parts of an already-parsed URL, which is how `srvx` itself builds the
+ * URL of an incoming request without paying for a parse, but its public types only declare the
+ * `string | URL` constructor.
+ */
+const FastURLFromParts = FastURL as unknown as new (init: { protocol: string, host: string, pathname: string, search: string }) => URL
+
+/**
+ * The fragment of a request URL, without paying for it when there is none.
+ *
+ * `srvx` builds the URL of an incoming request from its parts, leaving `hash` to be resolved by
+ * parsing the whole URL. That parse is wasted work: a fragment is never sent over the wire, so it
+ * can only appear on a URL we constructed ourselves (an internal `serverFetch`), and in that case
+ * it is present in `href`, which is always cheap to read.
+ */
+export function urlHash (url: URL): string {
+  return url.href.includes('#') ? url.hash : ''
+}
+
+/**
+ * Create the event for a Nuxt render, with the base URL removed from the request path.
+ *
+ * Nitro matches routes with the base URL still attached, whereas the app router, the page matcher
+ * and payload URLs all work with paths relative to the base.
+ */
+export function createEvent (request: ServerRequest): H3Event {
+  const event = new H3Event(request)
+  if (!BASE_URL || (event.url.pathname !== BASE_URL && !event.url.pathname.startsWith(BASE_URL_PREFIX))) {
+    return event
+  }
+
+  const url = event.url
+  const href = url.href
+  const pathname = url.pathname.slice(BASE_URL.length) || '/'
+  const hash = urlHash(url)
+  const protocolEnd = href.indexOf('://')
+  const hostEnd = protocolEnd === -1 ? -1 : href.indexOf('/', protocolEnd + 3)
+
+  event.url = hash || hostEnd === -1
+    // `FastURL` holds no fragment, so fall back to a full parse for the URLs that carry one
+    ? new URL(pathname + url.search + hash, url.origin)
+    : new FastURLFromParts({
+        protocol: href.slice(0, protocolEnd + 1),
+        host: href.slice(protocolEnd + 3, hostEnd),
+        pathname,
+        search: url.search,
+      })
+
+  return event
+}
+
+/** Prefix a base-relative path so it addresses the route nitro registered for it. */
+export function withBaseURL (path: string): string {
+  return BASE_URL + path
+}

--- a/packages/nitro-server/src/runtime/utils/renderer/app.ts
+++ b/packages/nitro-server/src/runtime/utils/renderer/app.ts
@@ -6,13 +6,14 @@ import '../../context'
 import { createHead } from '@unhead/vue/server'
 import type { NuxtPayload, NuxtSSRContext } from '#app/types'
 import { sharedPrerenderCache } from '../cache'
+import { urlHash } from '../base'
 import unheadOptions from '#internal/unhead-options.mjs'
 import { NUXT_NO_SSR, NUXT_PRERENDER_NO_SSR_ROUTES, NUXT_SHARED_DATA } from '#internal/nuxt/nitro-config.mjs'
 
 const PRERENDER_NO_SSR_ROUTES = new Set<string>(NUXT_PRERENDER_NO_SSR_ROUTES)
 
 export function createSSRContext (event: H3Event): NuxtSSRContext {
-  const url = event.url.pathname + event.url.search + event.url.hash
+  const url = event.url.pathname + event.url.search + urlHash(event.url)
   const ssrContext: NuxtSSRContext = {
     url,
     event,

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1721,6 +1721,9 @@ export interface ConfigSchema {
     /**
      * Whether to add a middleware to handle changes of base URL at runtime (has a performance overhead)
      *
+     * A base URL set in `app.baseURL` is applied when the app is built, at no runtime cost; this
+     * option is only needed to serve the app under a base URL set at runtime.
+     *
      * This option only has effect when using Nitro v3+.
      * @default false
      */

--- a/patches/nitro@3.0.260610-beta.patch
+++ b/patches/nitro@3.0.260610-beta.patch
@@ -44,6 +44,50 @@ index 76694ff062bae1ef5f6d548ae80b53dcfd8362ef..dbcec7dd4403102031410d3c7660a30d
  					code: `import {base64ToUint8Array } from "${HELPER_ID}" \n export default base64ToUint8Array("${Buffer.from(code, "binary").toString("base64")}")`,
  					map: rawAssetMap(path)
  				};
+diff --git a/dist/_chunks/nitro.mjs b/dist/_chunks/nitro.mjs
+index 6729fe35539d20c1bc01e9b6dc706aceaf8fd4d6..1c1859a048a24fe00f832c4b840b8844441a8f02 100644
+--- a/dist/_chunks/nitro.mjs
++++ b/dist/_chunks/nitro.mjs
+@@ -829,7 +829,7 @@ var Router = class {
+ 		this._router = createRouter();
+ 		this._compiled = void 0;
+ 		for (const route of routes) addRoute(this._router, route.method, this._baseURL + route.route, route.data);
+-		if (opts?.merge) mergeCatchAll(this._router);
++		if (opts?.merge) mergeCatchAll(this._router, this._baseURL);
+ 	}
+ 	hasRoutes() {
+ 		return this._routes.length > 0;
+@@ -841,9 +841,11 @@ var Router = class {
+ 		this._compiled[key] = compileRouterToString(this._router, void 0, opts);
+ 		if (this.routes.length === 1 && this.routes[0].route === "/**" && this.routes[0].method === "") {
+ 			const data = (opts?.serialize || JSON.stringify)(this.routes[0].data);
+-			let retCode = `{data,params:{"_":p.slice(1)}}`;
++			const base = this._baseURL;
++			let retCode = `{data,params:{"_":p.slice(${base.length + 1})}}`;
+ 			if (opts?.matchAll) retCode = `[${retCode}]`;
+-			this._compiled[key] = `/* @__PURE__ */ (() => {const data=${data};return ((_m, p)=>{return ${retCode};})})()`;
++			const guardCode = base ? `if(p!==${JSON.stringify(base)}&&!p.startsWith(${JSON.stringify(base + "/")})){return ${opts?.matchAll ? "[]" : "undefined"};}` : "";
++			this._compiled[key] = `/* @__PURE__ */ (() => {const data=${data};return ((_m, p)=>{${guardCode}return ${retCode};})})()`;
+ 		}
+ 		return this._compiled[key];
+ 	}
+@@ -854,8 +856,14 @@ var Router = class {
+ 		return findAllRoutes(this._router, method, path).map((route) => route.data);
+ 	}
+ };
+-function mergeCatchAll(router) {
+-	const handlers = router.root?.wildcard?.methods?.[""];
++function mergeCatchAll(router, baseURL) {
++	let node = router.root;
++	for (const segment of baseURL.split("/")) {
++		if (!segment) continue;
++		node = node?.static?.[segment];
++		if (!node) return;
++	}
++	const handlers = node?.wildcard?.methods?.[""];
+ 	if (!handlers || handlers.length < 2) return;
+ 	handlers.splice(0, handlers.length, {
+ 		...handlers[0],
 diff --git a/dist/runtime/internal/error/dev.mjs b/dist/runtime/internal/error/dev.mjs
 index 129d65476eff5b8f4486600a247a612dbdafd137..8b209fdd581bac45646de4cbed124bd78ab9b3ae 100644
 --- a/dist/runtime/internal/error/dev.mjs

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -594,7 +594,7 @@ overrides:
   vue: 3.5.42
 
 patchedDependencies:
-  nitro@3.0.260610-beta: 9273407579edf95350876c36b226440ebe6482463a007ad87c2f535365e21162
+  nitro@3.0.260610-beta: 3211111ca49ebe57bec06a9428f9129ea95059745bc08a4df231b5e35f6e0a39
   nitropack@2.13.4: 14fc1a0de87a798e71fa108469f4b19797146bf7e82bee35ba801b43c2919ab8
 
 importers:
@@ -729,7 +729,7 @@ importers:
         version: 0.49.1(supports-color@10.2.2)
       nitro:
         specifier: catalog:nitro-runtime
-        version: 3.0.260610-beta(patch_hash=9273407579edf95350876c36b226440ebe6482463a007ad87c2f535365e21162)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(lru-cache@11.5.2)(rollup@4.63.1)(vite@8.2.2)
+        version: 3.0.260610-beta(patch_hash=3211111ca49ebe57bec06a9428f9129ea95059745bc08a4df231b5e35f6e0a39)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(lru-cache@11.5.2)(rollup@4.63.1)(vite@8.2.2)
       nitropack:
         specifier: catalog:dev
         version: 2.13.4(patch_hash=14fc1a0de87a798e71fa108469f4b19797146bf7e82bee35ba801b43c2919ab8)(@parcel/watcher@2.6.0)(@rspack/core@2.2.1(@swc/helpers@0.5.23))(oxc-parser@0.147.0)(rolldown@1.2.6)(srvx@0.11.22)(supports-color@10.2.2)(vite@8.2.2)(webpack@5.110.1(cssnano@8.0.10(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
@@ -960,7 +960,7 @@ importers:
         version: 0.1.1
       nitro:
         specifier: catalog:nitro-runtime
-        version: 3.0.260610-beta(patch_hash=9273407579edf95350876c36b226440ebe6482463a007ad87c2f535365e21162)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(lru-cache@11.5.2)(rollup@4.63.1)(vite@8.2.2)
+        version: 3.0.260610-beta(patch_hash=3211111ca49ebe57bec06a9428f9129ea95059745bc08a4df231b5e35f6e0a39)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(lru-cache@11.5.2)(rollup@4.63.1)(vite@8.2.2)
       nostics:
         specifier: catalog:app-runtime
         version: 1.2.0
@@ -1036,7 +1036,7 @@ importers:
         version: '@nuxt/cli-nightly@4.0.0-20260829-080244-f02938d(@nuxt/schema@packages+schema)(jiti@2.7.0)(oxc-parser@0.147.0)(rolldown@1.2.6)'
       '@nuxt/devtools':
         specifier: catalog:build
-        version: 4.0.0-alpha.15(87c80243915d2f1fb8c790abbd8f2b49)
+        version: 4.0.0-alpha.15(a1314ca2dec8a977e332e498b391a024)
       '@nuxt/kit':
         specifier: workspace:*
         version: link:../kit
@@ -1840,6 +1840,12 @@ importers:
       nuxt:
         specifier: workspace:*
         version: link:../packages/nuxt
+
+  test/fixtures/base-url:
+    dependencies:
+      nuxt:
+        specifier: workspace:*
+        version: link:../../../packages/nuxt
 
   test/fixtures/basic:
     dependencies:
@@ -11553,22 +11559,22 @@ snapshots:
       execa: 8.0.1
       vite: 8.2.2(@types/node@24.13.3)(@vitejs/devtools@0.5.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0)
 
-  '@nuxt/devtools-kit@4.0.0-alpha.15(@nuxt/kit@packages+kit)(nitro@3.0.260610-beta(patch_hash=9273407579edf95350876c36b226440ebe6482463a007ad87c2f535365e21162)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(lru-cache@11.5.2)(rollup@4.63.1)(vite@8.2.2))(nitropack@2.13.4(patch_hash=14fc1a0de87a798e71fa108469f4b19797146bf7e82bee35ba801b43c2919ab8)(@parcel/watcher@2.6.0)(@rspack/core@2.2.1(@swc/helpers@0.5.23))(oxc-parser@0.147.0)(rolldown@1.2.6)(srvx@0.11.22)(supports-color@10.2.2)(vite@8.2.2)(webpack@5.110.1(cssnano@8.0.10(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(vite@8.2.2)':
+  '@nuxt/devtools-kit@4.0.0-alpha.15(@nuxt/kit@packages+kit)(nitro@3.0.260610-beta(patch_hash=3211111ca49ebe57bec06a9428f9129ea95059745bc08a4df231b5e35f6e0a39)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(lru-cache@11.5.2)(rollup@4.63.1)(vite@8.2.2))(nitropack@2.13.4(patch_hash=14fc1a0de87a798e71fa108469f4b19797146bf7e82bee35ba801b43c2919ab8)(@parcel/watcher@2.6.0)(@rspack/core@2.2.1(@swc/helpers@0.5.23))(oxc-parser@0.147.0)(rolldown@1.2.6)(srvx@0.11.22)(supports-color@10.2.2)(vite@8.2.2)(webpack@5.110.1(cssnano@8.0.10(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(vite@8.2.2)':
     dependencies:
       '@nuxt/kit': link:packages/kit
       nostics: 1.2.0
       tinyexec: 1.3.0
       vite: 8.2.2(@types/node@24.13.3)(@vitejs/devtools@0.5.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0)
     optionalDependencies:
-      nitro: 3.0.260610-beta(patch_hash=9273407579edf95350876c36b226440ebe6482463a007ad87c2f535365e21162)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(lru-cache@11.5.2)(rollup@4.63.1)(vite@8.2.2)
+      nitro: 3.0.260610-beta(patch_hash=3211111ca49ebe57bec06a9428f9129ea95059745bc08a4df231b5e35f6e0a39)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(lru-cache@11.5.2)(rollup@4.63.1)(vite@8.2.2)
       nitropack: 2.13.4(patch_hash=14fc1a0de87a798e71fa108469f4b19797146bf7e82bee35ba801b43c2919ab8)(@parcel/watcher@2.6.0)(@rspack/core@2.2.1(@swc/helpers@0.5.23))(oxc-parser@0.147.0)(rolldown@1.2.6)(srvx@0.11.22)(supports-color@10.2.2)(vite@8.2.2)(webpack@5.110.1(cssnano@8.0.10(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
 
-  '@nuxt/devtools@4.0.0-alpha.15(87c80243915d2f1fb8c790abbd8f2b49)':
+  '@nuxt/devtools@4.0.0-alpha.15(a1314ca2dec8a977e332e498b391a024)':
     dependencies:
       '@devframes/hub': 0.9.5(crossws@0.4.10(srvx@0.11.22))(devframe@0.9.5(cac@7.0.0)(srvx@0.11.22))
       '@devframes/plugin-code-server': 0.9.5(@devframes/hub-ui@0.9.5(@devframes/hub@0.9.5(crossws@0.4.10(srvx@0.11.22))(devframe@0.9.5(cac@7.0.0)(srvx@0.11.22)))(@devframes/json-render@0.9.5(@devframes/hub@0.9.5(crossws@0.4.10(srvx@0.11.22))(devframe@0.9.5(cac@7.0.0)(srvx@0.11.22)))(devframe@0.9.5(cac@7.0.0)(srvx@0.11.22)))(devframe@0.9.5(cac@7.0.0)(srvx@0.11.22)))(@devframes/hub@0.9.5(crossws@0.4.10(srvx@0.11.22))(devframe@0.9.5(cac@7.0.0)(srvx@0.11.22)))(devframe@0.9.5(cac@7.0.0)(srvx@0.11.22))(vite@8.2.2)
       '@devframes/plugin-data-inspector': 0.9.5(devframe@0.9.5(cac@7.0.0)(srvx@0.11.22))(vite@8.2.2)
-      '@nuxt/devtools-kit': 4.0.0-alpha.15(@nuxt/kit@packages+kit)(nitro@3.0.260610-beta(patch_hash=9273407579edf95350876c36b226440ebe6482463a007ad87c2f535365e21162)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(lru-cache@11.5.2)(rollup@4.63.1)(vite@8.2.2))(nitropack@2.13.4(patch_hash=14fc1a0de87a798e71fa108469f4b19797146bf7e82bee35ba801b43c2919ab8)(@parcel/watcher@2.6.0)(@rspack/core@2.2.1(@swc/helpers@0.5.23))(oxc-parser@0.147.0)(rolldown@1.2.6)(srvx@0.11.22)(supports-color@10.2.2)(vite@8.2.2)(webpack@5.110.1(cssnano@8.0.10(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(vite@8.2.2)
+      '@nuxt/devtools-kit': 4.0.0-alpha.15(@nuxt/kit@packages+kit)(nitro@3.0.260610-beta(patch_hash=3211111ca49ebe57bec06a9428f9129ea95059745bc08a4df231b5e35f6e0a39)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(lru-cache@11.5.2)(rollup@4.63.1)(vite@8.2.2))(nitropack@2.13.4(patch_hash=14fc1a0de87a798e71fa108469f4b19797146bf7e82bee35ba801b43c2919ab8)(@parcel/watcher@2.6.0)(@rspack/core@2.2.1(@swc/helpers@0.5.23))(oxc-parser@0.147.0)(rolldown@1.2.6)(srvx@0.11.22)(supports-color@10.2.2)(vite@8.2.2)(webpack@5.110.1(cssnano@8.0.10(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(vite@8.2.2)
       '@nuxt/kit': link:packages/kit
       '@vitejs/devtools': 0.5.2(@devframes/json-render@0.9.5(@devframes/hub@0.9.5(crossws@0.4.10(srvx@0.11.22))(devframe@0.9.5(cac@7.0.0)(srvx@0.11.22)))(devframe@0.9.5(cac@7.0.0)(srvx@0.11.22)))(crossws@0.4.10(srvx@0.11.22))(srvx@0.11.22)(vite@8.2.2)
       '@vitejs/devtools-kit': 0.5.2(cac@7.0.0)(crossws@0.4.10(srvx@0.11.22))(srvx@0.11.22)(vite@8.2.2)
@@ -11590,7 +11596,7 @@ snapshots:
       vite: 8.2.2(@types/node@24.13.3)(@vitejs/devtools@0.5.2)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0)
       vite-plugin-vue-tracer: 1.5.0(vite@8.2.2)(vue@3.5.42(typescript@6.0.3))
     optionalDependencies:
-      nitro: 3.0.260610-beta(patch_hash=9273407579edf95350876c36b226440ebe6482463a007ad87c2f535365e21162)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(lru-cache@11.5.2)(rollup@4.63.1)(vite@8.2.2)
+      nitro: 3.0.260610-beta(patch_hash=3211111ca49ebe57bec06a9428f9129ea95059745bc08a4df231b5e35f6e0a39)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(lru-cache@11.5.2)(rollup@4.63.1)(vite@8.2.2)
       nitropack: 2.13.4(patch_hash=14fc1a0de87a798e71fa108469f4b19797146bf7e82bee35ba801b43c2919ab8)(@parcel/watcher@2.6.0)(@rspack/core@2.2.1(@swc/helpers@0.5.23))(oxc-parser@0.147.0)(rolldown@1.2.6)(srvx@0.11.22)(supports-color@10.2.2)(vite@8.2.2)(webpack@5.110.1(cssnano@8.0.10(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -16596,7 +16602,7 @@ snapshots:
 
   nf3@0.3.23: {}
 
-  nitro@3.0.260610-beta(patch_hash=9273407579edf95350876c36b226440ebe6482463a007ad87c2f535365e21162)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(lru-cache@11.5.2)(rollup@4.63.1)(vite@8.2.2):
+  nitro@3.0.260610-beta(patch_hash=3211111ca49ebe57bec06a9428f9129ea95059745bc08a4df231b5e35f6e0a39)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(lru-cache@11.5.2)(rollup@4.63.1)(vite@8.2.2):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.10(srvx@0.11.22)

--- a/test/base-url.test.ts
+++ b/test/base-url.test.ts
@@ -1,0 +1,112 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { isWindows } from 'std-env'
+import { $fetch, fetch, getBrowser, setup, startServer, url } from '@nuxt/test-utils/e2e'
+
+import { isWebpack, runsOncePerBuilderInMatrix } from './matrix'
+
+// The axis that matters for base URL routing is the nitro pipeline (`nitroViteEnvironment`), which
+// decides whether the SSR renderer is the only route registered. Base URLs with webpack/rspack are
+// covered by `dynamic-paths`.
+const runs = runsOncePerBuilderInMatrix && !isWebpack
+
+if (runs) {
+  await setup({
+    rootDir: fileURLToPath(new URL('./fixtures/base-url', import.meta.url)),
+    dev: false,
+    server: true,
+    browser: true,
+    setupTimeout: (isWindows ? 360 : 120) * 1000,
+  })
+}
+
+describe.skipIf(!runs)('base URL set at build time', () => {
+  it('should server-render pages under the base URL', async () => {
+    const html = await $fetch<string>('/foo/')
+    expect(html).toContain('data-testid="path">/<')
+    expect(html).toContain('href="/foo/other"')
+
+    const other = await $fetch<string>('/foo/other')
+    expect(other).toContain('other page')
+  })
+
+  it('should not serve pages outside the base URL', async () => {
+    expect((await fetch('/other', { redirect: 'manual' })).status).toBe(302)
+    expect((await fetch('/foo/nonexistent')).status).toBe(404)
+  })
+
+  it('should serve assets under the base URL', async () => {
+    const html = await $fetch<string>('/foo/')
+    const urls = Array.from(html.matchAll(/(?:href|src)="([^"]+)"/g), m => m[1]!).filter(url => !url.startsWith('data:'))
+    expect(urls.length).toBeGreaterThan(0)
+    for (const url of urls) {
+      expect(url).toMatch(/^\/foo\//)
+      expect((await fetch(url)).status).toBe(200)
+    }
+  })
+
+  it('should apply route rules to paths relative to the base URL', async () => {
+    expect(await $fetch<string>('/foo/no-ssr')).toContain('data-ssr="false"')
+  })
+
+  it('should prerender routes relative to the base URL', async () => {
+    const html = await $fetch<string>('/foo/prerendered')
+    expect(html).toContain('prerendered')
+    expect(html).toContain('"prerenderedAt"')
+  })
+
+  it('should render the error page under the base URL', async () => {
+    const res = await fetch('/foo/nonexistent', { headers: { accept: 'text/html' } })
+    expect(res.status).toBe(404)
+    expect(res.headers.get('content-type')).toContain('text/html')
+    expect(await res.text()).toContain('<div id="__nuxt">')
+  })
+
+  it('should hydrate and navigate on the client under the base URL', async () => {
+    const browser = await getBrowser()
+    const page = await browser.newPage({})
+    const errors: string[] = []
+    const requests: string[] = []
+
+    page.on('pageerror', error => errors.push(error.message))
+    page.on('console', (message) => {
+      if (message.type() === 'error' || message.type() === 'warning') {
+        errors.push(message.text())
+      }
+    })
+    page.on('request', request => requests.push(request.url().replace(url('/'), '/')))
+
+    await page.goto(url('/foo/'))
+    await page.waitForFunction(() => !!window.useNuxtApp?.() && !window.useNuxtApp!().isHydrating)
+    expect(await page.getByTestId('path').textContent()).toContain('/')
+
+    await page.getByRole('link', { name: 'other' }).click()
+    await page.waitForFunction(() => window.location.pathname === '/foo/other')
+    expect(await page.getByTestId('other').textContent()).toContain('other page')
+
+    await page.goBack()
+    await page.getByRole('link', { name: 'prerendered' }).click()
+    await page.waitForFunction(() => window.location.pathname === '/foo/prerendered')
+    expect(await page.getByTestId('prerendered').textContent()).toContain('prerendered')
+    expect(requests.some(request => request.startsWith('/foo/prerendered/_payload.json'))).toBe(true)
+
+    expect(errors).toEqual([])
+    expect(requests.filter(request => !request.startsWith('/foo/'))).toEqual([])
+
+    await page.close()
+  })
+
+  it('should keep serving the build-time base URL when it is overridden at runtime', async () => {
+    await startServer({
+      env: {
+        NUXT_APP_BASE_URL: '/bar/',
+      },
+    })
+
+    // `experimental.runtimeBaseURL` is needed to move the app at runtime
+    expect((await fetch('/bar/', { redirect: 'manual' })).status).toBe(302)
+    expect(await $fetch<string>('/foo/')).toContain('data-testid="path">/<')
+
+    await startServer()
+  })
+})

--- a/test/fixtures/base-url/app/app.vue
+++ b/test/fixtures/base-url/app/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <NuxtPage />
+</template>

--- a/test/fixtures/base-url/app/pages/index.vue
+++ b/test/fixtures/base-url/app/pages/index.vue
@@ -1,0 +1,9 @@
+<template>
+  <div>
+    <div data-testid="path">
+      {{ $route.path }}
+    </div>
+    <NuxtLink to="/other">other</NuxtLink>
+    <NuxtLink to="/prerendered">prerendered</NuxtLink>
+  </div>
+</template>

--- a/test/fixtures/base-url/app/pages/no-ssr.vue
+++ b/test/fixtures/base-url/app/pages/no-ssr.vue
@@ -1,0 +1,5 @@
+<template>
+  <div data-testid="no-ssr">
+    no ssr
+  </div>
+</template>

--- a/test/fixtures/base-url/app/pages/other.vue
+++ b/test/fixtures/base-url/app/pages/other.vue
@@ -1,0 +1,5 @@
+<template>
+  <div data-testid="other">
+    other page
+  </div>
+</template>

--- a/test/fixtures/base-url/app/pages/prerendered.vue
+++ b/test/fixtures/base-url/app/pages/prerendered.vue
@@ -1,0 +1,5 @@
+<template>
+  <div data-testid="prerendered">
+    prerendered
+  </div>
+</template>

--- a/test/fixtures/base-url/nuxt.config.ts
+++ b/test/fixtures/base-url/nuxt.config.ts
@@ -1,0 +1,11 @@
+import { withMatrix } from '../../matrix.ts'
+
+export default withMatrix({
+  app: {
+    baseURL: '/foo/',
+  },
+  routeRules: {
+    '/no-ssr': { ssr: false },
+    '/prerendered': { prerender: true },
+  },
+})

--- a/test/fixtures/base-url/package.json
+++ b/test/fixtures/base-url/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "type": "module",
+  "name": "fixture-base-url",
+  "dependencies": {
+    "nuxt": "workspace:*"
+  },
+  "engines": {
+    "node": "^22.19.0 || ^24.11.0 || >=26.0.0"
+  }
+}

--- a/test/fixtures/base-url/tsconfig.json
+++ b/test/fixtures/base-url/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./.nuxt/tsconfig.app.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.server.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.node.json"
+    }
+  ]
+}


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

currently handlers get paths with `baseURL` if one is provided. this is a change from nitropack v2, and we only had handling for this with `experimental.runtimeBaseURL`.

this adds handling for _build-time_ URLs to the nuxt end of the picture, though nitrojs/nitro#4561 also needs to be merged for `baseURL` to actually work (it addresses a regression from nitrojs/nitro#3716)