### PR TITLE
fix(nitro): stop building request urls from parts on non-node runtimes

### DIFF
--- a/packages/nitro-server/src/runtime/utils/base.ts
+++ b/packages/nitro-server/src/runtime/utils/base.ts
@@ -1,5 +1,4 @@
 import { H3Event } from 'nitro/h3'
-import { FastURL } from 'srvx'
 import type { ServerRequest } from 'srvx'
 import { withoutTrailingSlash } from 'ufo'
 
@@ -17,13 +16,6 @@ const BASE_URL = /* @__PURE__ */ (() => {
 const BASE_URL_PREFIX = BASE_URL + '/'
 
 /**
- * `FastURL` also accepts the parts of an already-parsed URL, which is how `srvx` itself builds the
- * URL of an incoming request without paying for a parse, but its public types only declare the
- * `string | URL` constructor.
- */
-const FastURLFromParts = FastURL as unknown as new (init: { protocol: string, host: string, pathname: string, search: string }) => URL
-
-/**
  * The fragment of a request URL, without paying for it when there is none.
  *
  * `srvx` builds the URL of an incoming request from its parts, leaving `hash` to be resolved by
@@ -33,6 +25,21 @@ const FastURLFromParts = FastURL as unknown as new (init: { protocol: string, ho
  */
 export function urlHash (url: URL): string {
   return url.href.includes('#') ? url.hash : ''
+}
+
+/**
+ * Copy a request URL with `base` removed from its path.
+ */
+export function withoutBaseURL (url: URL, base: string): URL {
+  const href = url.href
+  const path = (url.pathname.slice(base.length) || '/') + url.search + urlHash(url)
+  const protocolEnd = href.indexOf('://')
+  const originEnd = protocolEnd === -1 ? -1 : href.indexOf('/', protocolEnd + 3)
+
+  // Taking the origin from `href` keeps this to a single parse
+  return originEnd === -1
+    ? new URL(path, url.origin)
+    : new URL(href.slice(0, originEnd) + path)
 }
 
 /**
@@ -47,22 +54,7 @@ export function createEvent (request: ServerRequest): H3Event {
     return event
   }
 
-  const url = event.url
-  const href = url.href
-  const pathname = url.pathname.slice(BASE_URL.length) || '/'
-  const hash = urlHash(url)
-  const protocolEnd = href.indexOf('://')
-  const hostEnd = protocolEnd === -1 ? -1 : href.indexOf('/', protocolEnd + 3)
-
-  event.url = hash || hostEnd === -1
-    // `FastURL` holds no fragment, so fall back to a full parse for the URLs that carry one
-    ? new URL(pathname + url.search + hash, url.origin)
-    : new FastURLFromParts({
-        protocol: href.slice(0, protocolEnd + 1),
-        host: href.slice(protocolEnd + 3, hostEnd),
-        pathname,
-        search: url.search,
-      })
+  event.url = withoutBaseURL(event.url, BASE_URL)
 
   return event
 }

--- a/packages/nitro-server/test/base-url.test.ts
+++ b/packages/nitro-server/test/base-url.test.ts
@@ -1,0 +1,46 @@
+import { FastURL } from 'srvx/node'
+import { describe, expect, it } from 'vitest'
+
+import { urlHash, withoutBaseURL } from '../src/runtime/utils/base.ts'
+
+// `srvx` builds the URL of an incoming request from its parts on Node, and hands over the platform
+// `URL` on runtimes it has no fast path for (workerd, and anything using the generic adapter).
+const requestURL = (path: string) => new (FastURL as unknown as new (init: unknown) => URL)({
+  protocol: 'https:',
+  host: 'example.com',
+  pathname: path.split('?')[0],
+  search: path.includes('?') ? path.slice(path.indexOf('?')) : '',
+})
+const platformURL = (path: string) => new URL(`https://example.com${path}`)
+
+describe.each([
+  ['srvx request url', requestURL],
+  ['platform url', platformURL],
+])('withoutBaseURL (%s)', (_name, url) => {
+  it.each([
+    ['/foo/bar', '/bar', 'https://example.com/bar'],
+    ['/foo/deep/nested?a=1&b=2', '/deep/nested', 'https://example.com/deep/nested?a=1&b=2'],
+    ['/foo', '/', 'https://example.com/'],
+    ['/foo/', '/', 'https://example.com/'],
+    ['/foo/bar#frag', '/bar', 'https://example.com/bar#frag'],
+  ])('%s -> %s', (path, pathname, href) => {
+    const stripped = withoutBaseURL(url(path), '/foo')
+    expect(stripped.pathname).toBe(pathname)
+    expect(stripped.href).toBe(href)
+  })
+
+  it('keeps the origin of the request', () => {
+    expect(withoutBaseURL(new URL('http://localhost:3000/foo/bar'), '/foo').href).toBe('http://localhost:3000/bar')
+    expect(withoutBaseURL(new URL('http://[::1]:3000/foo/bar'), '/foo').href).toBe('http://[::1]:3000/bar')
+  })
+})
+
+describe('urlHash', () => {
+  it('reads the fragment of a url that has one', () => {
+    expect(urlHash(new URL('https://example.com/a?b=1#frag'))).toBe('#frag')
+  })
+
+  it('is empty for a request url, which cannot carry one', () => {
+    expect(urlHash(requestURL('/a?b=1'))).toBe('')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this fixes an issue I introduced in #36174...

`srvx` only implements `FastURL` for Node, Deno and Bun, so this rewrites `withoutBaseURL` to use only standard `URL` properties
