### PR TITLE
fix(nuxt): key dynamic meta by file path + nuxt instance

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 
 import { normalize, relative } from 'pathe'
 import { joinURL } from 'ufo'
-import { getLayerDirectories, resolveFiles, resolvePath, useNuxt } from '@nuxt/kit'
+import { getLayerDirectories, resolveFiles, resolvePath, tryUseNuxt, useNuxt } from '@nuxt/kit'
 import { pageDiagnostics } from '@nuxt/kit/internal'
 import { genArrayFromRaw, genDynamicImport, genImport, genSafeVariableName } from 'knitwork'
 import { filename } from 'pathe/utils'
@@ -16,7 +16,7 @@ import type { BuildTreeOptions, InputFile, RouteTree, VueRouterEmitOptions } fro
 
 import { getLoader } from '../core/utils/index.ts'
 import { linkToAlias, logger, offsetToPosition, toArray } from '../utils.ts'
-import type { NuxtPage } from 'nuxt/schema'
+import type { Nuxt, NuxtPage } from 'nuxt/schema'
 
 // ---------------------------------------------------------------------------
 // PagesContext — persistent route tree for incremental dev-mode updates
@@ -148,6 +148,7 @@ export async function augmentAndResolve (pages: NuxtPage[], trackedFiles: Set<st
     extractSerializable: shouldExtractSerializablePageMeta(nuxt),
     fullyResolvedPaths: trackedFiles,
     originalPagePaths,
+    nuxt,
   }
   if (shouldAugment === 'after-resolve') {
     await nuxt.callHook('pages:extend', pages)
@@ -171,18 +172,25 @@ interface AugmentPagesContext {
   extraExtractionKeys?: Set<string>
   extractSerializable?: boolean
   originalPagePaths?: WeakMap<NuxtPage, string>
+  /** Owner of the dynamic page meta recorded during augmentation. */
+  nuxt?: Nuxt | null
 }
 
 export async function augmentPages (routes: NuxtPage[], vfs: Record<string, string>, ctx: AugmentPagesContext = {}) {
   ctx.augmentedPages ??= new Set()
+  const dynamicPageMeta = dynamicPageMetaCache(ctx.nuxt ?? tryUseNuxt())
   for (const route of routes) {
     if (route.file && !ctx.pagesToSkip?.has(route.file)) {
       const fileContent = vfs[route.file] ?? fs.readFileSync(ctx.fullyResolvedPaths?.has(route.file) ? route.file : await resolvePath(route.file), 'utf-8')
       const routeMeta = getRouteMeta(fileContent, route.file, ctx.extraExtractionKeys, { extractSerializable: ctx.extractSerializable })
+      const dynamic = getDynamicMetaKeys(route.file, { extractSerializable: ctx.extractSerializable })
+      if (dynamic.size) {
+        dynamicPageMeta.set(normalize(route.file), dynamic)
+      } else {
+        dynamicPageMeta.delete(normalize(route.file))
+      }
       if (route.meta) {
-        const dynamic = [...getDynamicMeta(routeMeta.meta), ...getDynamicMeta(route.meta)]
         routeMeta.meta = defu({}, routeMeta.meta, route.meta)
-        addDynamicMeta(routeMeta.meta, dynamic)
       }
       if (route.rules) {
         routeMeta.rules = defu({}, routeMeta.rules, route.rules)
@@ -235,24 +243,45 @@ const PAGE_META_MACRO_NAMES = new Set(['definePageMeta', 'defineRouteRules'])
 // is what actually identifies calls.
 const HAS_PAGE_MACRO_RE = new RegExp(`\\b(?:${[...PAGE_META_MACRO_NAMES].join('|')})\\b`)
 export const defaultExtractionKeys = ['name', 'path', 'props', 'alias', 'redirect', 'middleware'] as const
-/**
- * Marks which `definePageMeta` keys could not be statically extracted and must come from the
- * runtime macro module. A symbol keeps it out of `JSON.stringify`/`Object.keys` snapshots taken by
- * modules that observe `page.meta`, at the cost of being dropped by key-enumerating helpers
- * (`defu`, `klona`), so it is re-attached explicitly wherever meta is merged or cloned.
- */
-const DYNAMIC_META_KEY = Symbol.for('nuxt:dynamic-page-meta')
+const EMPTY_DYNAMIC_META: ReadonlySet<string> = new Set<string>()
 
-function getDynamicMeta (meta: Record<PropertyKey, any> | undefined): Set<string> {
-  const dynamic = meta?.[DYNAMIC_META_KEY] as Set<string> | undefined
-  return dynamic ?? new Set<string>()
+/**
+ * Which `definePageMeta` keys could not be statically extracted and must come from the runtime
+ * macro module, recorded per nuxt instance and keyed by page file.
+ *
+ * A page's dynamic keys are a pure function of its file, because extraction parses that file's
+ * contents and nothing else, and `page.file` is the one field that survives the page being
+ * rebuilt: modules in `pages:extend`/`pages:resolved` clone, merge and delete `page.meta` and
+ * replace the page objects wholesale (route localization emits a shallow copy per locale), while a
+ * page that loses its file loses its macro module too, which fails loudly instead of silently.
+ *
+ * Keyed by path with the latest extraction winning rather than by content, because
+ * `normalizeRoutes` has no contents to hash and augmentation always re-runs for a changed file
+ * before routes are generated, so a stale set cannot be observed. Scoped per instance because
+ * `extraPageMetaExtractionKeys` can differ between two instances sharing an absolute path.
+ */
+const dynamicPageMetaCaches = new WeakMap<object, Map<string, ReadonlySet<string>>>()
+// Used when pages are augmented outside of a nuxt instance, so that both sides agree on a cache.
+const detachedDynamicPageMeta = new Map<string, ReadonlySet<string>>()
+
+export function dynamicPageMetaCache (nuxt: Nuxt | null | undefined = tryUseNuxt()): Map<string, ReadonlySet<string>> {
+  if (!nuxt) {
+    return detachedDynamicPageMeta
+  }
+  let cache = dynamicPageMetaCaches.get(nuxt)
+  if (!cache) {
+    cache = new Map()
+    dynamicPageMetaCaches.set(nuxt, cache)
+  }
+  return cache
 }
 
-function addDynamicMeta (meta: Record<PropertyKey, any> | undefined, keys: Iterable<string>) {
-  const dynamic = new Set(keys)
-  if (meta && dynamic.size) {
-    meta[DYNAMIC_META_KEY] = dynamic
-  }
+/**
+ * Keys of `page` that `definePageMeta` sets at runtime rather than at build time. A page without a
+ * file has no macro module to defer to, so it never needs these and no fallback is required.
+ */
+export function getDynamicPageMeta (page: NuxtPage, cache = dynamicPageMetaCache()): ReadonlySet<string> {
+  return (page.file ? cache.get(normalize(page.file)) : undefined) ?? EMPTY_DYNAMIC_META
 }
 
 type StaticExpressionWrapper = ESTree.Node & { expression: ESTree.Node }
@@ -374,19 +403,35 @@ export function classifyPageMetaProperty (property: ESTree.ObjectPropertyKind, e
 const SERIALIZABLE_CACHE_SUFFIX = '\0serializable'
 const pageContentsCache: Record<string, string> = {}
 const extractCache: Record<string, Partial<Record<keyof NuxtPage, any>>> = {}
+const dynamicMetaCache: Record<string, Set<string>> = {}
+
+// The extracted metadata differs between the two extraction modes, but the file contents do not.
+function getExtractCacheKey (absolutePath: string, options: ClassifyPageMetaOptions) {
+  return options.extractSerializable ? absolutePath + SERIALIZABLE_CACHE_SUFFIX : absolutePath
+}
+
+/**
+ * Keys a page file's `definePageMeta` call sets at runtime rather than at build time. Derived
+ * purely from file contents, so it is cached alongside the extracted metadata for that file.
+ */
+export function getDynamicMetaKeys (absolutePath: string, options: ClassifyPageMetaOptions = {}): ReadonlySet<string> {
+  return dynamicMetaCache[getExtractCacheKey(absolutePath, options)] ?? EMPTY_DYNAMIC_META
+}
+
 export function getRouteMeta (contents: string, absolutePath: string, extraExtractionKeys: Set<string> = new Set(), options: ClassifyPageMetaOptions = {}): Partial<Record<keyof NuxtPage, any>> {
-  // The extracted metadata differs between the two extraction modes, but the file contents do not.
-  const cacheKey = options.extractSerializable ? absolutePath + SERIALIZABLE_CACHE_SUFFIX : absolutePath
+  const cacheKey = getExtractCacheKey(absolutePath, options)
 
   // set/update pageContentsCache, invalidate extractCache on cache mismatch
   if (!(absolutePath in pageContentsCache) || pageContentsCache[absolutePath] !== contents) {
     pageContentsCache[absolutePath] = contents
     delete extractCache[absolutePath]
     delete extractCache[absolutePath + SERIALIZABLE_CACHE_SUFFIX]
+    delete dynamicMetaCache[absolutePath]
+    delete dynamicMetaCache[absolutePath + SERIALIZABLE_CACHE_SUFFIX]
   }
 
   if (cacheKey in extractCache && extractCache[cacheKey]) {
-    return cloneExtractedData(extractCache[cacheKey])
+    return klona(extractCache[cacheKey])
   }
 
   const loader = getLoader(absolutePath)
@@ -516,18 +561,11 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
   }
 
   if (dynamicProperties.size) {
-    extractedData.meta ??= {}
-    addDynamicMeta(extractedData.meta, dynamicProperties)
+    dynamicMetaCache[cacheKey] = dynamicProperties
   }
 
   extractCache[cacheKey] = extractedData
-  return cloneExtractedData(extractedData)
-}
-
-function cloneExtractedData (data: Partial<Record<keyof NuxtPage, any>>) {
-  const cloned = klona(data)
-  addDynamicMeta(cloned.meta, getDynamicMeta(data.meta))
-  return cloned
+  return klona(extractedData)
 }
 
 function serializeRouteValue (value: any, skipSerialisation = false) {
@@ -597,10 +635,11 @@ function normalizeComponentWithName (page: NuxtPage, isSyncImport: boolean | und
 
 export function normalizeRoutes (routes: NuxtPage[], metaImports: Set<string> = new Set(), options: NormalizeRoutesOptions): { imports: Set<string>, routes: string } {
   const nuxt = useNuxt()
+  const dynamicPageMeta = dynamicPageMetaCache(nuxt)
   return {
     imports: metaImports,
     routes: genArrayFromRaw(routes.map((page) => {
-      const markedDynamic = getDynamicMeta(page.meta)
+      const markedDynamic = getDynamicPageMeta(page, dynamicPageMeta)
       const metaFiltered: Record<string, any> = {}
       let skipMeta = true
       for (const key in page.meta || {}) {

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -183,7 +183,7 @@ export async function augmentPages (routes: NuxtPage[], vfs: Record<string, stri
     if (route.file && !ctx.pagesToSkip?.has(route.file)) {
       const fileContent = vfs[route.file] ?? fs.readFileSync(ctx.fullyResolvedPaths?.has(route.file) ? route.file : await resolvePath(route.file), 'utf-8')
       const routeMeta = getRouteMeta(fileContent, route.file, ctx.extraExtractionKeys, { extractSerializable: ctx.extractSerializable })
-      const dynamic = getDynamicMetaKeys(route.file, { extractSerializable: ctx.extractSerializable })
+      const dynamic = getDynamicMetaKeys(route.file, ctx.extraExtractionKeys, { extractSerializable: ctx.extractSerializable })
       if (dynamic.size) {
         dynamicPageMeta.set(normalize(route.file), dynamic)
       } else {
@@ -400,44 +400,54 @@ export function classifyPageMetaProperty (property: ESTree.ObjectPropertyKind, e
   return isExtractionKey ? { kind: 'dynamic', key } : { kind: 'runtime' }
 }
 
-const SERIALIZABLE_CACHE_SUFFIX = '\0serializable'
 const pageContentsCache: Record<string, string> = {}
-const extractCache: Record<string, Partial<Record<keyof NuxtPage, any>>> = {}
-const dynamicMetaCache: Record<string, Set<string>> = {}
+// Keyed by file path, then by extraction variant. Two nuxt instances in one process can extract
+// the same absolute path with different `extraPageMetaExtractionKeys` or a different serializable
+// mode, and get legitimately different results from identical contents, so the variant has to be
+// part of the key while invalidation stays per file.
+const extractCache = new Map<string, Map<string, Partial<Record<keyof NuxtPage, any>>>>()
+const dynamicMetaCache = new Map<string, Map<string, ReadonlySet<string>>>()
 
-// The extracted metadata differs between the two extraction modes, but the file contents do not.
-function getExtractCacheKey (absolutePath: string, options: ClassifyPageMetaOptions) {
-  return options.extractSerializable ? absolutePath + SERIALIZABLE_CACHE_SUFFIX : absolutePath
+function getExtractVariant (extraExtractionKeys: Set<string>, options: ClassifyPageMetaOptions) {
+  return `${options.extractSerializable ? 'serializable' : 'raw'}\0${[...extraExtractionKeys].sort().join(',')}`
+}
+
+function cacheVariant<T> (cache: Map<string, Map<string, T>>, absolutePath: string) {
+  let variants = cache.get(absolutePath)
+  if (!variants) {
+    variants = new Map()
+    cache.set(absolutePath, variants)
+  }
+  return variants
 }
 
 /**
  * Keys a page file's `definePageMeta` call sets at runtime rather than at build time. Derived
  * purely from file contents, so it is cached alongside the extracted metadata for that file.
  */
-export function getDynamicMetaKeys (absolutePath: string, options: ClassifyPageMetaOptions = {}): ReadonlySet<string> {
-  return dynamicMetaCache[getExtractCacheKey(absolutePath, options)] ?? EMPTY_DYNAMIC_META
+export function getDynamicMetaKeys (absolutePath: string, extraExtractionKeys: Set<string> = new Set(), options: ClassifyPageMetaOptions = {}): ReadonlySet<string> {
+  return dynamicMetaCache.get(absolutePath)?.get(getExtractVariant(extraExtractionKeys, options)) ?? EMPTY_DYNAMIC_META
 }
 
 export function getRouteMeta (contents: string, absolutePath: string, extraExtractionKeys: Set<string> = new Set(), options: ClassifyPageMetaOptions = {}): Partial<Record<keyof NuxtPage, any>> {
-  const cacheKey = getExtractCacheKey(absolutePath, options)
+  const variant = getExtractVariant(extraExtractionKeys, options)
 
   // set/update pageContentsCache, invalidate extractCache on cache mismatch
   if (!(absolutePath in pageContentsCache) || pageContentsCache[absolutePath] !== contents) {
     pageContentsCache[absolutePath] = contents
-    delete extractCache[absolutePath]
-    delete extractCache[absolutePath + SERIALIZABLE_CACHE_SUFFIX]
-    delete dynamicMetaCache[absolutePath]
-    delete dynamicMetaCache[absolutePath + SERIALIZABLE_CACHE_SUFFIX]
+    extractCache.delete(absolutePath)
+    dynamicMetaCache.delete(absolutePath)
   }
 
-  if (cacheKey in extractCache && extractCache[cacheKey]) {
-    return klona(extractCache[cacheKey])
+  const cached = extractCache.get(absolutePath)?.get(variant)
+  if (cached) {
+    return klona(cached)
   }
 
   const loader = getLoader(absolutePath)
   const scriptBlocks = !loader ? null : loader === 'vue' ? extractScriptContent(contents) : [{ code: contents, loader, offset: 0 }]
   if (!scriptBlocks) {
-    extractCache[cacheKey] = {}
+    cacheVariant(extractCache, absolutePath).set(variant, {})
     return {}
   }
 
@@ -561,10 +571,10 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
   }
 
   if (dynamicProperties.size) {
-    dynamicMetaCache[cacheKey] = dynamicProperties
+    cacheVariant(dynamicMetaCache, absolutePath).set(variant, dynamicProperties)
   }
 
-  extractCache[cacheKey] = extractedData
+  cacheVariant(extractCache, absolutePath).set(variant, extractedData)
   return klona(extractedData)
 }
 

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -24,7 +24,7 @@ function augmentForNuxt (pages: NuxtPage[], vfs: Record<string, string>, ctx: Pa
  */
 function getRouteMeta (contents: string, absolutePath: string, extraExtractionKeys?: Set<string>, options: { extractSerializable?: boolean } = {}) {
   const meta = _getRouteMeta(contents, absolutePath, extraExtractionKeys, options)
-  const dynamic = getDynamicMetaKeys(absolutePath, options)
+  const dynamic = getDynamicMetaKeys(absolutePath, extraExtractionKeys, options)
   return dynamic.size ? { ...meta, dynamic } : meta
 }
 
@@ -191,6 +191,15 @@ definePageMeta({ name: 'bar' })
     expect(meta === _getRouteMeta(fileContents, '/app/pages/other.vue')).toBeFalsy()
     expect(meta === _getRouteMeta('<template><div>Hi</div></template>' + fileContents, filePath)).toBeFalsy()
     _klona.mockReset()
+  })
+
+  it('should key the extraction cache on the extra extraction keys', () => {
+    const sfc = `<script setup>definePageMeta({ middleware: someRef })</script>`
+    const path = '/app/pages/extra-keys.vue'
+    // whether `middleware` is an extra extraction key decides if the route field or the whole meta
+    // object has to come from the macro module, so it cannot share a cache entry
+    expect(getRouteMeta(sfc, path, new Set(['middleware']))).toEqual({ dynamic: new Set(['meta']) })
+    expect(getRouteMeta(sfc, path, new Set())).toEqual({ dynamic: new Set(['middleware']) })
   })
 
   it('should not share state between page metadata', () => {
@@ -792,6 +801,12 @@ describe('normalizeRoutes', () => {
     const page = await augment(withExtraKeys, new Set(['middleware']))
     expect(getDynamicPageMeta(page, dynamicPageMetaCache(withExtraKeys))).toEqual(new Set(['meta']))
     expect(getDynamicPageMeta(page, dynamicPageMetaCache(withoutExtraKeys))).toEqual(new Set())
+
+    // the same file, extracted by an instance that does not treat `middleware` as an extra key,
+    // marks the route field itself rather than the whole meta object
+    await augment(withoutExtraKeys, new Set())
+    expect(getDynamicPageMeta(page, dynamicPageMetaCache(withoutExtraKeys))).toEqual(new Set(['middleware']))
+    expect(getDynamicPageMeta(page, dynamicPageMetaCache(withExtraKeys))).toEqual(new Set(['meta']))
 
     const routesFor = (nuxt: Nuxt) => {
       vi.mocked(useNuxt).mockReturnValueOnce(nuxt)

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -2,29 +2,45 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { MockedFunction } from 'vitest'
 import { compileScript, parse } from '@vue/compiler-sfc'
 import { pageDiagnostics } from '@nuxt/kit/internal'
+import { defu } from 'defu'
 import { klona } from 'klona'
 import { parse as toAst } from 'acorn'
 
+import { useNuxt } from '@nuxt/kit'
 import { PageMetaPlugin } from '../src/pages/plugins/page-meta.ts'
-import { augmentPages, defaultExtractionKeys, getRouteMeta, normalizeRoutes, shouldExtractSerializablePageMeta } from '../src/pages/utils.ts'
-import type { NuxtPage } from '../schema.ts'
+import { getRouteMeta as _getRouteMeta, augmentPages, defaultExtractionKeys, dynamicPageMetaCache, getDynamicMetaKeys, getDynamicPageMeta, normalizeRoutes, shouldExtractSerializablePageMeta } from '../src/pages/utils.ts'
+import type { Nuxt, NuxtPage } from '../schema.ts'
 
 const filePath = '/app/pages/index.vue'
 
+/** `augmentPages`, tied to the mocked nuxt instance the way `augmentAndResolve` ties it to a real one. */
+function augmentForNuxt (pages: NuxtPage[], vfs: Record<string, string>, ctx: Parameters<typeof augmentPages>[2] = {}) {
+  return augmentPages(pages, vfs, { nuxt: mockNuxt as unknown as Nuxt, ...ctx })
+}
+
+/**
+ * Extracted metadata, plus the keys the file leaves to the runtime macro module (which are no
+ * longer part of the extracted object).
+ */
+function getRouteMeta (contents: string, absolutePath: string, extraExtractionKeys?: Set<string>, options: { extractSerializable?: boolean } = {}) {
+  const meta = _getRouteMeta(contents, absolutePath, extraExtractionKeys, options)
+  const dynamic = getDynamicMetaKeys(absolutePath, options)
+  return dynamic.size ? { ...meta, dynamic } : meta
+}
+
 vi.mock('klona', { spy: true })
+const mockNuxt = vi.hoisted(() => ({
+  options: {
+    experimental: {
+      normalizePageNames: false,
+    },
+  },
+}))
 vi.mock('@nuxt/kit', async (original) => {
   const mod = await original<typeof import('@nuxt/kit')>()
   return {
     ...mod,
-    useNuxt: vi.fn(() => {
-      return {
-        options: {
-          experimental: {
-            normalizePageNames: false,
-          },
-        },
-      }
-    }),
+    useNuxt: vi.fn(() => mockNuxt),
   }
 })
 describe('page metadata', () => {
@@ -48,9 +64,7 @@ definePageMeta({
 </script>`, filePath)
 
     expect(meta).toStrictEqual({
-      meta: {
-        [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']),
-      },
+      dynamic: new Set(['meta']),
     })
   })
 
@@ -172,17 +186,17 @@ definePageMeta({ name: 'bar' })
     const _klona = klona as unknown as MockedFunction<typeof klona>
     _klona.mockImplementation(obj => obj)
     const fileContents = `<script setup>definePageMeta({ foo: 'bar' })</script>`
-    const meta = getRouteMeta(fileContents, filePath)
-    expect(meta === getRouteMeta(fileContents, filePath)).toBeTruthy()
-    expect(meta === getRouteMeta(fileContents, '/app/pages/other.vue')).toBeFalsy()
-    expect(meta === getRouteMeta('<template><div>Hi</div></template>' + fileContents, filePath)).toBeFalsy()
+    const meta = _getRouteMeta(fileContents, filePath)
+    expect(meta === _getRouteMeta(fileContents, filePath)).toBeTruthy()
+    expect(meta === _getRouteMeta(fileContents, '/app/pages/other.vue')).toBeFalsy()
+    expect(meta === _getRouteMeta('<template><div>Hi</div></template>' + fileContents, filePath)).toBeFalsy()
     _klona.mockReset()
   })
 
   it('should not share state between page metadata', () => {
     const fileContents = `<script setup>definePageMeta({ foo: 'bar' })</script>`
-    const meta = getRouteMeta(fileContents, filePath)
-    expect(meta === getRouteMeta(fileContents, filePath)).toBeFalsy()
+    const meta = _getRouteMeta(fileContents, filePath)
+    expect(meta === _getRouteMeta(fileContents, filePath)).toBeFalsy()
   })
 
   it('should extract serialisable metadata', () => {
@@ -212,11 +226,9 @@ definePageMeta({ name: 'bar' })
         "alias": [
           "/alias",
         ],
-        "meta": {
-          Symbol(nuxt:dynamic-page-meta): Set {
-            "middleware",
-            "meta",
-          },
+        "dynamic": Set {
+          "middleware",
+          "meta",
         },
         "name": "some-custom-name",
         "path": "/some-custom-path",
@@ -294,10 +306,8 @@ definePageMeta({ name: 'bar' })
 
     expect(meta).toMatchInlineSnapshot(`
       {
-        "meta": {
-          Symbol(nuxt:dynamic-page-meta): Set {
-            "redirect",
-          },
+        "dynamic": Set {
+          "redirect",
         },
       }
     `)
@@ -327,11 +337,9 @@ definePageMeta({ name: 'bar' })
 
     expect(meta).toMatchInlineSnapshot(`
       {
-        "meta": {
-          Symbol(nuxt:dynamic-page-meta): Set {
-            "middleware",
-            "meta",
-          },
+        "dynamic": Set {
+          "middleware",
+          "meta",
         },
         "name": "some-custom-name",
         "path": "/some-custom-path",
@@ -356,10 +364,8 @@ definePageMeta({ name: 'bar' })
 
     expect(meta).toMatchInlineSnapshot(`
       {
-        "meta": {
-          Symbol(nuxt:dynamic-page-meta): Set {
-            "middleware",
-          },
+        "dynamic": Set {
+          "middleware",
         },
         "name": "some-custom-name",
         "path": "/some-custom-path",
@@ -380,10 +386,8 @@ definePageMeta({ name: 'bar' })
 
     expect(meta).toMatchInlineSnapshot(`
       {
-        "meta": {
-          Symbol(nuxt:dynamic-page-meta): Set {
-            "meta",
-          },
+        "dynamic": Set {
+          "meta",
         },
       }
     `)
@@ -440,10 +444,8 @@ definePageMeta({ name: 'bar' })
 
     expect(meta).toMatchInlineSnapshot(`
       {
-        "meta": {
-          Symbol(nuxt:dynamic-page-meta): Set {
-            "meta",
-          },
+        "dynamic": Set {
+          "meta",
         },
       }
     `)
@@ -460,10 +462,8 @@ definePageMeta({ name: 'bar' })
 
     expect(meta).toMatchInlineSnapshot(`
       {
-        "meta": {
-          Symbol(nuxt:dynamic-page-meta): Set {
-            "meta",
-          },
+        "dynamic": Set {
+          "meta",
         },
       }
     `)
@@ -479,10 +479,8 @@ definePageMeta({ name: 'bar' })
 
     expect(meta).toMatchInlineSnapshot(`
       {
-        "meta": {
-          Symbol(nuxt:dynamic-page-meta): Set {
-            "meta",
-          },
+        "dynamic": Set {
+          "meta",
         },
       }
     `)
@@ -601,9 +599,10 @@ describe('shouldExtractSerializablePageMeta', () => {
 })
 
 describe('normalizeRoutes', () => {
-  it('should produce valid route objects when used with extracted meta', () => {
+  it('should produce valid route objects when used with extracted meta', async () => {
     const page: NuxtPage = { path: '/', file: filePath }
-    Object.assign(page, getRouteMeta(`
+    await augmentForNuxt([page], {
+      [filePath]: `
       <script setup>
       definePageMeta({
         name: 'some-custom-name',
@@ -618,7 +617,8 @@ describe('normalizeRoutes', () => {
         },
       })
       </script>
-      `, filePath))
+      `,
+    }, { fullyResolvedPaths: new Set([filePath]) })
 
     page.meta ||= {}
     page.meta.layout = 'test'
@@ -647,16 +647,18 @@ describe('normalizeRoutes', () => {
     `)
   })
 
-  it('should not import the macro module when all metadata was extracted', () => {
+  it('should not import the macro module when all metadata was extracted', async () => {
     const page: NuxtPage = { path: '/', file: filePath }
-    Object.assign(page, getRouteMeta(`
+    await augmentForNuxt([page], {
+      [filePath]: `
       <script setup>
       definePageMeta({
         name: 'some-custom-name',
         alias: ['/some-alias'],
       })
       </script>
-      `, filePath))
+      `,
+    }, { fullyResolvedPaths: new Set([filePath]) })
 
     const { routes, imports } = normalizeRoutes([page], new Set(), {
       clientComponentRuntime: '<client-component-runtime>',
@@ -693,7 +695,7 @@ describe('normalizeRoutes', () => {
       { path: '/', file: filePath },
       { path: '/duplicate', file: filePath },
     ]
-    await augmentPages(pages, vfs, { fullyResolvedPaths: new Set([filePath]) })
+    await augmentForNuxt(pages, vfs, { fullyResolvedPaths: new Set([filePath]) })
 
     const { routes, imports } = normalizeRoutes(pages, new Set(), {
       clientComponentRuntime: '<client-component-runtime>',
@@ -719,15 +721,17 @@ describe('normalizeRoutes', () => {
     `)
   })
 
-  it('should import the macro module when metadata is not statically analysable', () => {
+  it('should import the macro module when metadata is not statically analysable', async () => {
     const page: NuxtPage = { path: '/', name: 'index', file: filePath }
-    Object.assign(page, getRouteMeta(`
+    await augmentForNuxt([page], {
+      [filePath]: `
       <script setup>
       definePageMeta({
         layout: 'custom',
       })
       </script>
-      `, filePath))
+      `,
+    }, { fullyResolvedPaths: new Set([filePath]) })
 
     const { imports } = normalizeRoutes([page], new Set(), {
       clientComponentRuntime: '<client-component-runtime>',
@@ -737,6 +741,71 @@ describe('normalizeRoutes', () => {
     expect(imports).toEqual(new Set([
       'import { default as indexndqPXFtP262szLmLJV4PriPTgAg5k_7f05QyTfosBXQMeta } from "/app/pages/index.vue?macro=true";',
     ]))
+  })
+
+  it.each([
+    // a module adding and then stripping its own meta key, dropping `page.meta` once it is empty
+    (page: NuxtPage) => {
+      page.meta = defu({ fromModule: {} }, klona(page.meta))
+      delete page.meta.fromModule
+      if (Object.keys(page.meta).length === 0) {
+        delete page.meta
+      }
+      return [page]
+    },
+    // route localization: page objects are replaced by one shallow copy per locale, then the
+    // module strips its own meta and drops `page.meta` once nothing of its own is left
+    (page: NuxtPage) => ['en', 'fr'].map((locale) => {
+      const localized: NuxtPage = { ...page, path: `/${locale}`, meta: { ...page.meta, i18n: {} } }
+      delete localized.meta!.i18n
+      if (Object.keys(localized.meta!).length === 0) {
+        delete localized.meta
+      }
+      return localized
+    }),
+  ])('should keep dynamic keys when a module rewrites pages (case %#)', async (rewritePages) => {
+    const page: NuxtPage = { path: '/', file: filePath }
+    await augmentForNuxt([page], {
+      [filePath]: `<script setup>definePageMeta({ name: ref('some-custom-name'), layout: 'custom' })</script>`,
+    }, { fullyResolvedPaths: new Set([filePath]) })
+
+    const { routes } = normalizeRoutes(rewritePages(page), new Set(), {
+      clientComponentRuntime: '<client-component-runtime>',
+      serverComponentRuntime: '<server-component-runtime>',
+      overrideMeta: true,
+    })
+    expect(routes).toContain('?.name ?? undefined')
+  })
+
+  it('should not share dynamic keys between nuxt instances', async () => {
+    const sfc = `<script setup>definePageMeta({ middleware: someRef })</script>`
+    // `middleware` is an extraction key for one instance only, so the two disagree about the key
+    const withExtraKeys = { options: { experimental: { normalizePageNames: false } } } as unknown as Nuxt
+    const withoutExtraKeys = { options: { experimental: { normalizePageNames: false } } } as unknown as Nuxt
+
+    const augment = async (nuxt: Nuxt, extraExtractionKeys: Set<string>) => {
+      const page: NuxtPage = { path: '/', file: filePath }
+      await augmentPages([page], { [filePath]: sfc }, { nuxt, extraExtractionKeys, fullyResolvedPaths: new Set([filePath]) })
+      return page
+    }
+
+    const page = await augment(withExtraKeys, new Set(['middleware']))
+    expect(getDynamicPageMeta(page, dynamicPageMetaCache(withExtraKeys))).toEqual(new Set(['meta']))
+    expect(getDynamicPageMeta(page, dynamicPageMetaCache(withoutExtraKeys))).toEqual(new Set())
+
+    const routesFor = (nuxt: Nuxt) => {
+      vi.mocked(useNuxt).mockReturnValueOnce(nuxt)
+      return normalizeRoutes([page], new Set(), {
+        clientComponentRuntime: '<client-component-runtime>',
+        serverComponentRuntime: '<server-component-runtime>',
+        overrideMeta: true,
+      }).routes
+    }
+
+    // the instance that extracted the file defers `meta` to the macro module; the other one has
+    // no record of the page and would drop it
+    expect(routesFor(withExtraKeys)).toContain('meta:')
+    expect(routesFor(withoutExtraKeys)).not.toContain('meta:')
   })
 
   it('should produce valid route objects when used without extracted meta', () => {
@@ -1412,7 +1481,7 @@ definePageMeta({ [name]: 'some-title' })
       `
       expect(macroModule(sfc, extractionKeys)).toContain('[name]: \'some-title\'')
       expect(getRouteMeta(sfc, '/app/pages/computed.vue')).toEqual({
-        meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) },
+        dynamic: new Set(['meta']),
       })
     })
 
@@ -1426,7 +1495,7 @@ definePageMeta({ layout: { name: 'admin', props: { collapsed: true } } })
       expect(macro).toContain('layout: \'admin\'')
       expect(macro).toContain('layoutProps: { collapsed: true }')
       expect(getRouteMeta(sfc, '/app/pages/layout.vue', new Set(['layout']))).toEqual({
-        meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) },
+        dynamic: new Set(['meta']),
       })
     })
 
@@ -1459,7 +1528,7 @@ definePageMeta(meta)
       `
       expect(macroModule(sfc, extractionKeys)).toContain('const __nuxt_page_meta = meta')
       expect(getRouteMeta(sfc, '/app/pages/variable.vue')).toEqual({
-        meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) },
+        dynamic: new Set(['meta']),
       })
     })
 
@@ -1474,7 +1543,7 @@ definePageMeta({ layout: { ...shared, props: { collapsed: true } } })
       expect(macro).toContain('...shared')
       expect(macro).not.toContain('layoutProps')
       expect(getRouteMeta(sfc, '/app/pages/layout-spread.vue')).toEqual({
-        meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) },
+        dynamic: new Set(['meta']),
       })
     })
 
@@ -1498,7 +1567,7 @@ definePageMeta({ get name () { return 'from-getter' } })
       `
       expect(macroModule(sfc, extractionKeys)).toContain('from-getter')
       expect(getRouteMeta(sfc, '/app/pages/getter.vue')).toEqual({
-        meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) },
+        dynamic: new Set(['meta']),
       })
     })
   })
@@ -1538,7 +1607,8 @@ definePageMeta({ title: 'hello', validate: () => true })
 </script>
       `
       expect(extract(sfc)).toEqual({
-        meta: { title: 'hello', [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) },
+        meta: { title: 'hello' },
+        dynamic: new Set(['meta']),
       })
       expect(macroModule(sfc)).toContain('validate')
     })
@@ -1550,7 +1620,7 @@ definePageMeta({ path: ref('/dynamic') })
 </script>
       `
       expect(extract(sfc)).toEqual({
-        meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['path']) },
+        dynamic: new Set(['path']),
       })
       expect(macroModule(sfc)).toContain('ref(\'/dynamic\')')
     })
@@ -1572,7 +1642,7 @@ definePageMeta({ title: 'first', title: 'last' })
       const path = '/app/pages/cache-key.vue'
       expect(getRouteMeta(sfc, path, new Set(), options)).toEqual({ meta: { title: 'hello' } })
       expect(getRouteMeta(sfc, path)).toEqual({
-        meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) },
+        dynamic: new Set(['meta']),
       })
     })
 
@@ -1584,7 +1654,7 @@ definePageMeta({ title: 'first', title: 'last' })
       const updated = `<script setup lang="ts">definePageMeta({ title: 'goodbye' })</script>`
       expect(getRouteMeta(updated, path, new Set(), options)).toEqual({ meta: { title: 'goodbye' } })
       expect(getRouteMeta(updated, path)).toEqual({
-        meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) },
+        dynamic: new Set(['meta']),
       })
     })
 
@@ -1649,7 +1719,7 @@ definePageMeta({ layout: { name: 'admin', props: { collapsed: true } } as const 
 definePageMeta({ layout: { props: { collapsed: true } } })
 </script>
         `
-        expect(extract(sfc)).toEqual({ meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) } })
+        expect(extract(sfc)).toEqual({ dynamic: new Set(['meta']) })
         const macro = macroModule(sfc)
         expect(macro).toContain('layoutProps: { collapsed: true }')
         expect(macro).not.toContain('layout:')
@@ -1661,7 +1731,7 @@ definePageMeta({ layout: { props: { collapsed: true } } })
 definePageMeta({ layout: {} })
 </script>
         `
-        expect(extract(sfc)).toEqual({ meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) } })
+        expect(extract(sfc)).toEqual({ dynamic: new Set(['meta']) })
       })
 
       it('should leave a non-serializable layout name to the macro module', () => {
@@ -1671,7 +1741,7 @@ const layoutName = 'admin'
 definePageMeta({ layout: { name: layoutName } })
 </script>
         `
-        expect(extract(sfc)).toEqual({ meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) } })
+        expect(extract(sfc)).toEqual({ dynamic: new Set(['meta']) })
         expect(macroModule(sfc)).toContain('layout: layoutName')
       })
 
@@ -1681,7 +1751,7 @@ definePageMeta({ layout: { name: layoutName } })
 definePageMeta({ layout: { name: 'admin', props: { onClick: () => {} } } })
 </script>
         `
-        expect(extract(sfc)).toEqual({ meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) } })
+        expect(extract(sfc)).toEqual({ dynamic: new Set(['meta']) })
         const macro = macroModule(sfc)
         expect(macro).toContain('layout: \'admin\'')
         expect(macro).toContain('layoutProps: { onClick: () => {} }')
@@ -1694,7 +1764,7 @@ const shared = { name: 'admin' }
 definePageMeta({ layout: { ...shared } })
 </script>
         `
-        expect(extract(sfc)).toEqual({ meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) } })
+        expect(extract(sfc)).toEqual({ dynamic: new Set(['meta']) })
         expect(macroModule(sfc)).toContain('...shared')
       })
 
@@ -1704,7 +1774,7 @@ definePageMeta({ layout: { ...shared } })
 definePageMeta({ layout: { name: 'admin', other: 1 } })
 </script>
         `
-        expect(extract(sfc)).toEqual({ meta: { [Symbol.for('nuxt:dynamic-page-meta')]: new Set(['meta']) } })
+        expect(extract(sfc)).toEqual({ dynamic: new Set(['meta']) })
         expect(macroModule(sfc)).toContain('other: 1')
       })
 
@@ -1733,9 +1803,10 @@ definePageMeta({ layout: { name: 'admin', props: { collapsed: true } } })
       })
     })
 
-    it('should not import the macro module when every key is serializable', () => {
+    it('should not import the macro module when every key is serializable', async () => {
       const page: NuxtPage = { path: '/', file: filePath }
-      Object.assign(page, getRouteMeta(`
+      await augmentForNuxt([page], {
+        [filePath]: `
       <script setup>
       definePageMeta({
         name: 'some-custom-name',
@@ -1743,7 +1814,8 @@ definePageMeta({ layout: { name: 'admin', props: { collapsed: true } } })
         title: 'hello',
       })
       </script>
-      `, filePath, new Set(), options))
+      `,
+      }, { fullyResolvedPaths: new Set([filePath]), extractSerializable: true })
 
       const { routes, imports } = normalizeRoutes([page], new Set(), {
         clientComponentRuntime: '<client-component-runtime>',

--- a/packages/nuxt/test/pages-module-workflow.test.ts
+++ b/packages/nuxt/test/pages-module-workflow.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { augmentAndResolve, normalizeRoutes } from '../src/pages/utils.ts'
+import type { Nuxt, NuxtPage } from '../schema.ts'
+
+const holder = vi.hoisted(() => ({ nuxt: undefined as unknown }))
+vi.mock('@nuxt/kit', async (original) => {
+  const mod = await original<typeof import('@nuxt/kit')>()
+  return {
+    ...mod,
+    useNuxt: vi.fn(() => holder.nuxt),
+    tryUseNuxt: vi.fn(() => holder.nuxt),
+  }
+})
+
+interface FakeNuxtOptions {
+  vfs: Record<string, string>
+  scanPageMeta?: boolean | 'after-resolve'
+  extractSerializablePageMeta?: boolean
+  extraPageMetaExtractionKeys?: string[]
+}
+
+function createNuxt ({ vfs, scanPageMeta = 'after-resolve', extractSerializablePageMeta = false, extraPageMetaExtractionKeys = [] }: FakeNuxtOptions) {
+  const hooks: Record<string, Array<(...args: any[]) => any>> = {}
+  const nuxt = {
+    vfs,
+    options: {
+      experimental: {
+        scanPageMeta,
+        extractSerializablePageMeta,
+        extraPageMetaExtractionKeys,
+        normalizePageNames: false,
+      },
+    },
+    hook: (name: string, fn: (...args: any[]) => any) => void (hooks[name] ??= []).push(fn),
+    callHook: async (name: string, ...args: any[]) => {
+      for (const fn of hooks[name] ?? []) {
+        await fn(...args)
+      }
+    },
+  }
+  holder.nuxt = nuxt
+  return nuxt as unknown as Nuxt & typeof nuxt
+}
+
+function resolve (nuxt: ReturnType<typeof createNuxt>, pages: NuxtPage[]) {
+  return augmentAndResolve(pages, new Set(Object.keys(nuxt.vfs)), nuxt as unknown as Nuxt)
+}
+
+function generate (pages: NuxtPage[], overrideMeta = true) {
+  return normalizeRoutes(pages, new Set(), {
+    clientComponentRuntime: '<client-component-runtime>',
+    serverComponentRuntime: '<server-component-runtime>',
+    overrideMeta,
+  }).routes
+}
+
+const filePath = '/app/pages/about.vue'
+
+beforeEach(() => {
+  holder.nuxt = undefined
+})
+
+describe('page meta overrides from hooks', () => {
+  it('should keep meta a module adds in `pages:resolved`', async () => {
+    const nuxt = createNuxt({ vfs: { [filePath]: `<script setup>definePageMeta({ layout: someLayout })</script>` } })
+    nuxt.hook('pages:resolved', (pages: NuxtPage[]) => {
+      pages[0]!.meta = { ...pages[0]!.meta, fromModule: 'kept' }
+    })
+
+    const pages = await resolve(nuxt, [{ path: '/about', file: filePath }])
+    const routes = generate(pages)
+
+    // the macro module still supplies the runtime `layout`, and the module's key is layered on top
+    expect(routes).toContain('|| {}), ...{"fromModule":"kept"} }')
+  })
+
+  it('should let a module override a statically extracted value without changing what was scanned', async () => {
+    const nuxt = createNuxt({
+      vfs: { [filePath]: `<script setup>definePageMeta({ name: 'from-file', title: 'from-file' })</script>` },
+      extractSerializablePageMeta: true,
+      scanPageMeta: true,
+    })
+    nuxt.hook('pages:resolved', (pages: NuxtPage[]) => {
+      pages[0]!.name = 'from-module'
+      pages[0]!.meta!.title = 'from-module'
+    })
+
+    const pages = await resolve(nuxt, [{ path: '/about', file: filePath }])
+    expect(pages[0]!.name).toBe('from-module')
+    expect(generate(pages)).toContain('name: "from-module"')
+    expect(generate(pages)).toContain('"title":"from-module"')
+
+    // a second route reusing the file re-reads the scanned metadata, which the override left alone
+    const reused = await resolve(createNuxt({
+      vfs: { [filePath]: `<script setup>definePageMeta({ name: 'from-file', title: 'from-file' })</script>` },
+      extractSerializablePageMeta: true,
+      scanPageMeta: true,
+    }), [{ path: '/about-again', file: filePath }])
+    expect(reused[0]!.name).toBe('from-file')
+    expect(reused[0]!.meta).toEqual({ title: 'from-file' })
+  })
+})
+
+describe('page meta through i18n-shaped route localization', () => {
+  const locales = ['en', 'ja']
+
+  /**
+   * Mirrors how `@nuxtjs/i18n` uses the pages workflow: it reads custom paths from an extra
+   * extraction key, replaces every page with one shallow copy per locale (the copies share the
+   * original `meta` object), and then strips its own meta, dropping `page.meta` entirely when
+   * nothing of its own is left.
+   */
+  function localize (pages: NuxtPage[]): NuxtPage[] {
+    const localized = pages.flatMap(page => locales.map((locale) => {
+      const custom = (page.meta?.i18n as { paths?: Record<string, string> } | undefined)?.paths?.[locale]
+      const copy: NuxtPage = {
+        ...page,
+        path: `/${locale}${custom ?? page.path}`,
+        name: `${page.name ?? 'page'}___${locale}`,
+      }
+      if (page.children?.length) {
+        copy.children = localize(page.children)
+      }
+      return copy
+    }))
+    for (const page of localized) {
+      if (typeof page.meta?.i18n === 'object') {
+        delete page.meta.i18n
+        if (Object.keys(page.meta).length === 0) {
+          delete page.meta
+        }
+      }
+    }
+    return localized
+  }
+
+  function createI18nNuxt (vfs: Record<string, string>) {
+    const nuxt = createNuxt({ vfs, extraPageMetaExtractionKeys: ['i18n'] })
+    nuxt.hook('pages:resolved', (pages: NuxtPage[]) => {
+      const localized = localize(pages)
+      pages.length = 0
+      pages.push(...localized)
+    })
+    return nuxt
+  }
+
+  it('should keep runtime page meta reachable after custom paths are stripped', async () => {
+    const nuxt = createI18nNuxt({
+      [filePath]: `<script setup>definePageMeta({ i18n: { paths: { ja: '/gaiyou' } }, layout: someLayout })</script>`,
+    })
+
+    const pages = await resolve(nuxt, [{ path: '/about', file: filePath }])
+    expect(pages.map(page => page.path)).toEqual(['/en/about', '/ja/gaiyou'])
+    // the copies share one meta object, so stripping the module's own key empties it for all of
+    // them and drops `page.meta` from the copy that got there first
+    expect(pages.map(page => page.meta)).toEqual([undefined, {}])
+
+    const routes = generate(pages)
+    // `layout` cannot be extracted, so both copies have to take their meta from the macro module
+    expect(routes.match(/meta: \w+Meta \|\| \{\}/g)).toHaveLength(2)
+    expect(routes).not.toContain('i18n')
+  })
+
+  it('should apply custom paths taken from an extra extraction key and strip them afterwards', async () => {
+    const nuxt = createI18nNuxt({
+      [filePath]: `<script setup>definePageMeta({ i18n: { paths: { ja: '/gaiyou' } } })</script>`,
+    })
+
+    const pages = await resolve(nuxt, [{ path: '/about', file: filePath }])
+    expect(pages.map(page => page.path)).toEqual(['/en/about', '/ja/gaiyou'])
+
+    const routes = generate(pages)
+    expect(routes).not.toContain('i18n')
+    expect(routes).toContain('path: "/ja/gaiyou"')
+    // every key was statically extracted, so no route needs the macro module
+    expect(routes).not.toContain('Meta?.')
+  })
+
+  it('should not leak scanned metadata between two instances reading the same file', async () => {
+    const contents = `<script setup>definePageMeta({ title: 'hello' })</script>`
+
+    // an instance that extracts `title` can hardcode it into the route record
+    const withExtraKey = createNuxt({ vfs: { [filePath]: contents }, extraPageMetaExtractionKeys: ['title'] })
+    const extracted = await resolve(withExtraKey, [{ path: '/about', file: filePath }])
+    expect(extracted[0]!.meta).toEqual({ title: 'hello' })
+
+    holder.nuxt = withExtraKey
+    expect(generate(extracted)).toContain('meta: {"title":"hello"}')
+
+    // an instance that does not has to leave the same key to the macro module
+    const withoutExtraKey = createNuxt({ vfs: { [filePath]: contents } })
+    const deferred = await resolve(withoutExtraKey, [{ path: '/about', file: filePath }])
+    expect(deferred[0]!.meta).toBeUndefined()
+
+    holder.nuxt = withoutExtraKey
+    const deferredRoutes = generate(deferred)
+    expect(deferredRoutes).toContain('Meta || {}')
+    expect(deferredRoutes).not.toContain('"title"')
+  })
+})

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -1,28 +1,36 @@
 import type { TestAPI } from 'vitest'
 import { describe, expect, it, vi } from 'vitest'
 import type { RouteLocationNormalizedLoaded } from 'vue-router'
-import { type PagesContextOptions, augmentPages, createPagesContext, normalizeRoutes, relativizeToParent } from '../src/pages/utils.ts'
+import { type PagesContextOptions, augmentPages, createPagesContext, dynamicPageMetaCache, getDynamicPageMeta, normalizeRoutes, relativizeToParent } from '../src/pages/utils.ts'
 import type { RouterViewSlotProps } from '../src/pages/runtime/utils.ts'
 import { generateRouteKey } from '../src/pages/runtime/utils.ts'
-import type { NuxtPage } from 'nuxt/schema'
+import type { Nuxt, NuxtPage } from 'nuxt/schema'
 import { useNuxt } from '@nuxt/kit'
 import type { InputFile } from 'unrouting'
 
+const mockNuxt = vi.hoisted(() => ({
+  options: {
+    experimental: {
+      normalizePageNames: false,
+    },
+  },
+}))
 vi.mock('@nuxt/kit', async (original) => {
   const mod = await original<typeof import('@nuxt/kit')>()
   return {
     ...mod,
-    useNuxt: vi.fn(() => {
-      return {
-        options: {
-          experimental: {
-            normalizePageNames: false,
-          },
-        },
-      }
-    }),
+    useNuxt: vi.fn(() => mockNuxt),
   }
 })
+
+/** `augmentPages`, tied to the mocked nuxt instance the way `augmentAndResolve` ties it to a real one. */
+function augmentForNuxt (pages: NuxtPage[], vfs: Record<string, string>, ctx: Parameters<typeof augmentPages>[2] = {}) {
+  return augmentPages(pages, vfs, { nuxt: mockNuxt as unknown as Nuxt, ...ctx })
+}
+
+function dynamicMetaFor (page: NuxtPage) {
+  return getDynamicPageMeta(page, dynamicPageMetaCache(mockNuxt as unknown as Nuxt))
+}
 
 export function generateRoutesFromFiles (files: InputFile[], options: PagesContextOptions = {}): NuxtPage[] {
   if (!files.length) { return [] }
@@ -46,6 +54,18 @@ describe('pages:generateRoutesFromFiles', () => {
   const normalizedOverrideMetaResults: Record<string, any> = {}
 
   const enUSComparator = new Intl.Collator('en-US')
+  // dynamic keys are recorded per file rather than on the page, so surface them for `output`
+  function withDynamicMeta (routes: NuxtPage[]): Array<NuxtPage & { dynamic?: string[] }> {
+    return routes.map((route) => {
+      const dynamic = dynamicMetaFor(route)
+      return {
+        ...route,
+        ...dynamic.size ? { dynamic: [...dynamic] } : {},
+        ...route.children ? { children: withDynamicMeta(route.children) } : {},
+      }
+    })
+  }
+
   function sortRoutes (routes: NuxtPage[]) {
     for (const route of routes) {
       route.children &&= sortRoutes(route.children)
@@ -94,7 +114,7 @@ describe('pages:generateRoutesFromFiles', () => {
             }
           })
 
-          await augmentPages(result, vfs, { extraExtractionKeys: new Set(['extracted']) })
+          await augmentForNuxt(result, vfs, { extraExtractionKeys: new Set(['extracted']) })
         } catch (error: any) {
           expect(error.message).toEqual(test.error)
         }
@@ -103,7 +123,7 @@ describe('pages:generateRoutesFromFiles', () => {
       }
 
       if (result) {
-        expect.soft(sortRoutes(result)).toEqual(test.output ? sortRoutes(test.output) : undefined)
+        expect.soft(withDynamicMeta(sortRoutes(result))).toEqual(test.output ? sortRoutes(test.output) : undefined)
 
         normalizedResults[test.description] = normalizeRoutes(result, new Set(), {
           clientComponentRuntime: '<client-component-runtime>',
@@ -432,7 +452,6 @@ describe('pages:relativizeToParent', () => {
 })
 
 describe('page:extends', () => {
-  const DYNAMIC_META_KEY = Symbol.for('nuxt:dynamic-page-meta')
   it('should preserve distinct metadata for multiple routes referencing the same file', async () => {
     const files: NuxtPage[] = [
       { path: 'home', file: `pages/index.vue` },
@@ -448,24 +467,26 @@ describe('page:extends', () => {
             </script>
           `]),
     ) as Record<string, string>
-    await augmentPages(files, vfs)
+    await augmentForNuxt(files, vfs)
     expect(files).toEqual([
       {
         path: 'home',
         file: `pages/index.vue`,
-        meta: { [DYNAMIC_META_KEY]: new Set(['meta']) },
       },
       {
         path: 'home1',
         file: `pages/index.vue`,
-        meta: { [DYNAMIC_META_KEY]: new Set(['meta']), test: true },
+        meta: { test: true },
       },
       {
         path: 'home2',
         file: `pages/index.vue`,
-        meta: { [DYNAMIC_META_KEY]: new Set(['meta']), snap: true },
+        meta: { snap: true },
       },
     ])
+    for (const file of files) {
+      expect(dynamicMetaFor(file)).toEqual(new Set(['meta']))
+    }
   })
 
   it('keeps an explicit route name/path when reusing a file with a `definePageMeta` name (#27358)', async () => {
@@ -480,7 +501,7 @@ describe('page:extends', () => {
         </script>
       `,
     }
-    await augmentPages(files, vfs)
+    await augmentForNuxt(files, vfs)
     // first route takes the file's name; the second keeps its own, else both are `test` -> dropped
     expect(files[0]!.name).toBe('test')
     expect(files[1]!.name).toBe('testExtend')
@@ -490,12 +511,10 @@ describe('page:extends', () => {
 
 const pagesDir = 'pages'
 const layerDir = 'layer/pages'
-const DYNAMIC_META_KEY = Symbol.for('nuxt:dynamic-page-meta')
-
 export const pageTests: Array<{
   description: string
   files?: Array<{ path: string, template?: string, meta?: Record<string, any> }>
-  output?: NuxtPage[]
+  output?: Array<NuxtPage & { dynamic?: string[] }>
   it?: TestAPI
   normalized?: Record<string, any>[]
   error?: string
@@ -1033,7 +1052,7 @@ export const pageTests: Array<{
         name: 'index',
         path: '/',
         file: `${pagesDir}/index.vue`,
-        meta: { [DYNAMIC_META_KEY]: new Set(['name', 'alias', 'redirect', 'meta']) },
+        dynamic: ['name', 'alias', 'redirect', 'meta'],
         children: [],
       },
     ],
@@ -1063,7 +1082,7 @@ export const pageTests: Array<{
         alias: ['sweet-home'],
         redirect: '/',
         children: [],
-        meta: { [DYNAMIC_META_KEY]: new Set(['meta']) },
+        dynamic: ['meta'],
       },
     ],
   },
@@ -1186,7 +1205,8 @@ export const pageTests: Array<{
         path: '/page-with-meta',
         file: `${pagesDir}/page-with-meta.vue`,
         children: [],
-        meta: { [DYNAMIC_META_KEY]: new Set(['meta']), test: 1, extracted: { foo: 'foo', bar: 'bar' } },
+        meta: { test: 1, extracted: { foo: 'foo', bar: 'bar' } },
+        dynamic: ['meta'],
       },
     ],
   },


### PR DESCRIPTION
### 🔗 Linked issue

reverts nuxt/nuxt#36081

### 📚 Description

discovered in https://github.com/nuxt/ecosystem-ci/actions/runs/33121358338.

we've had a number of issues with nuxt/i18n where we inadvertently broke something in nuxt relating to page metadata. this PR makes two fixes:

1. we no longer key dynamic metadata _at all_ based on a secret key on a NuxtPage - the extracted metadata (and specifically what _cannot_ be extracted) is now keyed purely by file path
2. it was previously possible for multiple nuxt's running at the same time to access the 'wrong' metadata, which wasn't a real issue in a nuxt project but was present in our own test suite

I've fixed both and also added a test suite that should mirror how nuxt/i18n uses this, to avoid future regressions 🤞

cc: @BobbieGoede 