### PR TITLE
fix(nuxt): ignore grouping folders when collapsing repeated name segments

### DIFF
--- a/docs/2.directory-structure/1.app/1.middleware.md
+++ b/docs/2.directory-structure/1.app/1.middleware.md
@@ -20,6 +20,10 @@ Name of middleware are normalized to kebab-case: `myMiddleware` becomes `my-midd
 ::
 
 ::note
+Only files at the top level of the directory (or index files within any subdirectories) are registered. An index file takes its name from the folder that contains it: `middleware/auth/index.ts` is registered as `auth`.
+::
+
+::note
 Route middleware run within the Vue part of your Nuxt app. Despite the similar name, they are completely different from [server middleware](/docs/4.x/directory-structure/server#server-middleware), which are run in the Nitro server part of your app.
 ::
 

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -227,7 +227,7 @@ export async function resolveApp (nuxt: Nuxt, app: NuxtApp) {
       `*/index{${extensionGlob}}`,
     ])
     for (const file of middlewareFiles) {
-      const name = getNameFromPath(file)
+      const name = getNameFromPath(file, dirs.appMiddleware)
       if (!name) {
         // Ignore files like `~/middleware/index.vue` which end up not having a name at all
         pageDiagnostics.NUXT_B4010({ file: linkToAlias(file, nuxt) })

--- a/packages/nuxt/src/core/utils/names.ts
+++ b/packages/nuxt/src/core/utils/names.ts
@@ -40,10 +40,12 @@ export function resolveComponentNameSegments (fileName: string, prefixParts: str
     matchedSuffix.unshift(...splitByCase(prefixPart).map(p => p.toLowerCase()))
     const matchedSuffixContent = matchedSuffix.join('/')
     if ((fileNamePartsContent === matchedSuffixContent || fileNamePartsContent.startsWith(matchedSuffixContent + '/')) ||
-      // e.g. Item/Item/Item.vue -> Item
+      // e.g. Item/Item/Item.vue -> Item. `index` walks the prefix parts with grouping
+      // folders removed, so the repeated part is looked up there too; indexing the
+      // unfiltered parts would compare a different pair whenever a grouping folder
+      // precedes them, and grouping folders may not affect the resolved name.
       (prefixPart.toLowerCase() === fileNamePartsContent &&
-        prefixParts[index + 1] &&
-        prefixParts[index] === prefixParts[index + 1])) {
+        componentPrefixParts[index + 1] === prefixPart)) {
       componentNameParts.length = index
     }
     index--

--- a/packages/nuxt/test/app.test.ts
+++ b/packages/nuxt/test/app.test.ts
@@ -110,9 +110,14 @@ describe('resolveApp', () => {
       'layouts/default/index.vue',
       'layouts/other.vue',
     ])
-    // Middleware are not resolved in a nested manner
+    // A folder index is named after its folder; `middleware/index.ts` has no name at all
     expect(app.middleware.filter(m => m.path.startsWith('<rootDir>'))).toMatchInlineSnapshot(`
       [
+        {
+          "global": false,
+          "name": "auth",
+          "path": "<rootDir>/middleware/auth/index.ts",
+        },
         {
           "global": false,
           "name": "other",

--- a/packages/nuxt/test/naming.test.ts
+++ b/packages/nuxt/test/naming.test.ts
@@ -1,3 +1,4 @@
+import fc from 'fast-check'
 import { describe, expect, it } from 'vitest'
 import { pascalCase } from 'scule'
 import { getNameFromPath, resolveComponentNameSegments } from '../src/core/utils/index.ts'
@@ -11,6 +12,21 @@ describe('getNameFromPath', () => {
   }
   it.each(Object.keys(cases))('correctly deduplicates segments - %s', (filename) => {
     expect(getNameFromPath(filename)).toEqual(cases[filename])
+  })
+
+  it('should resolve the same name with and without grouping folders', () => {
+    expect(getNameFromPath('components/(admin)/user/user/User.vue', 'components')).toBe(getNameFromPath('components/user/user/User.vue', 'components'))
+    expect(getNameFromPath('components/user/(admin)/user/User.vue', 'components')).toBe(getNameFromPath('components/user/user/User.vue', 'components'))
+  })
+
+  it('should produce a kebab-case name that is stable under separator style', () => {
+    const segment = fc.constantFrom('base', 'Base', 'baseLayout', 'index', 'foo', '(group)', 'sub')
+    const path = fc.tuple(fc.array(segment, { maxLength: 2 }), segment.filter(s => s !== '(group)'))
+      .map(([dirs, file]) => [...dirs, file].join('/') + '.vue')
+    fc.assert(fc.property(path, (path) => {
+      expect(getNameFromPath(path)).toBe(getNameFromPath(path.replace(/\//g, '\\')))
+      expect(getNameFromPath(path)).toMatch(/^[a-z0-9-]*$/)
+    }), { numRuns: 1000 })
   })
 })
 
@@ -42,5 +58,26 @@ const tests: Array<[string, string[], string]> = [
 describe('components:resolveComponentNameSegments', () => {
   it.each(tests)('resolves %s with prefix parts %s and filename %s', (fileName, prefixParts: string[], result) => {
     expect(pascalCase(resolveComponentNameSegments(fileName, prefixParts))).toBe(result)
+  })
+
+  const word = fc.constantFrom('Item', 'Holder', 'Icon', 'Icones', 'Thing', 'Test', 'In', 'Foo', 'GameList', 'base', 'base-layout', 'base1', '(group)')
+  const fileName = fc.array(word.filter(part => part !== '(group)'), { maxLength: 3 }).map(parts => pascalCase(parts.join('-')))
+  const prefixParts = fc.array(word, { maxLength: 4 })
+
+  it('should always end the name with the file name', () => {
+    fc.assert(fc.property(fileName, prefixParts, (fileName, prefixParts) => {
+      expect(pascalCase(resolveComponentNameSegments(fileName, prefixParts)).endsWith(pascalCase(fileName))).toBe(true)
+    }), { numRuns: 1000 })
+  })
+
+  it('should ignore grouping folders wherever they appear', () => {
+    fc.assert(fc.property(fileName, prefixParts, fc.array(fc.nat(6), { maxLength: 3 }), (fileName, prefixParts, positions) => {
+      const withGroups = [...prefixParts]
+      for (const position of positions) {
+        withGroups.splice(position % (withGroups.length + 1), 0, '(group)')
+      }
+      expect(pascalCase(resolveComponentNameSegments(fileName, withGroups)))
+        .toBe(pascalCase(resolveComponentNameSegments(fileName, prefixParts.filter(part => part !== '(group)'))))
+    }), { numRuns: 1000 })
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

spotted with fast-check that groups could wrongly affect component naming, eg:

```
components/user/user/User.vue            -> user
components/(admin)/user/user/User.vue    -> user-user
```

the same issue also affected layouts, and there was a related issue with middleware where `middleware/something/index.ts` was silently dropped

regression from #35699 