### PR TITLE
feat: support dev-only type checking

### DIFF
--- a/docs/3.guide/1.concepts/8.typescript.md
+++ b/docs/3.guide/1.concepts/8.typescript.md
@@ -44,7 +44,7 @@ To enable type-checking at build or development time, you can also use the [`typ
 ```ts twoslash [nuxt.config.ts]
 export default defineNuxtConfig({
   typescript: {
-    typeCheck: true,
+    typeCheck: true, // or 'build' / 'dev'
   },
 })
 ```

--- a/docs/4.api/6.nuxt-config.md
+++ b/docs/4.api/6.nuxt-config.md
@@ -1594,11 +1594,11 @@ You can extend the generated tsconfig files with shared options using this optio
 
 ### `typeCheck`
 
-Enable build-time type checking.
+Enable type checking.
 
-If set to true, this will type check in development. You can restrict this to build-time type checking by setting it to `build`. Requires to install `typescript` and `vue-tsc` as dev dependencies.
+If set to true, this will type check in development and at build time. You can restrict this to either build-time type checking by setting it to `build`, or development-only type checking by setting it to `dev`. Requires to install `typescript` and `vue-tsc` as dev dependencies.
 
-- **Type**: `boolean`
+- **Type**: `boolean | "build" | "dev"`
 - **Default:** `false`
 
 **See**: [Nuxt TypeScript docs](/docs/4.x/guide/concepts/typescript)

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -1933,13 +1933,13 @@ export interface ConfigSchema {
     includeWorkspace: boolean
 
     /**
-     * Enable build-time type checking.
+     * Enable type checking.
      *
-     * If set to true, this will type check in development. You can restrict this to build-time type checking by setting it to `build`. Requires to install `typescript` and `vue-tsc` as dev dependencies.
+     * If set to true, this will type check in development and at build time. You can restrict this to either build-time type checking by setting it to `build`, or development-only type checking by setting it to `dev`. Requires to install `typescript` and `vue-tsc` as dev dependencies.
      *
      * @see [Nuxt TypeScript docs](https://nuxt.com/docs/4.x/guide/concepts/typescript)
      */
-    typeCheck: boolean | 'build'
+    typeCheck: boolean | 'build' | 'dev'
 
     /**
      * Extend the generated tsconfig files with shared options.

--- a/packages/vite/src/plugins/type-check.ts
+++ b/packages/vite/src/plugins/type-check.ts
@@ -2,6 +2,7 @@ import { generateTransform, rolldownString } from 'rolldown-string'
 import type { Nuxt } from '@nuxt/schema'
 import type { Plugin } from 'vite'
 import { resolveClientEntry } from '../utils/config.ts'
+import { shouldTypeCheck } from '../utils/type-check.ts'
 
 const QUERY_RE = /\?.+$/
 
@@ -11,7 +12,7 @@ export function TypeCheckPlugin (nuxt: Nuxt): Plugin {
     name: 'nuxt:type-check',
     applyToEnvironment: environment => environment.name === 'client' && !environment.config.isProduction,
     apply: () => {
-      return !nuxt.options.test && nuxt.options.typescript.typeCheck === true
+      return !nuxt.options.test && shouldTypeCheck(nuxt.options.typescript.typeCheck, true)
     },
     configResolved (config) {
       try {

--- a/packages/vite/src/plugins/vite-plugin-checker.ts
+++ b/packages/vite/src/plugins/vite-plugin-checker.ts
@@ -1,9 +1,10 @@
 import type { Plugin } from 'vite'
 import type { Nuxt } from '@nuxt/schema'
 import { readTSConfig, resolveTSConfig } from 'pkg-types'
+import { shouldTypeCheck } from '../utils/type-check.ts'
 
 export async function VitePluginCheckerPlugin (nuxt: Nuxt, environment?: string): Promise<Array<Plugin | undefined> | undefined> {
-  if (!nuxt.options.test && (nuxt.options.typescript.typeCheck === true || (nuxt.options.typescript.typeCheck === 'build' && !nuxt.options.dev))) {
+  if (!nuxt.options.test && shouldTypeCheck(nuxt.options.typescript.typeCheck, nuxt.options.dev)) {
     const [checker, tsconfigPath] = await Promise.all([
       import('vite-plugin-checker').then(r => r.default),
       resolveTSConfig(nuxt.options.rootDir),

--- a/packages/vite/src/utils/type-check.ts
+++ b/packages/vite/src/utils/type-check.ts
@@ -1,0 +1,5 @@
+export type TypeCheckMode = boolean | 'build' | 'dev'
+
+export function shouldTypeCheck (typeCheck: TypeCheckMode, isDev: boolean) {
+  return typeCheck === true || typeCheck === (isDev ? 'dev' : 'build')
+}

--- a/packages/vite/test/type-check.test.ts
+++ b/packages/vite/test/type-check.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { shouldTypeCheck } from '../src/utils/type-check.ts'
+
+describe('shouldTypeCheck', () => {
+  it('enables type checking in both dev and build when configured as true', () => {
+    expect(shouldTypeCheck(true, true)).toBe(true)
+    expect(shouldTypeCheck(true, false)).toBe(true)
+  })
+
+  it('enables type checking only in build when configured as build', () => {
+    expect(shouldTypeCheck('build', true)).toBe(false)
+    expect(shouldTypeCheck('build', false)).toBe(true)
+  })
+
+  it('enables type checking only in dev when configured as dev', () => {
+    expect(shouldTypeCheck('dev', true)).toBe(true)
+    expect(shouldTypeCheck('dev', false)).toBe(false)
+  })
+
+  it('disables type checking when configured as false', () => {
+    expect(shouldTypeCheck(false, true)).toBe(false)
+    expect(shouldTypeCheck(false, false)).toBe(false)
+  })
+})

--- a/packages/webpack/src/configs/client.ts
+++ b/packages/webpack/src/configs/client.ts
@@ -164,7 +164,7 @@ function clientPlugins (ctx: WebpackConfigContext) {
   // Normally type checking runs in server config, but in `ssr: false` there is
   // no server build, so we inject here instead.
   if (!ctx.nuxt.options.ssr) {
-    if (!ctx.nuxt.options.test && (ctx.nuxt.options.typescript.typeCheck === true || (ctx.nuxt.options.typescript.typeCheck === 'build' && !ctx.nuxt.options.dev))) {
+    if (!ctx.nuxt.options.test && (ctx.nuxt.options.typescript.typeCheck === true || ctx.nuxt.options.typescript.typeCheck === (ctx.nuxt.options.dev ? 'dev' : 'build'))) {
       ctx.config.plugins!.push(new TsCheckerPlugin({
         logger,
       }))

--- a/packages/webpack/src/configs/server.ts
+++ b/packages/webpack/src/configs/server.ts
@@ -149,7 +149,7 @@ function serverPlugins (ctx: WebpackConfigContext) {
   }
 
   // Add type-checking
-  if (!ctx.nuxt.options.test && (ctx.nuxt.options.typescript.typeCheck === true || (ctx.nuxt.options.typescript.typeCheck === 'build' && !ctx.nuxt.options.dev))) {
+  if (!ctx.nuxt.options.test && (ctx.nuxt.options.typescript.typeCheck === true || ctx.nuxt.options.typescript.typeCheck === (ctx.nuxt.options.dev ? 'dev' : 'build'))) {
     ctx.config.plugins!.push(new TsCheckerPlugin({
       logger,
     }))


### PR DESCRIPTION
### Summary
- add support for 	ypescript.typeCheck: 'dev'
- share Vite typecheck gating through a small helper
- update Webpack gating, schema typing, and docs

Closes #36004

### Tests
- pnpm exec tsc --noEmit --ignoreConfig --allowImportingTsExtensions --moduleResolution bundler --module esnext --target es2022 --skipLibCheck packages/vite/test/type-check.test.ts
- git diff --check

Note: local pnpm vitest run --project unit packages/vite/test/type-check.test.ts did not produce output within a practical time window on my Windows checkout, so I stopped it and used the focused TypeScript check above.