### PR TITLE
fix(schema): keep `nuxt/schema` augmentation bridge out of bundled types

### DIFF
--- a/packages/nuxt/src/app/types.ts
+++ b/packages/nuxt/src/app/types.ts
@@ -8,7 +8,7 @@ import type { SSRHeadPayload } from '@unhead/vue/server'
 import type { SSRContext, createRenderer } from 'vue-bundle-renderer/runtime'
 import type { H3Event, HTTPError } from '@nuxt/nitro-server/h3'
 import type { Hookable } from 'hookable'
-import type { RuntimeConfig } from 'nuxt/schema'
+import type { RuntimeConfig } from '@nuxt/schema'
 
 type HookResult = Promise<void> | void
 

--- a/scripts/check-public-api.ts
+++ b/scripts/check-public-api.ts
@@ -103,6 +103,14 @@ const typeImportPatterns = [
 /** A bare import with no bindings, which still pulls in the package's augmentations. */
 const augmentationPatterns = [/^\s*import\s+["']([^"']+)["'];?$/gm]
 
+/**
+ * An interface whose base type collapsed onto its own name, which TypeScript rejects with
+ * `TS2310`. This happens when a file that augments a module through an import alias
+ * (`interface X extends _X {}`) is inlined into the bundle that declares `X`, and the alias is
+ * rewritten to the bare local name.
+ */
+const selfReferentialBase = /\binterface\s+(\w+)\s+extends\s+\1\s*[<{]/g
+
 const root = new URL('../', import.meta.url)
 
 function specifiersMatching (contents: string, patterns: RegExp[]) {
@@ -131,6 +139,16 @@ for (const [file, entrypoint] of Object.entries(entrypoints)) {
   const found = {
     types: specifiersMatching(contents, typeImportPatterns),
     augmentations: specifiersMatching(contents, augmentationPatterns),
+  }
+
+  const selfReferential = [...new Set([...contents.matchAll(selfReferentialBase)].map(match => match[1]!))].sort()
+  if (selfReferential.length) {
+    failed = true
+    console.error(`[check-public-api] ${file} declares interfaces that recursively reference themselves as a base type:`)
+    for (const name of selfReferential) {
+      console.error(`  - ${name}`)
+    }
+    console.error('Keep the augmenting file out of the bundle, or reference the base type in a way that survives inlining.')
   }
 
   for (const kind of ['types', 'augmentations'] as const) {

--- a/test/fixtures/basic-types/app/app-types.ts
+++ b/test/fixtures/basic-types/app/app-types.ts
@@ -8,7 +8,7 @@ import type { AppConfig, AppConfigInput, NuxtConfig as NuxtConfigFromAt, NuxtHoo
 import type { AppConfigInput as AppConfigInputFromNuxt, NuxtConfig as NuxtConfigFromNuxt, NuxtHooks as NuxtHooksFromNuxt } from 'nuxt/schema'
 import { defineNuxtConfig } from 'nuxt/config'
 import { callWithNuxt, isVue3 } from '#app'
-import type { NuxtError, PageMeta } from '#app'
+import type { NuxtError, NuxtSSRContext, PageMeta } from '#app'
 import type { NavigateToOptions } from '#app/composables/router'
 import { LazyWithTypes, NuxtIsland, NuxtLayout, NuxtLink, NuxtPage, ServerComponent, WithTypes } from '#components'
 import type { IslandComponent, LazyComponent } from '#components'
@@ -475,6 +475,13 @@ describe('runtimeConfig', () => {
     expectTypeOf(injectedConfig.privateConfig).toEqualTypeOf<string>()
     expectTypeOf(injectedConfig.public.ids).toEqualTypeOf<(1 | 2 | 3)[]>()
     expectTypeOf(injectedConfig.unknown).toEqualTypeOf<unknown>()
+  })
+
+  it('reaches the payload and SSR context types', () => {
+    const payloadConfig = useNuxtApp().payload.config!
+    expectTypeOf(payloadConfig.public.ids).toEqualTypeOf<(1 | 2 | 3)[]>()
+    expectTypeOf(payloadConfig.public.testConfig).toEqualTypeOf<number>()
+    expectTypeOf<NonNullable<NuxtSSRContext['runtimeConfig']>['public']['ids']>().toEqualTypeOf<(1 | 2 | 3)[]>()
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

spotted in ecosystem ci. this crept in with #35179 + #35605.

this strips out a self-referential interface and adds some tests to ensure 1) schema augmentation doesn't break, and 2) we don't re-introduce something like this into schema built types in future