### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1939,7 +1939,7 @@ export interface ConfigSchema {
      *
      * @see [Nuxt TypeScript docs](https://nuxt.com/docs/4.x/guide/concepts/typescript)
      */
-    typeCheck: boolean | 'build'
+    typeCheck: boolean | 'build' | 'dev'
 
     /**
      * Extend the generated tsconfig files with shared options.

--- a/packages/vite/src/plugins/type-check.ts
+++ b/packages/vite/src/plugins/type-check.ts
@@ -11,7 +11,7 @@ export function TypeCheckPlugin (nuxt: Nuxt): Plugin {
     name: 'nuxt:type-check',
     applyToEnvironment: environment => environment.name === 'client' && !environment.config.isProduction,
     apply: () => {
-      return !nuxt.options.test && nuxt.options.typescript.typeCheck === true
+      return !nuxt.options.test && (nuxt.options.typescript.typeCheck === true || nuxt.options.typescript.typeCheck === 'dev')
     },
     configResolved (config) {
       try {

--- a/packages/vite/src/plugins/vite-plugin-checker.ts
+++ b/packages/vite/src/plugins/vite-plugin-checker.ts
@@ -3,7 +3,7 @@ import type { Nuxt } from '@nuxt/schema'
 import { readTSConfig, resolveTSConfig } from 'pkg-types'
 
 export async function VitePluginCheckerPlugin (nuxt: Nuxt, environment?: string): Promise<Array<Plugin | undefined> | undefined> {
-  if (!nuxt.options.test && (nuxt.options.typescript.typeCheck === true || (nuxt.options.typescript.typeCheck === 'build' && !nuxt.options.dev))) {
+  if (!nuxt.options.test && (nuxt.options.typescript.typeCheck === true || (nuxt.options.typescript.typeCheck === 'build' && !nuxt.options.dev) || (nuxt.options.typescript.typeCheck === 'dev' && nuxt.options.dev))) {
     const [checker, tsconfigPath] = await Promise.all([
       import('vite-plugin-checker').then(r => r.default),
       resolveTSConfig(nuxt.options.rootDir),

--- a/packages/webpack/src/configs/client.ts
+++ b/packages/webpack/src/configs/client.ts
@@ -164,7 +164,7 @@ function clientPlugins (ctx: WebpackConfigContext) {
   // Normally type checking runs in server config, but in `ssr: false` there is
   // no server build, so we inject here instead.
   if (!ctx.nuxt.options.ssr) {
-    if (!ctx.nuxt.options.test && (ctx.nuxt.options.typescript.typeCheck === true || (ctx.nuxt.options.typescript.typeCheck === 'build' && !ctx.nuxt.options.dev))) {
+    if (!ctx.nuxt.options.test && (ctx.nuxt.options.typescript.typeCheck === true || (ctx.nuxt.options.typescript.typeCheck === 'build' && !ctx.nuxt.options.dev) || (ctx.nuxt.options.typescript.typeCheck === 'dev' && ctx.nuxt.options.dev))) {
       ctx.config.plugins!.push(new TsCheckerPlugin({
         logger,
       }))

--- a/packages/webpack/src/configs/server.ts
+++ b/packages/webpack/src/configs/server.ts
@@ -149,7 +149,7 @@ function serverPlugins (ctx: WebpackConfigContext) {
   }
 
   // Add type-checking
-  if (!ctx.nuxt.options.test && (ctx.nuxt.options.typescript.typeCheck === true || (ctx.nuxt.options.typescript.typeCheck === 'build' && !ctx.nuxt.options.dev))) {
+  if (!ctx.nuxt.options.test && (ctx.nuxt.options.typescript.typeCheck === true || (ctx.nuxt.options.typescript.typeCheck === 'build' && !ctx.nuxt.options.dev) || (ctx.nuxt.options.typescript.typeCheck === 'dev' && ctx.nuxt.options.dev))) {
     ctx.config.plugins!.push(new TsCheckerPlugin({
       logger,
     }))


### PR DESCRIPTION
## Problem

Currently `typescript.typeCheck` supports `true` (always), `false` (never), and `'build'` (build only). There's no way to enable type checking only in dev mode.

## Fix

Added `'dev'` as a valid value for `typescript.typeCheck`. When set to `'dev'`, type checking only runs in dev mode (not during build).

## Changes

- `packages/schema/src/types/schema.ts`: Added `'dev'` to the typeCheck union type
- `packages/vite/src/plugins/vite-plugin-checker.ts`: Handle `'dev'` value
- `packages/vite/src/plugins/type-check.ts`: Handle `'dev'` value
- `packages/webpack/src/configs/server.ts`: Handle `'dev'` value
- `packages/webpack/src/configs/client.ts`: Handle `'dev'` value

Refs #36004