### PR TITLE
fix(nuxt): keep extracted `__proto__` page meta keys as own properties

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -906,7 +906,7 @@ export function isSerializable (node: ESTree.Node): { value?: any, serializable:
       if (!serializable) {
         return { serializable: false }
       }
-      value[key] = propertyValue
+      Object.defineProperty(value, key, { value: propertyValue, enumerable: true, writable: true, configurable: true })
     }
     return { value, serializable: true }
   }

--- a/packages/nuxt/test/is-serializable.test.ts
+++ b/packages/nuxt/test/is-serializable.test.ts
@@ -1,3 +1,4 @@
+import fc from 'fast-check'
 import { describe, expect, it } from 'vitest'
 import { parseSync } from 'rolldown/utils'
 import type { ESTree } from 'rolldown/utils'
@@ -104,5 +105,31 @@ describe('isSerializable', () => {
 
   it('rejects arrow function values', () => {
     expect(check(`{ foo: () => 1 }`)).toEqual({ serializable: false })
+  })
+
+  it('keeps a `__proto__` key as an own property', () => {
+    const { serializable, value } = check(`{ __proto__: { polluted: true } }`)
+    expect(serializable).toBe(true)
+    expect(JSON.stringify(value)).toBe(`{"__proto__":{"polluted":true}}`)
+    expect(value.polluted).toBeUndefined()
+  })
+
+  const objectKey = fc.oneof(fc.string(), fc.constantFrom('__proto__', 'constructor', 'toString', 'a', '0', '1e3'))
+  const jsonValue = fc.letrec<{ value: unknown }>(tie => ({
+    value: fc.oneof(
+      { weight: 6, arbitrary: fc.oneof(fc.string(), fc.integer(), fc.double({ noNaN: true, noDefaultInfinity: true }), fc.boolean(), fc.constant(null)) },
+      { weight: 1, arbitrary: fc.array(tie('value'), { maxLength: 3 }) },
+      { weight: 1, arbitrary: fc.dictionary(objectKey, tie('value'), { maxKeys: 3 }) },
+    ),
+  })).value
+
+  it('should round-trip any JSON value printed as a literal', () => {
+    fc.assert(fc.property(jsonValue, (value) => {
+      const json = JSON.stringify(value)
+      const { serializable, value: extracted } = check(json)
+      expect(serializable).toBe(true)
+      expect(extracted).toEqual(JSON.parse(json))
+      expect(JSON.stringify(extracted)).toBe(json)
+    }), { numRuns: 1000 })
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

not a security issue, but this avoids some fast-check errors and ensures it behaves like a plain object