### PR TITLE
fix(nuxt): apply `baseURL` when calling `navigateTo` with `open`

### DIFF
--- a/packages/nuxt/src/app/composables/router.ts
+++ b/packages/nuxt/src/app/composables/router.ts
@@ -194,6 +194,7 @@ function encodeForHtmlAttr (value: string): string {
 export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: NavigateToOptions): Promise<void | NavigationFailure | false> | false | void | RouteLocationRaw => {
   to ||= '/'
 
+  const isPathForm = typeof to === 'string' || 'path' in to
   const toPath = typeof to === 'string' ? to : 'path' in to ? resolveRouteObject(to) : useRouter().resolve(to).href
 
   // Early open handler
@@ -202,6 +203,10 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
     if (protocol && isScriptProtocol(protocol)) {
       throw navigationDiagnostics.NUXT_E2002({ toPath, protocol })
     }
+
+    // route objects with a `name` are already resolved against the router base by `router.resolve`
+    const isInternal = isPathForm && !hasProtocol(toPath, { acceptRelative: true }) && !toPath.startsWith('#')
+    const openPath = isInternal ? joinURL(useRuntimeConfig().app.baseURL, toPath) : toPath
 
     const { target = '_blank', windowFeatures = {} } = options.open
 
@@ -212,7 +217,7 @@ export const navigateTo = (to: RouteLocationRaw | undefined | null, options?: Na
       }
     }
 
-    open(toPath, target, features.join(', '))
+    open(openPath, target, features.join(', '))
     return Promise.resolve()
   }
 

--- a/test/nuxt/composables.test.ts
+++ b/test/nuxt/composables.test.ts
@@ -834,6 +834,25 @@ describe('routing utilities: `navigateTo`', () => {
       open.mockRestore()
     }
   })
+  it('navigateTo should respect app.baseURL when opening internal routes', () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null)
+    const config = useRuntimeConfig()
+    const originalBaseURL = config.app.baseURL
+    config.app.baseURL = '/docs/'
+    try {
+      navigateTo('/guide', { open: { target: '_blank' } })
+      expect(open).toHaveBeenCalledWith('/docs/guide', '_blank', '')
+
+      navigateTo({ path: '/guide' }, { open: { target: '_blank' } })
+      expect(open).toHaveBeenCalledWith('/docs/guide', '_blank', '')
+
+      navigateTo('https://example.com', { open: { target: '_blank' } })
+      expect(open).toHaveBeenCalledWith('https://example.com', '_blank', '')
+    } finally {
+      config.app.baseURL = originalBaseURL
+      open.mockRestore()
+    }
+  })
   it('reloadNuxtApp should disallow paths with data/script URLs', () => {
     const urls = [
       'javascript:alert("hi")',


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/36182

### 📚 Description

an edge case when using nuxt with a baseURL