### PR TITLE
fix(nitro): resolve aliases and rootDir-relative asset dirs

### DIFF
--- a/packages/kit/src/diagnostics/bundler.ts
+++ b/packages/kit/src/diagnostics/bundler.ts
@@ -116,5 +116,10 @@ export const bundlerDiagnostics = /* #__PURE__ */ defineDiagnostics({
       fix: (p: { canFold: boolean }) => `Disambiguate the keys${p.canFold ? ' or set `router.options.sensitive: true`' : ''}.`,
       docs: false,
     },
+    NUXT_B7023: {
+      why: (p: { dir: string, baseURL: string }) => `A configured \`nitro.publicAssets\` directory does not exist: \`${p.dir}\`. Requests to \`${p.baseURL}\` will return a 404.`,
+      fix: 'Relative `dir` values are tried against your server directory and then your project root, and this one exists in neither. Point `dir` at an existing directory, using an absolute path or a Nuxt alias (such as `~~/public/video`) if it lives elsewhere.',
+      docs: false,
+    },
   },
 })

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -7,7 +7,7 @@ import { randomUUID } from 'node:crypto'
 import type { Nuxt, NuxtBuildOutputs, NuxtOptions } from '@nuxt/schema'
 import { addRoute, createRouter as createRou3Router } from 'rou3'
 import { compileRouterToString } from 'rou3/compiler'
-import { join, relative, resolve } from 'pathe'
+import { isAbsolute, join, relative, resolve } from 'pathe'
 import { joinURL, withTrailingSlash } from 'ufo'
 import { hash } from 'ohash'
 import nuxtPkg from 'nuxt/package.json' with { type: 'json' }
@@ -101,6 +101,34 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
   // Resolve aliases in user-provided input - so `~~/server/test` will work
   nuxt.options.nitro.plugins ||= []
   nuxt.options.nitro.plugins = nuxt.options.nitro.plugins.map(plugin => plugin ? resolveAlias(plugin, nuxt.options.alias) : plugin)
+
+  for (const asset of [...nuxt.options.nitro.publicAssets || [], ...nuxt.options.nitro.serverAssets || []]) {
+    if (asset?.dir) {
+      asset.dir = resolveAlias(asset.dir, nuxt.options.alias)
+    }
+  }
+
+  // nitropack v2 resolves asset dirs against `srcDir`, which Nuxt sets to `serverDir`, so a
+  // `public/video` written against the project root would silently resolve to `server/public/video`
+  const nitroSrcDir = resolve(nuxt.options.rootDir, nuxt.options.srcDir, nuxt.options.nitro.srcDir || nuxt.options.serverDir)
+  for (const asset of [...nuxt.options.nitro.publicAssets || [], ...nuxt.options.nitro.serverAssets || []]) {
+    if (!asset?.dir || isAbsolute(asset.dir)) {
+      continue
+    }
+    if (!existsSync(resolve(nitroSrcDir, asset.dir))) {
+      const rootRelative = resolve(nuxt.options.rootDir, asset.dir)
+      if (existsSync(rootRelative)) {
+        asset.dir = rootRelative
+      }
+    }
+  }
+
+  // a missing `dir` is otherwise silent: nitro registers the base URL and serves a hard 404 from it
+  for (const asset of nuxt.options.nitro.publicAssets || []) {
+    if (asset?.dir && !existsSync(resolve(nitroSrcDir, asset.dir))) {
+      bundlerDiagnostics.NUXT_B7023({ dir: resolve(nitroSrcDir, asset.dir), baseURL: joinURL('/', asset.baseURL || '/', '**') })
+    }
+  }
 
   if (nuxt.options.dev && nuxt.options.features.devLogs) {
     addPlugin(resolve(nuxt.options.appDir, 'plugins/dev-server-logs'))

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -8,7 +8,7 @@ import { $fetch, createPage, fetch, setup, url, useTestContext } from '@nuxt/tes
 import { $fetchComponent } from '@nuxt/test-utils/experimental'
 import { createRegExp, exactly } from 'magic-regexp'
 
-import { asyncContext, isDev, isRenderingJson, isTestingAppManifest, isWebpack, runsOnceInMatrix } from './matrix'
+import { asyncContext, isDev, isRenderingJson, isTestingAppManifest, isWebpack, runsOnceInMatrix, runsOncePerEnvInMatrix } from './matrix'
 import { expectNoClientErrors, gotoPath, parseData, parsePayload, renderPage } from './utils'
 
 await setup({
@@ -1993,6 +1993,21 @@ describe.skipIf(!runsOnceInMatrix)('public directories', () => {
 
     const greek = await $fetch<string>('/Ελληνικά.html')
     expect(greek).toContain('Ελληνικά')
+  })
+})
+
+// runs in dev as well as built, as nitro serves `publicAssets` via separate code paths in each
+describe.skipIf(!runsOncePerEnvInMatrix)('nitro publicAssets dirs', () => {
+  it('should serve assets from a relative `nitro.publicAssets` dir', async () => {
+    const res = await fetch('/custom/file.svg')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('image/svg')
+  })
+
+  it('should serve assets from an aliased `nitro.publicAssets` dir', async () => {
+    const res = await fetch('/aliased/file.svg')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('image/svg')
   })
 })
 

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -168,8 +168,12 @@ export default withMatrix({
   nitro: {
     publicAssets: [
       {
-        dir: '../custom-public',
+        dir: './custom-public',
         baseURL: '/custom',
+      },
+      {
+        dir: '~~/custom-public',
+        baseURL: '/aliased',
       },
     ],
     esbuild: {


### PR DESCRIPTION
### 🔗 Linked issue

closes https://github.com/nuxt/nuxt/pull/35000 (rework)
closes https://github.com/nuxt/nuxt/pull/26679
resolves https://github.com/nuxt/nuxt/issues/26517

### 📚 Description

in nitro v2, publicAssets dirs are resolved against `server/`, which is unexpected.

this aligns with nitro v3 and resolves vs nuxt's `rootDir`, as well as supporting nuxt aliases
