### PR TITLE
fix(kit): forward `configFile` and `rcFile` to config loader

### DIFF
--- a/packages/kit/src/loader/config.ts
+++ b/packages/kit/src/loader/config.ts
@@ -74,6 +74,21 @@ export interface LoadNuxtConfigOptions {
   /** Directory to load `nuxt.config` from. @default process.cwd() */
   cwd?: string
   /**
+   * Name of the config file to load, without an extension.
+   * @default 'nuxt.config'
+   */
+  configFile?: string
+  /**
+   * Name of the `.rc` file to load alongside the config file, or `false` to load none.
+   * @default '.nuxtrc'
+   */
+  rcFile?: string | false
+  /**
+   * Also load the user-level and workspace-level `.nuxtrc` files.
+   * @default true
+   */
+  globalRc?: boolean
+  /**
    * Configuration applied above every layer, including the root project's own `nuxt.config`.
    * Excluded from the `rawConfig` snapshot passed to `onConfigResolved`.
    */
@@ -223,6 +238,7 @@ const merger = createDefu((obj, key, value) => {
 
 export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<NuxtOptions> {
   const rootCwd = resolve(opts.cwd || process.cwd())
+  const configFileName = opts.configFile || 'nuxt.config'
 
   // Automatically detect and import layers from `~~/layers/` directory
   const localLayers = (await glob('layers/*', {
@@ -266,7 +282,7 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
   // Looking for jiti can mean offering to install it, so that is reserved for a failure jiti is
   // expected to fix; an ordinary mistake in a config file must never lead to a dependency prompt
   const getJiti = async (install: boolean) => {
-    jitiPromise ??= loadJiti({ rootDir: rootCwd, install }).then(mod => mod?.createJiti(join(rootCwd, 'nuxt.config'), {
+    jitiPromise ??= loadJiti({ rootDir: rootCwd, install }).then(mod => mod?.createJiti(join(rootCwd, configFileName), {
       interopDefault: true,
       moduleCache: false,
       extensions: [...CONFIG_EXTENSIONS],
@@ -339,10 +355,10 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
   const loadRootConfig = () => withDefineNuxtConfig(
     () => loadConfig<NuxtConfig>({
       name: 'nuxt',
-      configFile: 'nuxt.config',
-      rcFile: '.nuxtrc',
+      configFile: configFileName,
+      rcFile: opts.rcFile ?? '.nuxtrc',
       extend: { extendKey: ['theme', '_extends', 'extends'] },
-      globalRc: true,
+      globalRc: opts.globalRc ?? true,
       merger: merger as (...sources: Array<NuxtConfig | null | undefined>) => NuxtConfig,
       cwd: opts.cwd,
       overrides: opts.overrides,
@@ -388,7 +404,7 @@ export async function loadNuxtConfig (opts: LoadNuxtConfigOptions): Promise<Nuxt
           const layer = await loadConfig<NuxtConfig>({
             cwd: aliased,
             name: 'nuxt',
-            configFile: 'nuxt.config',
+            configFile: configFileName,
             rcFile: false,
             extend: false,
             // Reuse the current load's importer so a nested layer is not loaded through a


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

in #35936 we stripped back our public API by no longer spreading `...opts`, which was a breaking change if anyone wanted to pass a custom config file.

this reverts that change by adding back options that were previously respected