### PR TITLE
fix(nuxt): register namespace binding alongside default import

### DIFF
--- a/packages/nuxt/src/core/utils/parse-utils.ts
+++ b/packages/nuxt/src/core/utils/parse-utils.ts
@@ -46,19 +46,17 @@ export function processImports (imports: ParsedStaticImport[], alias: Record<str
     }
 
     if (i.defaultImport) {
-      // handle default import
-      const namespace = i.defaultImport
       const entry = namespaces.get(resolvedSpecifier)!
-      entry.namespaces.add(namespace)
+      entry.namespaces.add(i.defaultImport)
       directImports.set(i.defaultImport, {
         originalName: 'default',
         source: resolvedSpecifier,
       })
-    } else if (i.namespacedImport) {
-      // handle namespace import
-      const namespace = i.namespacedImport
+    }
+
+    if (i.namespacedImport) {
       const entry = namespaces.get(resolvedSpecifier)!
-      entry.namespaces.add(namespace)
+      entry.namespaces.add(i.namespacedImport)
     }
   }
 

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -906,7 +906,7 @@ export function isSerializable (node: ESTree.Node): { value?: any, serializable:
       if (!serializable) {
         return { serializable: false }
       }
-      value[key] = propertyValue
+      Object.defineProperty(value, key, { value: propertyValue, enumerable: true, writable: true, configurable: true })
     }
     return { value, serializable: true }
   }

--- a/packages/nuxt/test/is-serializable.test.ts
+++ b/packages/nuxt/test/is-serializable.test.ts
@@ -1,3 +1,4 @@
+import fc from 'fast-check'
 import { describe, expect, it } from 'vitest'
 import { parseSync } from 'rolldown/utils'
 import type { ESTree } from 'rolldown/utils'
@@ -104,5 +105,31 @@ describe('isSerializable', () => {
 
   it('rejects arrow function values', () => {
     expect(check(`{ foo: () => 1 }`)).toEqual({ serializable: false })
+  })
+
+  it('keeps a `__proto__` key as an own property', () => {
+    const { serializable, value } = check(`{ __proto__: { polluted: true } }`)
+    expect(serializable).toBe(true)
+    expect(JSON.stringify(value)).toBe(`{"__proto__":{"polluted":true}}`)
+    expect(value.polluted).toBeUndefined()
+  })
+
+  const objectKey = fc.oneof(fc.string(), fc.constantFrom('__proto__', 'constructor', 'toString', 'a', '0', '1e3'))
+  const jsonValue = fc.letrec<{ value: unknown }>(tie => ({
+    value: fc.oneof(
+      { weight: 6, arbitrary: fc.oneof(fc.string(), fc.integer(), fc.double({ noNaN: true, noDefaultInfinity: true }), fc.boolean(), fc.constant(null)) },
+      { weight: 1, arbitrary: fc.array(tie('value'), { maxLength: 3 }) },
+      { weight: 1, arbitrary: fc.dictionary(objectKey, tie('value'), { maxKeys: 3 }) },
+    ),
+  })).value
+
+  it('should round-trip any JSON value printed as a literal', () => {
+    fc.assert(fc.property(jsonValue, (value) => {
+      const json = JSON.stringify(value)
+      const { serializable, value: extracted } = check(json)
+      expect(serializable).toBe(true)
+      expect(extracted).toEqual(JSON.parse(json))
+      expect(JSON.stringify(extracted)).toBe(json)
+    }), { numRuns: 1000 })
   })
 })

--- a/packages/nuxt/test/static-imports.test.ts
+++ b/packages/nuxt/test/static-imports.test.ts
@@ -1,6 +1,55 @@
+import fc from 'fast-check'
 import { describe, expect, it } from 'vitest'
 
 import { parseStaticImports } from '../src/core/utils/static-imports.ts'
+import { processImports } from '../src/core/utils/parse-utils.ts'
+
+const identifier = fc.constantFrom('a', 'b', 'c', 'd', 'foo', 'Bar', '_x', '$y')
+const specifier = fc.constantFrom('./x', './y.mjs', 'vue', '#imports', '~/utils/thing', '@scope/pkg/sub')
+
+interface Statement {
+  specifier: string
+  defaultImport?: string
+  namespacedImport?: string
+  namedImports: Array<[string, string, boolean]>
+  typeOnly: boolean
+}
+
+const statement: fc.Arbitrary<Statement> = fc.record({
+  specifier,
+  defaultImport: fc.option(identifier, { nil: undefined }),
+  namespacedImport: fc.option(identifier, { nil: undefined }),
+  namedImports: fc.uniqueArray(fc.tuple(identifier, identifier, fc.boolean()), { maxLength: 3, selector: ([imported]) => imported }),
+  typeOnly: fc.boolean(),
+}).filter(s => !(s.namespacedImport && s.namedImports.length))
+
+function print (statement: Statement) {
+  const clauses: string[] = []
+  if (statement.defaultImport) { clauses.push(statement.defaultImport) }
+  if (statement.namespacedImport) { clauses.push(`* as ${statement.namespacedImport}`) }
+  if (statement.namedImports.length) {
+    clauses.push(`{ ${statement.namedImports.map(([imported, local, typeOnly]) => `${typeOnly ? 'type ' : ''}${imported === local ? imported : `${imported} as ${local}`}`).join(', ')} }`)
+  }
+  const type = statement.typeOnly ? 'type ' : ''
+  return clauses.length
+    ? `import ${type}${clauses.join(', ')} from '${statement.specifier}'`
+    : `import '${statement.specifier}'`
+}
+
+function withUniqueLocals (statements: Statement[]): Statement[] {
+  const seen = new Set<string>()
+  const take = (name: string | undefined) => {
+    if (!name || seen.has(name)) { return undefined }
+    seen.add(name)
+    return name
+  }
+  return statements.map(statement => ({
+    ...statement,
+    defaultImport: take(statement.defaultImport),
+    namespacedImport: take(statement.namespacedImport),
+    namedImports: statement.namedImports.filter(([, local]) => take(local) !== undefined),
+  }))
+}
 
 describe('parseStaticImports', () => {
   it('should extract default, named and namespaced imports', () => {
@@ -66,5 +115,66 @@ describe('parseStaticImports', () => {
     expect(parseStaticImports(code, 'component.vue')).toMatchObject([
       { specifier: './a', namedImports: { a: 'a' } },
     ])
+  })
+
+  it('should register both bindings of a combined default and namespace import', () => {
+    const { directImports, namespaces } = processImports(parseStaticImports(`import a, * as ns from './x'`, 'file.ts'), {})
+    expect(directImports.get('a')).toEqual({ originalName: 'default', source: './x' })
+    expect(namespaces.get('./x')?.namespaces).toEqual(new Set(['a', 'ns']))
+  })
+
+  it('should round-trip printed import statements', () => {
+    fc.assert(fc.property(fc.array(statement, { minLength: 1, maxLength: 3 }), (statements) => {
+      const lines = statements.map(print)
+      const code = lines.join('\n')
+      const parsed = parseStaticImports(code, 'file.ts')
+
+      expect(parsed).toHaveLength(statements.length)
+      for (const [index, statement] of statements.entries()) {
+        const entry = parsed[index]!
+        expect(entry.code).toBe(lines[index])
+        expect(code.slice(entry.start, entry.end)).toBe(lines[index])
+        expect(entry.specifier).toBe(statement.specifier)
+        if (statement.typeOnly) {
+          expect(entry.defaultImport).toBeUndefined()
+          expect(entry.namespacedImport).toBeUndefined()
+          expect(entry.namedImports).toEqual({})
+          continue
+        }
+        expect(entry.defaultImport).toBe(statement.defaultImport)
+        expect(entry.namespacedImport).toBe(statement.namespacedImport)
+        expect(entry.namedImports).toEqual(Object.fromEntries(statement.namedImports.filter(([,, typeOnly]) => !typeOnly).map(([imported, local]) => [imported, local])))
+      }
+    }), { numRuns: 500 })
+  })
+
+  it('should resolve every value binding introduced by the imports', () => {
+    fc.assert(fc.property(fc.array(statement, { minLength: 1, maxLength: 3 }).map(withUniqueLocals), (statements) => {
+      const code = statements.map(print).join('\n')
+      const { directImports, namespaces } = processImports(parseStaticImports(code, 'file.ts'), { '~': '/root', '@scope/pkg': '/root/pkg' })
+
+      for (const statement of statements) {
+        if (statement.typeOnly) { continue }
+        for (const [imported, local] of statement.namedImports.filter(([,, typeOnly]) => !typeOnly)) {
+          const entry = directImports.get(local)
+          expect(entry, `${local} from ${statement.specifier}`).toBeDefined()
+          if (entry!.source.endsWith(statement.specifier.replace(/\.mjs$/, ''))) {
+            expect(entry!.originalName).toBe(imported)
+          }
+        }
+        if (statement.defaultImport) {
+          expect(directImports.get(statement.defaultImport)).toBeDefined()
+        }
+        for (const local of [statement.defaultImport, statement.namespacedImport]) {
+          if (!local) { continue }
+          expect([...namespaces.values()].some(entry => entry.namespaces.has(local))).toBe(true)
+        }
+      }
+
+      for (const source of namespaces.keys()) {
+        expect(source).not.toMatch(/\.mjs$/)
+        expect(source.startsWith('~')).toBe(false)
+      }
+    }), { numRuns: 500 })
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

another unlikely one, but this fast-check spotted that it was possible to do _both_ a default and a namespaced import. so 🤷