### PR TITLE
chore: bump @flakiness/vitest to 1.9.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,8 +288,8 @@ catalogs:
       specifier: 2.0.2
       version: 2.0.2
     '@flakiness/vitest':
-      specifier: 1.9.1
-      version: 1.9.1
+      specifier: 1.9.2
+      version: 1.9.2
     '@nuxt/eslint-config':
       specifier: 1.17.0
       version: 1.17.0
@@ -618,7 +618,7 @@ importers:
         version: 2.0.2
       '@flakiness/vitest':
         specifier: catalog:dev
-        version: 1.9.1
+        version: 1.9.2
       '@nuxt/cli':
         specifier: catalog:build
         version: '@nuxt/cli-nightly@4.0.0-20260825-093611-2e29f1f(@nuxt/schema@packages+schema)(jiti@2.7.0)(oxc-parser@0.146.0)(rolldown@1.2.5)'
@@ -2807,8 +2807,8 @@ packages:
     engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
 
-  '@flakiness/vitest@1.9.1':
-    resolution: {integrity: sha512-BQBekpxKD8Be58M+mPmtvh4FGDBJzStzPBJWW2+QDC6ax2ZqKxRTE2O/wHjeZERyOs5Et9mgaXjL51AY1NSoVg==}
+  '@flakiness/vitest@1.9.2':
+    resolution: {integrity: sha512-dZwXW0vzjqNCiH056ADChmzOloHW6iKWIwJRnl3GGi8PdZRB3k+N9zLgXIhiaReXL+pC2spIsywh8qt1AYiHyQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
   '@floating-ui/core@1.8.0':
@@ -11156,7 +11156,7 @@ snapshots:
 
   '@flakiness/playwright@2.0.2': {}
 
-  '@flakiness/vitest@1.9.1': {}
+  '@flakiness/vitest@1.9.2': {}
 
   '@floating-ui/core@1.8.0':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -49,6 +49,7 @@ minimumReleaseAgeExclude:
   - impound@1.2.0
   - vue
   - '@vue/*'
+  - '@flakiness/vitest@1.9.2'
 
 catalogs:
   # imported in the nuxt app runtime (packages/nuxt/src/app, head/runtime, pages/runtime)
@@ -207,7 +208,7 @@ catalogs:
     '@codspeed/vitest-plugin': 5.7.1
     '@eslint/markdown': 8.0.3
     '@flakiness/playwright': 2.0.2
-    '@flakiness/vitest': 1.9.1
+    '@flakiness/vitest': 1.9.2
     '@nuxt/eslint-config': 1.17.0
     '@nuxt/scripts': 1.3.8
     '@nuxt/test-utils': 4.1.0


### PR DESCRIPTION
Vitest has a bug that makes it retry tests that are marked with `.fails`: https://github.com/vitest-dev/vitest/issues/11068

The new `@flakiness/vitest` reporter works around this bug, so that test flakiness is properly computed on the dashboard.

NOTE: the @flakiness/vitest@1.9.2 has been just published, so it's marked as an exclusion to the "min release age" rule.

