### PR TITLE
docs: explain custom typecheck includes

### DIFF
--- a/docs/3.guide/1.concepts/8.typescript.md
+++ b/docs/3.guide/1.concepts/8.typescript.md
@@ -99,6 +99,27 @@ Similarly:
 - For the `server` context, place the augmentation file in the `server/` directory.
 - For types that are **shared between the app and server**, place the file in the `shared/` directory.
 
+If you keep type files outside these directories, include them in the matching generated tsconfig from `nuxt.config.ts`:
+
+```ts twoslash [nuxt.config.ts]
+export default defineNuxtConfig({
+  typescript: {
+    // Files that rely on the Nuxt app context, such as auto-imports or aliases.
+    appTsConfig: {
+      include: ['../test/nuxt/**/*.ts'],
+    },
+    // Files that should be typed as plain Node.js code.
+    nodeTsConfig: {
+      include: ['../scripts/**/*.ts'],
+    },
+    // Files shared between app and server contexts.
+    sharedTsConfig: {
+      include: ['../types/shared/**/*.d.ts'],
+    },
+  },
+})
+```
+
 ::read-more{to="/docs/4.x/guide/modules/recipes-advanced#extend-typescript-config"}
 Read more about augmenting specific type contexts from **files outside those contexts** in the Module Author Guide.
 ::


### PR DESCRIPTION
This PR adds a short example to the TypeScript guide for users who keep files outside Nuxt's default type contexts.

The main point is to make it clearer that the right config depends on where the file is meant to run:

- `appTsConfig` for files that rely on the Nuxt app context
- `nodeTsConfig` for plain Node.js files such as scripts
- `sharedTsConfig` for files shared between app and server code

Closes #34756

Checked with:

```sh
git diff --check -- docs/3.guide/1.concepts/8.typescript.md
```