### PR TITLE
refactor(kit,nuxt,schema,vite): decouple core from `@nuxt/nitro-server`

### DIFF
--- a/docs/3.guide/6.going-further/8.builders.md
+++ b/docs/3.guide/6.going-further/8.builders.md
@@ -217,6 +217,8 @@ The contract above is deliberately builder-agnostic and works for both the legac
 
 For a custom builder you only need to satisfy the generic contract. The Vite Environment API integration (`experimental.nitroViteEnvironment`) is specific to `@nuxt/vite-builder`; other builders, including custom ones, use the legacy Nitro Rollup path.
 
+Which of the two paths is in use is decided by the *server* builder, not by the flag directly: a server builder declares whether its build is a pass of its own, run after the app build, or an environment of the app builder's build. `@nuxt/nitro-server` declares it from `experimental.nitroViteEnvironment`, and a server builder with no build pass of its own (such as `@nuxt/vite-server`) declares that Vite is building everything.
+
 ::read-more{to="/docs/4.x/guide/going-further/internals"}
 Learn more about the Nuxt interface and the build vs. runtime split.
 ::

--- a/packages/kit/src/internal/server-build.ts
+++ b/packages/kit/src/internal/server-build.ts
@@ -53,6 +53,7 @@ export function createServerBuild (options: NuxtOptions): NuxtServerBuild {
   const outputDir = () => options.nitro?.output?.dir || '.output'
   return {
     name: typeof options.server?.builder === 'string' ? options.server.builder : 'custom',
+    buildsSeparately: !options.experimental?.nitroViteEnvironment,
     output: {
       dir: () => resolve(options.rootDir, outputDir()),
       publicDir: () => resolve(options.rootDir, options.nitro?.output?.publicDir || join(outputDir(), 'public')),

--- a/packages/nitro-server/src/augments.ts
+++ b/packages/nitro-server/src/augments.ts
@@ -1,5 +1,5 @@
 /// <reference path="./internal.d.ts" />
-import type { InternalApi, Nitro, NitroConfig, NitroDevEventHandler, NitroEventHandler, NitroOptions, NitroRouteConfig, NitroRuntimeConfig, NitroRuntimeConfigApp, TracingOptions } from 'nitro/types'
+import type { InternalApi, Nitro, NitroConfig, NitroDevEventHandler, NitroEventHandler, NitroOptions, NitroRouteConfig, NitroRouteRules, NitroRuntimeConfig, NitroRuntimeConfigApp, TracingOptions } from 'nitro/types'
 import type { EventHandler, H3Event } from 'nitro/h3'
 import type { LogObject } from 'consola'
 import type { NuxtIslandContext, NuxtIslandResponse, NuxtRenderChunkContext, NuxtRenderCloseContext, NuxtRenderHTMLContext, NuxtRenderRouteContext } from '#app/types'
@@ -66,6 +66,7 @@ declare module '@nuxt/schema' {
 
   interface ServerTypes {
     event: H3Event
+    routeRules: NitroRouteRules
   }
 
   // Nitro writes the routes it has scanned into its own `InternalApi`; extending it here hands
@@ -197,6 +198,7 @@ declare module 'nuxt/schema' {
 
   interface ServerTypes {
     event: H3Event
+    routeRules: NitroRouteRules
   }
 
   // Nitro writes the routes it has scanned into its own `InternalApi`; extending it here hands

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -839,6 +839,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
       publicDir: () => withoutTrailingSlash(nitro.options.output.publicDir),
     },
     capabilities: { server: true, dev: true },
+    buildsSeparately: !nuxt.options.experimental.nitroViteEnvironment,
     preview: { command: () => nitro.options.commands.preview },
   }, nuxt)
   await nuxt.callHook('nitro:init', nitro)

--- a/packages/nuxt/src/app/composables/layout.ts
+++ b/packages/nuxt/src/app/composables/layout.ts
@@ -1,6 +1,6 @@
 import type { ComputedRef } from 'vue'
 import { computed, inject, unref } from 'vue'
-import type { NitroRouteRules } from 'nitro/types'
+import type { AppRouteRules } from '@nuxt/schema'
 import type { RouteLocationNormalizedLoaded } from 'vue-router'
 
 import type { NuxtLayouts } from '../../pages/runtime/composables'
@@ -10,8 +10,8 @@ import { useRoute } from './router'
 import _routeRulesMatcher from '#build/route-rules.mjs'
 
 // hoisted so a circular import cannot hit the TDZ of the `#build/route-rules.mjs` default export
-function routeRulesMatcher (path: string): NitroRouteRules {
-  return (_routeRulesMatcher as (path: string) => NitroRouteRules)(path)
+function routeRulesMatcher (path: string): AppRouteRules {
+  return (_routeRulesMatcher as (path: string) => AppRouteRules)(path)
 }
 
 export type LayoutName = keyof NuxtLayouts | 'default' | false

--- a/packages/nuxt/src/app/composables/manifest.ts
+++ b/packages/nuxt/src/app/composables/manifest.ts
@@ -1,5 +1,4 @@
-import type { RequestEvent } from '@nuxt/schema'
-import type { NitroRouteRules } from 'nitro/types'
+import type { AppRouteRules, RequestEvent } from '@nuxt/schema'
 import { useRuntimeConfig } from '../nuxt'
 import { manifestDiagnostics } from '../diagnostics/manifest'
 import { appManifest as isAppManifestEnabled } from '#build/nuxt.config.mjs'
@@ -7,8 +6,8 @@ import { buildAssetsURL } from '#internal/nuxt/paths'
 import _routeRulesMatcher from '#build/route-rules.mjs'
 
 // hoisted so a circular import cannot hit the TDZ of the `#build/route-rules.mjs` default export
-function routeRulesMatcher (path: string): NitroRouteRules {
-  return (_routeRulesMatcher as (path: string) => NitroRouteRules)(path)
+function routeRulesMatcher (path: string): AppRouteRules {
+  return (_routeRulesMatcher as (path: string) => AppRouteRules)(path)
 }
 
 export interface NuxtAppManifestMeta {
@@ -71,7 +70,7 @@ export function getAppManifest (): Promise<NuxtAppManifest> {
 }
 
 /** @since 3.7.4 */
-export function getRouteRules (event: RequestEvent): NitroRouteRules
+export function getRouteRules (event: RequestEvent): AppRouteRules
 export function getRouteRules (options: { path: string }): Record<string, any>
 /** @deprecated use `getRouteRules({ path })` instead */
 export function getRouteRules (url: string): Record<string, any>

--- a/packages/nuxt/src/core/builder.ts
+++ b/packages/nuxt/src/core/builder.ts
@@ -3,7 +3,7 @@ import type { EventType } from '@parcel/watcher'
 import type { FSWatcher } from 'chokidar'
 import { watch as chokidarWatch } from 'chokidar'
 import { createIsIgnored, directoryToURL, getAddDependencyCommand, getLayerDirectories, importModule, isIgnored, recoverThrottledChanges, useNuxt, writeTypes } from '@nuxt/kit'
-import { buildDiagnostics } from '@nuxt/kit/internal'
+import { buildDiagnostics, useServerBuild } from '@nuxt/kit/internal'
 import { debounce } from 'perfect-debounce'
 import { dirname, join, normalize, relative, resolve } from 'pathe'
 
@@ -93,14 +93,14 @@ export async function build (nuxt: Nuxt): Promise<void> {
     const { restoreCache, collectCache, clientCachePlugin } = await getVueHash(nuxt)
     const hit = await restoreCache()
 
-    if (hit && !nuxt.options.experimental.nitroViteEnvironment) {
+    if (hit && useServerBuild(nuxt).buildsSeparately) {
       // `@nuxt/nitro-server` builds nitro from `build:done` in the legacy path
       await nuxt.callHook('build:done')
       await nuxt.callHook('close', nuxt)
       return
     }
 
-    if (nuxt.options.experimental.nitroViteEnvironment) {
+    if (!useServerBuild(nuxt).buildsSeparately) {
       // nitro only builds as part of the vite build, so a cache hit still has
       // to run it. The plugin is registered at the root rather than with
       // `addVitePlugin`, which in this path scopes plugins to the client and

--- a/packages/nuxt/src/core/cache.ts
+++ b/packages/nuxt/src/core/cache.ts
@@ -46,7 +46,7 @@ export async function getVueHash (nuxt: Nuxt) {
 
   // When Nitro builds as a Vite environment the client bundle is written to
   // `output.publicDir`, outside `buildDir`, so it needs its own cache entry.
-  const cachesClientAssets = nuxt.options.experimental.nitroViteEnvironment
+  const cachesClientAssets = !useServerBuild(nuxt).buildsSeparately
   let clientFiles: string[] = []
 
   return {

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -319,12 +319,22 @@ async function initNuxt (nuxt: Nuxt) {
   }
 
   let serverBuilderReference: { path: string } | { types: string } | undefined
+  /**
+   * A server builder declares the augmentations it contributes (`ServerTypes`, `ServerRoutes`,
+   * `RuntimeConfig`, …) from an `./augments` subpath export, which is referenced on its own so
+   * the declarations reach the shared environment without pulling in the builder's own types.
+   * Builders without that export are referenced by package name.
+   */
   const getServerBuilderReference = () => {
     if (serverBuilderReference || typeof nuxt.options.server.builder !== 'string') {
       return serverBuilderReference
     }
-    serverBuilderReference = nuxt.options.server.builder === '@nuxt/nitro-server'
-      ? { path: resolveModulePath('@nuxt/nitro-server/augments', { from: import.meta.url }).replace(/\.mjs$/, '.d.mts') }
+    const augments = resolveModulePath(`${nuxt.options.server.builder}/augments`, {
+      from: [import.meta.url, directoryToURL(nuxt.options.rootDir)],
+      try: true,
+    })
+    serverBuilderReference = augments
+      ? { path: augments.replace(/\.mjs$/, '.d.mts') }
       : { types: nuxt.options.server.builder }
     return serverBuilderReference
   }
@@ -357,7 +367,7 @@ async function initNuxt (nuxt: Nuxt) {
     if (serverBuilderReference) {
       opts.references.push(serverBuilderReference)
       opts.nodeReferences.push(serverBuilderReference)
-      if (nuxt.options.server.builder === '@nuxt/nitro-server') {
+      if ('path' in serverBuilderReference) {
         opts.sharedReferences.push(serverBuilderReference)
       }
     }

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -265,6 +265,13 @@ async function initNuxt (nuxt: Nuxt) {
         '    appLayout?: LayoutKey | false',
         '  }',
         '}',
+        ...['@nuxt/schema', 'nuxt/schema'].flatMap(module => [
+          `declare module '${module}' {`,
+          '  interface AppRouteRulesExtensions {',
+          '    appLayout?: LayoutKey | false',
+          '  }',
+          '}',
+        ]),
       ].join('\n')
     },
   }, { nuxt: true, nitro: true, node: true })

--- a/packages/nuxt/src/core/nuxt.ts
+++ b/packages/nuxt/src/core/nuxt.ts
@@ -340,8 +340,9 @@ async function initNuxt (nuxt: Nuxt) {
       from: [import.meta.url, directoryToURL(nuxt.options.rootDir)],
       try: true,
     })
-    serverBuilderReference = augments
-      ? { path: augments.replace(/\.mjs$/, '.d.mts') }
+    const declaration = augments?.replace(JS_EXTENSION_RE, (_, modifier = '') => `.d.${modifier}ts`)
+    serverBuilderReference = declaration && existsSync(declaration)
+      ? { path: declaration }
       : { types: nuxt.options.server.builder }
     return serverBuilderReference
   }
@@ -1112,6 +1113,7 @@ export async function loadNuxt (opts: LoadNuxtOptions): Promise<Nuxt> {
   return nuxt
 }
 
+const JS_EXTENSION_RE = /\.(m|c)?js$/
 const RESTART_RE = /^(?:app|error|app\.config)\.(?:js|ts|mjs|jsx|tsx|vue)$/i
 
 function deduplicateArray<T = unknown> (maybeArray: T): T {

--- a/packages/nuxt/src/core/server.ts
+++ b/packages/nuxt/src/core/server.ts
@@ -1,4 +1,5 @@
 import { directoryToURL, getAddDependencyCommand, importModule } from '@nuxt/kit'
+import { resolveModulePath } from 'exsolve'
 import { buildDiagnostics } from '@nuxt/kit/internal'
 
 import type { Nuxt, NuxtBuilder } from 'nuxt/schema'
@@ -20,7 +21,7 @@ export async function bundleServer (nuxt: Nuxt) {
 async function loadServerBuilder (nuxt: Nuxt, builder = '@nuxt/nitro-server'): Promise<NuxtBuilder> {
   try {
     // prefer our own dependency tree before walking up from rootDir
-    if (builder === '@nuxt/nitro-server' || builder === '@nuxt/vite-server') {
+    if (resolveModulePath(builder, { from: import.meta.url, try: true })) {
       return await import(builder)
     }
     return await importModule(builder, { url: [new URL(import.meta.url), directoryToURL(nuxt.options.rootDir)] })

--- a/packages/nuxt/src/pages/runtime/plugins/prerender.server.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/prerender.server.ts
@@ -1,6 +1,6 @@
 import type { RouteRecordRaw } from 'vue-router'
 import { joinURL } from 'ufo'
-import type { NitroRouteRules } from 'nitro/types'
+import type { AppRouteRules } from '@nuxt/schema'
 
 import { defineNuxtPlugin } from '#app/nuxt'
 import type { ObjectPlugin, Plugin } from '#app/nuxt'
@@ -11,8 +11,8 @@ import { crawlLinks } from '#build/nuxt.config.mjs'
 import _routeRulesMatcher from '#build/route-rules.mjs'
 
 // hoisted so a circular import cannot hit the TDZ of the `#build/route-rules.mjs` default export
-function routeRulesMatcher (path: string): NitroRouteRules {
-  return (_routeRulesMatcher as (path: string) => NitroRouteRules)(path)
+function routeRulesMatcher (path: string): AppRouteRules {
+  return (_routeRulesMatcher as (path: string) => AppRouteRules)(path)
 }
 
 let routes: string[]

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -16,7 +16,7 @@ export type { ModuleDefinition, ModuleDependencies, ModuleDependencyMeta, Module
 export type { Nuxt, NuxtApp, NuxtBuildOutputs, NuxtPlugin, NuxtPluginTemplate, NuxtTemplate, NuxtTemplateChange, NuxtTemplateDependency, NuxtTypeTemplate, NuxtServerTemplate, ResolvedNuxtTemplate } from './types/nuxt.ts'
 export type { RouterConfig, RouterConfigSerializable, RouterOptions } from './types/router.ts'
 export type { NitroInstance, NitroInstanceFallback, NitroInstanceOptions, NitroInstanceOptionsFallback, NitroTypes } from './types/nitro.ts'
-export type { RequestEvent, RequestEventFallback, ServerRoutes, ServerTypes } from './types/server.ts'
+export type { AppRouteRules, AppRouteRulesBase, AppRouteRulesExtensions, RequestEvent, RequestEventFallback, ServerRoutes, ServerTypes } from './types/server.ts'
 export type { ConfigSchema } from './types/schema.ts'
 export type { NuxtDebugContext, NuxtDebugOptions, NuxtDebugModuleMutationRecord } from './types/debug.ts'
 

--- a/packages/schema/src/types/nuxt.ts
+++ b/packages/schema/src/types/nuxt.ts
@@ -223,6 +223,13 @@ export interface NuxtServerBuild {
   target?: () => string | undefined
   /** What to call the `target` axis when printing it, such as `preset`. */
   targetLabel?: string
+  /**
+   * Whether the server build is a pass of its own, run by the server builder, rather than
+   * an environment of the app builder's build. A builder that builds separately also hosts
+   * the dev server, and reads the client manifest from disk rather than from the app
+   * builder's own build.
+   */
+  buildsSeparately: boolean
   output: NuxtServerBuildOutput
   capabilities: NuxtServerBuildCapabilities
   runtime: NuxtServerBuildRuntime

--- a/packages/schema/src/types/server.ts
+++ b/packages/schema/src/types/server.ts
@@ -2,7 +2,8 @@
  * Extension point through which the configured `server.builder` contributes the type of the
  * request event its runtime hands to the app layer.
  *
- * `@nuxt/nitro-server` declares `event` here as h3's `H3Event`, and Nuxt references its
+ * `@nuxt/nitro-server` declares `event` here as h3's `H3Event` and `routeRules` as its own
+ * `NitroRouteRules`, and Nuxt references its
  * declarations from the generated `.nuxt` types. Declaring the event where it is constructed
  * keeps the resolved shape accurate without the app layer depending on a server runtime.
  */
@@ -63,3 +64,52 @@ export type ResolveRequestEvent<T> = T extends { event: infer E } ? E : RequestE
  * by the configured `server.builder`, or {@link RequestEventFallback} when none has declared it.
  */
 export type RequestEvent = ResolveRequestEvent<ServerTypes>
+
+/**
+ * The route rules the app layer reads, as compiled into the route-rules matcher: keys the
+ * server builder resolves for itself (headers, caching, proxying, and so on) are not part of
+ * it, and rules the app layer normalises are described in their normalised form.
+ *
+ * A server builder contributes its own rules through the `routeRules` key of a
+ * {@link ServerTypes} registry, and they are resolved into {@link AppRouteRules}.
+ */
+export interface AppRouteRulesBase {
+  /** Whether the matched route is prerendered. */
+  prerender?: boolean
+  /** Path the matched route redirects to. */
+  redirect?: string
+  /** Whether a payload is cached for the matched route. */
+  payload?: boolean
+  /** Named app middleware to run (`true`) or skip (`false`) for the matched route. */
+  appMiddleware?: Record<string, boolean>
+  /** Whether the matched route is rendered on the server. */
+  ssr?: boolean
+  /** Whether the matched route is rendered without any scripts. */
+  noScripts?: boolean
+}
+
+/**
+ * Extension point for app-facing route rules that are not known statically, such as
+ * `appLayout`, whose values Nuxt generates from the layouts it has scanned.
+ *
+ * Rules declared here take precedence over those the server builder contributes, so they
+ * describe the value the app layer reads rather than the value the server was configured
+ * with.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface AppRouteRulesExtensions {}
+
+/**
+ * Resolves the route rules contributed to a {@link ServerTypes} registry against the
+ * app-facing rules, which win where both describe a rule. Exported for type tests; not part
+ * of the public API.
+ *
+ * @internal
+ */
+export type ResolveAppRouteRules<T> = AppRouteRulesBase & AppRouteRulesExtensions & (T extends { routeRules: infer R } ? Omit<R, keyof AppRouteRulesBase | keyof AppRouteRulesExtensions> : unknown)
+
+/**
+ * The route rules matched for a route in the app, combining the rules the app layer itself
+ * reads with those declared by the configured `server.builder`.
+ */
+export type AppRouteRules = ResolveAppRouteRules<ServerTypes>

--- a/packages/schema/test/server-types.spec.ts
+++ b/packages/schema/test/server-types.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, it } from 'vitest'
 import type { H3Event } from 'h3'
 
-import type { RequestEventFallback, ResolveRequestEvent } from '../src/types/server.ts'
+import type { AppRouteRulesBase, RequestEventFallback, ResolveAppRouteRules, ResolveRequestEvent } from '../src/types/server.ts'
 
 describe('fallback request event shape', () => {
   it('is satisfied by an event of a real server runtime', () => {
@@ -30,5 +30,28 @@ describe('`ServerTypes` registry', () => {
     interface Empty {}
 
     expectTypeOf<ResolveRequestEvent<Empty>>().toEqualTypeOf<RequestEventFallback>()
+  })
+})
+
+describe('app-facing route rules', () => {
+  it('resolves the rules contributed by a server builder alongside the app-facing ones', () => {
+    interface Contributed { routeRules: { swr?: number | boolean } }
+
+    expectTypeOf<ResolveAppRouteRules<Contributed>['swr']>().toEqualTypeOf<number | boolean | undefined>()
+    expectTypeOf<ResolveAppRouteRules<Contributed>['prerender']>().toEqualTypeOf<boolean | undefined>()
+  })
+
+  it('describes an app-facing rule as the app layer reads it, not as the builder declares it', () => {
+    interface Contributed { routeRules: { redirect?: { to: string, status: number } } }
+
+    expectTypeOf<ResolveAppRouteRules<Contributed>['redirect']>().toEqualTypeOf<string | undefined>()
+  })
+
+  it('falls back to the app-facing rules when a builder contributes none', () => {
+    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+    interface Empty {}
+
+    expectTypeOf<ResolveAppRouteRules<Empty>>().toExtend<AppRouteRulesBase>()
+    expectTypeOf<AppRouteRulesBase>().toExtend<ResolveAppRouteRules<Empty>>()
   })
 })

--- a/packages/vite-server/src/index.ts
+++ b/packages/vite-server/src/index.ts
@@ -51,6 +51,7 @@ export function bundle (nuxt: Nuxt): Promise<void> {
     output: { dir: () => outputDir, publicDir: () => publicDir },
     // TODO: report what actually claimed the server, once a target can declare itself
     capabilities: { server: nuxt.options.ssr !== false, dev: true },
+    buildsSeparately: false,
     // neither `nitro` nor `nitro/runtime-config` resolves in a build without nitro
     runtime: {
       fetch: resolve(distDir, 'runtime/fetch'),
@@ -58,10 +59,6 @@ export function bundle (nuxt: Nuxt): Promise<void> {
     },
     preview: { staticDir: () => publicDir },
   }, nuxt)
-
-  // The env-API path is the only one that does not route the client build, the dev
-  // middleware and the client manifest through nitro's own pipeline.
-  nuxt.options.experimental.nitroViteEnvironment = true
 
   // There is no server to read runtime config from the environment, so the values known
   // at build time are serialised instead. Only `app` and `public` are included: this

--- a/packages/vite/src/plugins/client-manifest.ts
+++ b/packages/vite/src/plugins/client-manifest.ts
@@ -9,7 +9,7 @@ import { serialize } from 'seroval'
 import type { Manifest as RendererManifest } from 'vue-bundle-renderer'
 import type { Plugin, Manifest as ViteClientManifest } from 'vite'
 import { setBuildOutput } from '@nuxt/kit'
-import { bundlerDiagnostics } from '@nuxt/kit/internal'
+import { bundlerDiagnostics, useServerBuild } from '@nuxt/kit/internal'
 import type { Nuxt } from '@nuxt/schema'
 import { resolveClientEntry, resolveClientManifestFile } from '../utils/config.ts'
 import { collectGlobalCss, toFsUrl } from '../utils/css.ts'
@@ -28,7 +28,7 @@ export function ClientManifestPlugin (nuxt: Nuxt): Plugin {
   // captured in-memory from the client env's bundle under env-API
   let rawClientManifest: ViteClientManifest | undefined
 
-  const envApi = nuxt.options.experimental.nitroViteEnvironment
+  const envApi = !useServerBuild(nuxt).buildsSeparately
 
   let finalized: Promise<void> | undefined
   const finalize = () => (finalized ??= finalizeBuildManifest())

--- a/packages/vite/src/plugins/dev-server.ts
+++ b/packages/vite/src/plugins/dev-server.ts
@@ -7,6 +7,7 @@ import type { H3Event as H3V1Event } from 'h3'
 import { tryUseNitro } from '@nuxt/kit'
 import { joinURL } from 'ufo'
 import type { IncomingMessage, ServerResponse } from 'node:http'
+import { useServerBuild } from '@nuxt/kit/internal'
 
 export function DevServerPlugin (nuxt: Nuxt): Plugin {
   let useViteCors = false
@@ -67,7 +68,7 @@ export function DevServerPlugin (nuxt: Nuxt): Plugin {
     async configureServer (viteServer) {
       await nuxt.callHook('vite:serverCreated', viteServer, { isClient: true, isServer: true })
 
-      if (nuxt.options.experimental.nitroViteEnvironment) {
+      if (!useServerBuild(nuxt).buildsSeparately) {
         return
       }
 

--- a/packages/vite/src/plugins/resolved-externals.ts
+++ b/packages/vite/src/plugins/resolved-externals.ts
@@ -2,6 +2,7 @@ import type { Plugin } from 'vite'
 import type { Nuxt } from '@nuxt/schema'
 import { resolveModulePath } from 'exsolve'
 import escapeStringRegexp from 'escape-string-regexp'
+import { useServerBuild } from '@nuxt/kit/internal'
 
 export function ResolveExternalsPlugin (nuxt: Nuxt): Plugin {
   let external: Set<string> = new Set()
@@ -18,7 +19,7 @@ export function ResolveExternalsPlugin (nuxt: Nuxt): Plugin {
       }
     },
     applyToEnvironment (environment) {
-      if (nuxt.options.dev || environment.name !== 'ssr' || nuxt.options.experimental.nitroViteEnvironment) {
+      if (nuxt.options.dev || environment.name !== 'ssr' || !useServerBuild(nuxt).buildsSeparately) {
         return false
       }
       return {

--- a/packages/vite/src/plugins/server-entry.ts
+++ b/packages/vite/src/plugins/server-entry.ts
@@ -3,16 +3,17 @@ import { pathToFileURL } from 'node:url'
 import { setBuildOutput } from '@nuxt/kit'
 import type { Nuxt } from '@nuxt/schema'
 import type { Plugin } from 'vite'
+import { useServerBuild } from '@nuxt/kit/internal'
 
 export function ServerEntryPlugin (nuxt: Nuxt, entry: string): Plugin | undefined {
-  if (!nuxt.options.experimental.nitroViteEnvironment && nuxt.options.dev) {
+  if (useServerBuild(nuxt).buildsSeparately && nuxt.options.dev) {
     return
   }
 
   const serverEntryFile = resolve(nuxt.options.buildDir, 'dist/server/server.mjs')
   const appEntryFile = pathToFileURL(entry).href
 
-  const serverEntryCode = nuxt.options.experimental.nitroViteEnvironment
+  const serverEntryCode = !useServerBuild(nuxt).buildsSeparately
     ? `export { default } from ${JSON.stringify(appEntryFile)}`
     : `export { default } from ${JSON.stringify(pathToFileURL(serverEntryFile).href)}`
   setBuildOutput('serverEntry', () => serverEntryCode)

--- a/packages/vite/src/plugins/sourcemap-preserver.ts
+++ b/packages/vite/src/plugins/sourcemap-preserver.ts
@@ -6,6 +6,7 @@ import escapeStringRegexp from 'escape-string-regexp'
 
 import type { Plugin as RollupPlugin } from 'rollup'
 import type { Plugin as VitePlugin } from 'vite'
+import { useServerBuild } from '@nuxt/kit/internal'
 
 export const SourcemapPreserverPlugin = (nuxt: Nuxt): VitePlugin | VitePlugin[] => {
   let outputDir: string
@@ -45,7 +46,7 @@ export const SourcemapPreserverPlugin = (nuxt: Nuxt): VitePlugin | VitePlugin[] 
 
   // there is no second rollup pass to hand the emitted sourcemaps to when nitro
   // runs as a vite environment
-  if (!nuxt.options.experimental.nitroViteEnvironment) {
+  if (useServerBuild(nuxt).buildsSeparately) {
     nuxt.hook('nitro:build:before', (nitro) => {
       nitro.options.rollupConfig = defu(nitro.options.rollupConfig, {
         plugins: [nitroPlugin()],

--- a/packages/vite/src/plugins/ssr-styles.ts
+++ b/packages/vite/src/plugins/ssr-styles.ts
@@ -13,6 +13,7 @@ import { IS_CSS_RE, isCSS, isVue, parseModuleId } from '../utils/index.ts'
 import { withInlineQuery } from '../utils/inline-styles.ts'
 import { resolveClientEntry } from '../utils/config.ts'
 import escapeStringRegexp from 'escape-string-regexp'
+import { useServerBuild } from '@nuxt/kit/internal'
 
 const SUPPORTED_FILES_RE = /\.(?:vue|(?:[cm]?j|t)sx?)$/
 const QUERY_RE = /\?.+$/
@@ -49,7 +50,7 @@ function wrapStringGenerateScopedName (
 export function SSRStylesPlugin (nuxt: Nuxt): Plugin | undefined {
   if (nuxt.options.dev) { return }
 
-  const envApi = nuxt.options.experimental.nitroViteEnvironment
+  const envApi = !useServerBuild(nuxt).buildsSeparately
 
   const chunksWithInlinedCSS = new Set<string>()
   // Client module graph (ids and importers with any query stripped), used to

--- a/packages/vite/src/plugins/vite-node.ts
+++ b/packages/vite/src/plugins/vite-node.ts
@@ -10,7 +10,7 @@ import { randomUUID } from 'node:crypto'
 import { win32 as pathWin32 } from 'node:path'
 import { dirname, join, normalize } from 'pathe'
 import { setBuildOutput, tryUseNuxt, useNitro } from '@nuxt/kit'
-import { bundlerDiagnostics } from '@nuxt/kit/internal'
+import { bundlerDiagnostics, useServerBuild } from '@nuxt/kit/internal'
 import type { EnvironmentModuleNode, ModuleNode, PluginContainer, ViteDevServer, Plugin as VitePlugin } from 'vite'
 import type { FetchResult } from 'vite-node'
 import type { Nitro } from 'nitro/types'
@@ -163,7 +163,7 @@ export function ViteNodePlugin (nuxt: Nuxt): VitePlugin | undefined {
   if (!nuxt.options.dev) {
     return
   }
-  if (nuxt.options.experimental.nitroViteEnvironment) {
+  if (!useServerBuild(nuxt).buildsSeparately) {
     return
   }
 

--- a/packages/vite/src/shared/server.ts
+++ b/packages/vite/src/shared/server.ts
@@ -5,9 +5,10 @@ import escapeStringRegexp from 'escape-string-regexp'
 import { withTrailingSlash } from 'ufo'
 
 import { getTranspilePatterns, getTranspileStrings } from '../utils/transpile.ts'
+import { useServerBuild } from '@nuxt/kit/internal'
 
 export function ssr (nuxt: Nuxt) {
-  const isEnvApi = nuxt.options.experimental.nitroViteEnvironment
+  const isEnvApi = !useServerBuild(nuxt).buildsSeparately
   return {
     external: isEnvApi
       ? []
@@ -28,7 +29,7 @@ export function ssr (nuxt: Nuxt) {
 }
 
 export function ssrEnvironment (nuxt: Nuxt, serverEntry: string) {
-  const isEnvApi = nuxt.options.experimental.nitroViteEnvironment
+  const isEnvApi = !useServerBuild(nuxt).buildsSeparately
   const sharedDirExternal = new RegExp('^' + escapeStringRegexp(withTrailingSlash(resolve(nuxt.options.rootDir, nuxt.options.dir.shared))))
   const legacyExternals = isEnvApi
     ? []

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -44,6 +44,7 @@ import { ResolveDeepImportsPlugin } from './plugins/resolve-deep-imports.ts'
 import { ResolveExternalsPlugin } from './plugins/resolved-externals.ts'
 import { PerfPlugin } from './plugins/perf.ts'
 import { isNavigationRequest, warmupViteServer } from './utils/warmup.ts'
+import { useServerBuild } from '@nuxt/kit/internal'
 
 export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
   const useAsyncEntry = nuxt.options.experimental.asyncEntry || nuxt.options.dev
@@ -121,7 +122,7 @@ export const bundle: NuxtBuilder['bundle'] = async (nuxt) => {
         },
       },
       // `nitro/vite`'s plugin runs the build process, including prerendering + asset copying
-      ...nuxt.options.experimental.nitroViteEnvironment
+      ...!useServerBuild(nuxt).buildsSeparately
         ? {}
         : {
             builder: {
@@ -368,7 +369,7 @@ function startWarmup (nuxt: Nuxt, server: vite.ViteDevServer, entry: string, ser
   }
 
   // we hook to avoid blocking nitro's build, and do not await crawl so we don't block the dev server
-  const nitro = nuxt.options.experimental.nitroViteEnvironment ? undefined : tryUseNitro()
+  const nitro = !useServerBuild(nuxt).buildsSeparately ? undefined : tryUseNitro()
   if (nitro) {
     nitro.hooks.hookOnce('compiled', () => { void run() })
   } else {

--- a/test/fixtures/basic-types/app/app-types.ts
+++ b/test/fixtures/basic-types/app/app-types.ts
@@ -13,7 +13,8 @@ import type { NuxtError, NuxtSSRContext, PageMeta, RequestEvent } from '#app'
 import type { NavigateToOptions } from '#app/composables/router'
 import { LazyWithTypes, NuxtIsland, NuxtLayout, NuxtLink, NuxtPage, ServerComponent, WithTypes } from '#components'
 import type { IslandComponent, LazyComponent } from '#components'
-import { prefetchComponents, preloadComponents, useRouter } from '#imports'
+import { getRouteRules, prefetchComponents, preloadComponents, useRequestEvent, useRouter } from '#imports'
+import type { LayoutKey } from '#build/types/nitro-layouts'
 
 type DefaultAsyncDataErrorValue = undefined
 type DefaultAsyncDataValue = undefined
@@ -1051,5 +1052,18 @@ describe('request event typing', () => {
     expectTypeOf(useRequestEvent()).toEqualTypeOf<H3Event | undefined>()
     expectTypeOf<NuxtSSRContext['event']>().toEqualTypeOf<H3Event>()
     expectTypeOf<RequestEvent>().toEqualTypeOf<H3Event>()
+  })
+})
+
+describe('route rules typing', () => {
+  it('resolves the rules contributed by `@nuxt/nitro-server`', () => {
+    const rules = getRouteRules(useRequestEvent()!)
+    expectTypeOf(rules.redirect).toEqualTypeOf<string | undefined>()
+    expectTypeOf(rules.prerender).toEqualTypeOf<boolean | undefined>()
+    expectTypeOf(rules.appMiddleware).toEqualTypeOf<Record<string, boolean> | undefined>()
+    expectTypeOf(rules.payload).toEqualTypeOf<boolean | undefined>()
+    expectTypeOf(rules.appLayout).toEqualTypeOf<LayoutKey | false | undefined>()
+    expectTypeOf(rules.swr).toBeAny()
+    expectTypeOf(rules.headers).toBeAny()
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

carries on from #36212 and #36218

### 📚 Description

this is another step towards a builder-agnostic server layer. after #36218 there were still a few places where core assumed the server builder was `@nuxt/nitro-server`

1. **app-facing route rules are now a nuxt type.** this makes sense as our implementation is internal (we even compile our own `rou3` router and previously we were piggy-backing on nitro

2. **server builder augmentations.** we now add `<server-builder>/augment` to nuxt types, if it exists, rather than special-casing 1st party nuxt builders.

3. we now register `serverBuild.buildsSeparately` instead of using `experimental.nitroViteEnvironment`. this may be relevant later for the rsbuild builder.
