### PR TITLE
fix(nuxt): make `target` optional if calling `navigateTo` w/ open

### DIFF
--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -149,7 +149,7 @@ export type OpenWindowFeatures = {
   & XOR<{ top?: number }, { screenY?: number }>
 
 export type OpenOptions = {
-  target: '_blank' | '_parent' | '_self' | '_top' | (string & {})
+  target?: '_blank' | '_parent' | '_self' | '_top' | (string & {})
   windowFeatures?: OpenWindowFeatures
 }
 

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -834,6 +834,15 @@ describe('routing utilities: `navigateTo`', () => {
       open.mockRestore()
     }
   })
+  it('navigateTo should default `open.target` to `_blank`', () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null)
+    try {
+      navigateTo('https://example.com', { open: {} })
+      expect(open).toHaveBeenCalledWith('https://example.com', '_blank', '')
+    } finally {
+      open.mockRestore()
+    }
+  })
   it('reloadNuxtApp should disallow paths with data/script URLs', () => {
     const urls = [
       'javascript:alert("hi")',

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -841,7 +841,6 @@ describe('routing utilities: `navigateTo`', () => {
       navigateTo('https://example.com', { open: {} })
       expect(open).toHaveBeenCalledWith('https://example.com', '_blank', '')
     } finally {
-      config.app.baseURL = originalBaseURL
       open.mockRestore()
     }
   })

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -862,7 +862,7 @@ describe('routing utilities: `navigateTo`', () => {
       expect(open).toHaveBeenCalledWith('https://example.com', '_blank', '')
     } finally {
       config.app.baseURL = originalBaseURL
-      open.mockRestore()y
+      open.mockRestore()
     }
   })
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/36183

### 📚 Description

allows an optional `target`