### PR TITLE
fix(vite): exclude stable entry chunk from preload dependencies

### DIFF
--- a/packages/vite/src/plugins/stable-entry.ts
+++ b/packages/vite/src/plugins/stable-entry.ts
@@ -9,12 +9,35 @@ import { toArray } from '../utils/index.ts'
 
 export function StableEntryPlugin (nuxt: Nuxt): Plugin {
   let entryFileName: string | undefined
+  let entryChunkFileName: string | undefined
 
   setBuildOutput('entryChunkName', () => `export const entryFileName = ${JSON.stringify(entryFileName)}`)
 
   return {
     name: 'nuxt:stable-entry',
     apply: () => !nuxt.options.dev && nuxt.options.experimental.entryImportMap,
+    configEnvironment (name, config) {
+      if (name !== 'client' || config.build?.modulePreload === false) {
+        return
+      }
+      const modulePreload = typeof config.build?.modulePreload === 'object' ? config.build.modulePreload : {}
+      const resolveDependencies = modulePreload.resolveDependencies
+      return {
+        build: {
+          modulePreload: {
+            ...modulePreload,
+            // the entry is a static import of any chunk that would preload it, so it is
+            // already loaded. Leaving it in the list would reinject its hash into chunks
+            // whose rendered content no longer references it, so the same [hash] filename
+            // could be emitted with different content across builds
+            resolveDependencies: (filename, deps, context) => {
+              const resolved = resolveDependencies ? resolveDependencies(filename, deps, context) : deps
+              return entryChunkFileName ? resolved.filter(dep => dep !== entryChunkFileName) : resolved
+            },
+          },
+        },
+      }
+    },
     applyToEnvironment (environment) {
       if (environment.name !== 'client') {
         return false
@@ -41,8 +64,14 @@ export function StableEntryPlugin (nuxt: Nuxt): Plugin {
 
       return generateTransform(s, chunk.fileName)
     },
-    writeBundle (_options, bundle) {
-      let entry = Object.values(bundle).find(chunk => chunk.type === 'chunk' && chunk.isEntry && chunk.name === 'entry')?.fileName
+    generateBundle: {
+      order: 'pre',
+      handler (_options, bundle) {
+        entryChunkFileName = Object.values(bundle).find(chunk => chunk.type === 'chunk' && chunk.isEntry && chunk.name === 'entry')?.fileName
+      },
+    },
+    writeBundle () {
+      let entry = entryChunkFileName
       const prefix = withoutLeadingSlash(nuxt.options.app.buildAssetsDir)
       if (entry?.startsWith(prefix)) {
         entry = entry.slice(prefix.length)

--- a/packages/vite/test/stable-entry.test.ts
+++ b/packages/vite/test/stable-entry.test.ts
@@ -1,0 +1,97 @@
+import { createHash } from 'node:crypto'
+import { mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { afterAll, describe, expect, it } from 'vitest'
+import { buildNuxt, loadNuxt } from '@nuxt/kit'
+import { join } from 'pathe'
+
+const tmpDir = fileURLToPath(new URL('./.tmp/stable-entry', import.meta.url))
+
+async function writeApp (extraPages: number) {
+  await mkdir(join(tmpDir, 'app/components'), { recursive: true })
+  await mkdir(join(tmpDir, 'app/pages'), { recursive: true })
+  await writeFile(join(tmpDir, 'app/app.vue'), '<template><div><NuxtPage /></div></template>')
+  await writeFile(join(tmpDir, 'app/pages/index.vue'), [
+    '<script setup>',
+    'const Lazy = defineAsyncComponent(() => import(\'../components/Lazy.vue\'))',
+    '</script>',
+    '',
+    '<template><div><Lazy /></div></template>',
+  ].join('\n'))
+  // a lazy component which itself lazily loads a component that pulls in the entry,
+  // so the chunk for `Lazy.vue` carries a preload dependency list mentioning the entry
+  await writeFile(join(tmpDir, 'app/components/Lazy.vue'), [
+    '<script setup>',
+    'const Nested = defineAsyncComponent(() => import(\'./Nested.vue\'))',
+    '</script>',
+    '',
+    '<template><div><Nested /></div></template>',
+  ].join('\n'))
+  await writeFile(join(tmpDir, 'app/components/Nested.vue'), [
+    '<script setup>',
+    'const count = useState(\'count\', () => 0)',
+    '</script>',
+    '',
+    '<template><p>{{ count }}</p></template>',
+  ].join('\n'))
+  for (let i = 0; i < extraPages; i++) {
+    await writeFile(join(tmpDir, `app/pages/extra-${i}.vue`), `<template><p>extra ${i}</p></template>`)
+  }
+}
+
+async function build () {
+  const nuxt = await loadNuxt({
+    cwd: tmpDir,
+    ready: true,
+    dev: false,
+    overrides: {
+      compatibilityDate: 'latest',
+      devtools: { enabled: false },
+      ssr: true,
+    },
+  })
+
+  try {
+    await buildNuxt(nuxt)
+  } finally {
+    await nuxt.close()
+  }
+
+  const dir = join(tmpDir, '.output/public', nuxt.options.app.buildAssetsDir.replace(/^\/+/, ''))
+  const chunks: Record<string, string> = {}
+  let importsEntrySpecifier = false
+  for (const file of await readdir(dir)) {
+    if (!file.endsWith('.js')) { continue }
+    const contents = await readFile(join(dir, file), 'utf8')
+    importsEntrySpecifier ||= contents.includes('"#entry"')
+    chunks[file] = createHash('sha256').update(contents).digest('hex')
+  }
+  return { chunks, importsEntrySpecifier }
+}
+
+// https://github.com/nuxt/nuxt/issues/36136
+describe('stable entry', () => {
+  afterAll(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('emits identical content for chunks whose hashed filename is unchanged', async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+
+    await writeApp(0)
+    const before = await build()
+
+    await writeApp(1)
+    const after = await build()
+
+    // guard against the assertion below passing vacuously if the entry is no
+    // longer rewritten to a bare specifier
+    expect(before.importsEntrySpecifier).toBe(true)
+
+    const shared = Object.keys(before.chunks).filter(file => file in after.chunks)
+    expect(shared.length).toBeGreaterThan(0)
+
+    const collisions = shared.filter(file => before.chunks[file] !== after.chunks[file])
+    expect(collisions).toEqual([])
+  }, 240 * 1000)
+})


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/36136

### 📚 Description

this addresses the root cause of the reported hash instability, which was that the entry chunk was being included in the `__vite__mapDeps` preload array. this was emitted _after_ hashes are decided, so changes to the array could result in different content with the same hash...