### PR TITLE
fix(nuxt): validate component export name before code generation

### DIFF
--- a/packages/kit/src/diagnostics/build.ts
+++ b/packages/kit/src/diagnostics/build.ts
@@ -111,5 +111,10 @@ export const buildDiagnostics = /* #__PURE__ */ defineDiagnostics({
       fix: 'Remove `experimental.watcher` from your `nuxt.config`, or use a builder that supports its own watcher.',
       docs: false,
     },
+    NUXT_B1021: {
+      why: (p: { export: string }) => `Component export name \`${p.export}\` is not a valid JavaScript identifier.`,
+      fix: 'If you are a module author, ensure the `export` you register for a component is a valid identifier. Otherwise, please report this issue.',
+      docs: false,
+    },
   },
 })

--- a/packages/nuxt/src/components/plugins/transform.ts
+++ b/packages/nuxt/src/components/plugins/transform.ts
@@ -12,6 +12,7 @@ import type { getComponentsT } from '../module.ts'
 import type { Nuxt } from 'nuxt/schema'
 
 const COMPONENT_QUERY_RE = /[?&]nuxt_component=/
+const IDENTIFIER_RE = /^[$_\p{ID_Start}][$\u200C\u200D\p{ID_Continue}]*$/u
 
 interface TransformPluginOptions {
   getComponents: getComponentsT
@@ -77,6 +78,9 @@ export function TransformPlugin (nuxt: Nuxt, options: TransformPluginOptions) {
           const mode = params.get('nuxt_component')
           const bare = id.replace(/\?.*/, '')
           const componentExport = params.get('nuxt_component_export') || 'default'
+          if (!IDENTIFIER_RE.test(componentExport)) {
+            throw buildDiagnostics.NUXT_B1021({ export: componentExport })
+          }
           const exportWording = componentExport === 'default' ? 'export default' : `export const ${componentExport} =`
           if (mode === 'async') {
             return {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

small fix to improve dx - otherwise this would error later on, confusingly...