### PR TITLE
fix(nuxt): disable early 404 for page paths that cannot be decoded

### DIFF
--- a/packages/nitro-server/test/early-404-matching.test.ts
+++ b/packages/nitro-server/test/early-404-matching.test.ts
@@ -1,0 +1,116 @@
+import fc from 'fast-check'
+import { describe, expect, it, vi } from 'vitest'
+import { addRoute, createRouter as createRou3Router } from 'rou3'
+import { compileRouterToString } from 'rou3/compiler'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import { defineComponent, h } from 'vue'
+import type { H3Event } from 'nitro/h3'
+import type { NuxtPage } from 'nuxt/schema'
+
+import { collectRou3PagePatterns } from '../../nuxt/src/pages/utils.ts'
+import { normalizeRouteRulePath } from '../../nuxt/src/core/utils/route-rules.ts'
+import { throwIfUnmatchedPagePath } from '../src/runtime/utils/renderer/early-404.ts'
+
+let matcher: ((method: string, path: string) => unknown) | undefined
+
+vi.mock('#internal/nuxt/nitro-config.mjs', () => ({
+  get NUXT_PAGE_MATCHER () {
+    return matcher
+  },
+}))
+
+const Stub = defineComponent({ render: () => h('div') })
+
+const pathSegment = fc.constantFrom(
+  'about', 'Products', 'deep', '测试', 'a.b', 'café', 'CAFÉ', '100% legit', 'a+b', '%2Fa', 'İstanbul',
+  ':id()', ':id?', ':slug(.*)*', ':id(\\d+)', ':a()-:b()',
+)
+
+const page: fc.Arbitrary<NuxtPage> = fc.letrec<{ page: NuxtPage }>(tie => ({
+  page: fc.record({
+    path: fc.array(pathSegment, { minLength: 1, maxLength: 3 }).map(segments => '/' + segments.join('/')),
+    alias: fc.oneof(
+      { weight: 3, arbitrary: fc.constant(undefined) },
+      { weight: 1, arbitrary: fc.array(pathSegment.map(segment => '/' + segment), { minLength: 1, maxLength: 2 }) },
+    ),
+    children: fc.oneof(
+      { weight: 3, arbitrary: fc.constant(undefined) },
+      { weight: 1, arbitrary: fc.array(tie('page').map(child => ({ ...child, path: child.path.slice(1) })), { maxLength: 2 }) },
+    ),
+  }),
+})).page
+
+function toVueRouterRoutes (pages: NuxtPage[]) {
+  return pages.map((page) => {
+    const route: Record<string, unknown> = { path: page.path, component: Stub }
+    if (page.alias) { route.alias = page.alias }
+    if (page.children) { route.children = toVueRouterRoutes(page.children) }
+    return route
+  })
+}
+
+function fullPaths (pages: NuxtPage[], prefix = ''): string[] {
+  return pages.flatMap((page) => {
+    const path = page.path.startsWith('/') ? page.path : `${prefix}/${page.path}`
+    const aliases = (Array.isArray(page.alias) ? page.alias : page.alias ? [page.alias] : [])
+      .map(alias => alias.startsWith('/') ? alias : `${prefix}/${alias}`)
+    return [path, ...aliases, ...(page.children ? fullPaths(page.children, path) : [])]
+  })
+}
+
+function candidateUrls (fullPath: string): string[] {
+  const filled = fullPath
+    .replace(/:\w+\(\.\*\)\*/g, 'a/b')
+    .replace(/:\w+\(\\d\+\)/g, '42')
+    .replace(/:\w+\?/g, 'x')
+    .replace(/:\w+\(\)/g, 'x')
+  const withoutOptionalParams = fullPath
+    .replace(/\/:\w+\?/g, '')
+    .replace(/:\w+\(\.\*\)\*/g, '')
+    .replace(/:\w+\(\\d\+\)/g, '7')
+    .replace(/:\w+\(\)/g, 'Y') || '/'
+  return [...new Set([
+    filled,
+    withoutOptionalParams,
+    filled.toUpperCase(),
+    filled.toLowerCase(),
+    encodeURI(filled),
+    filled + '/',
+    filled + '/_payload.json',
+  ])].filter(url => url.startsWith('/') && !url.includes('//'))
+}
+
+function compileMatcher (patterns: string[]) {
+  const router = createRou3Router()
+  for (const pattern of new Set(patterns.map(pattern => normalizeRouteRulePath(pattern, true)))) {
+    addRoute(router, '', pattern, 1)
+  }
+  return new Function(`${compileRouterToString(router, 'NUXT_PAGE_MATCHER')}\nreturn NUXT_PAGE_MATCHER`)() as (method: string, path: string) => unknown
+}
+
+function isEarly404 (url: string) {
+  try {
+    throwIfUnmatchedPagePath({ url: new URL(url, 'http://localhost'), req: { method: 'GET' } } as unknown as H3Event, {})
+    return false
+  } catch {
+    return true
+  }
+}
+
+describe('early 404 matching', () => {
+  it('should let through every URL a page route can match', () => {
+    fc.assert(fc.property(fc.array(page, { minLength: 1, maxLength: 3 }), (pages) => {
+      const patterns = collectRou3PagePatterns(pages)
+      fc.pre(patterns !== undefined)
+      matcher = compileMatcher(patterns!)
+
+      const router = createRouter({ history: createMemoryHistory(), routes: toVueRouterRoutes(pages) as never })
+      for (const fullPath of fullPaths(pages)) {
+        for (const url of candidateUrls(fullPath)) {
+          if (!router.resolve(url).matched.length) { continue }
+          expect(isEarly404(url), `${url} (patterns: ${patterns!.join(', ')})`).toBe(false)
+        }
+      }
+    }), { numRuns: 500 })
+  })
+})

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -943,6 +943,22 @@ export function routerOptionsMayModifyRoutes (code: string, filename: string): b
 }
 
 /**
+ * Whether a route can be normalised to the same form as an incoming request path.
+ * A path carrying a `%` that is not a valid escape sequence cannot be decoded, and is
+ * matched in its raw form on both sides: the pattern keeps the authored characters while
+ * the request keeps the encoding the client sent, so the two can never meet.
+ */
+function isDecodable (route: string): boolean {
+  if (!route.includes('%')) { return true }
+  try {
+    decodeURI(route)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
  * Collect a rou3 pattern for every path a page can be reached by: its canonical
  * path, each alias, and the whole subtree below it. Returns `undefined` when any
  * path cannot be converted, so callers can fall back to matching everything;
@@ -963,6 +979,11 @@ export function collectRou3PagePatterns (pages: NuxtPage[], prefixes: string[] =
       }
     }
     for (const route of routes) {
+      if (!isDecodable(route)) {
+        onUnconvertible?.(route)
+        failed = true
+        continue
+      }
       const { patterns: converted } = vueRouterToRou3(route, { collapse: true })
       if (!converted.length) {
         onUnconvertible?.(route)

--- a/packages/nuxt/test/early-404-patterns.test.ts
+++ b/packages/nuxt/test/early-404-patterns.test.ts
@@ -62,6 +62,16 @@ describe('collectRou3PagePatterns', () => {
     `)
   })
 
+  it('should refuse to convert a path that cannot be decoded', () => {
+    const pages: NuxtPage[] = [
+      { name: 'index', path: '/' },
+      { name: 'odd', path: '/100% legit' },
+    ]
+    const unconvertible: string[] = []
+    expect(collectRou3PagePatterns(pages, ['/'], route => unconvertible.push(route))).toBeUndefined()
+    expect(unconvertible).toStrictEqual(['/100% legit'])
+  })
+
   it('should collapse routes it cannot express exactly into broader patterns', () => {
     const pages: NuxtPage[] = [
       { name: 'index', path: '/' },


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

spotted (and fixed) an issue with invalid routes that could never be decoded back; this would never have worked, and this time we give people an earlier warning

(it fixes a potential false 404)