### PR TITLE
fix(nuxt): serialize numeric v-for island slot scopes 1-based

### DIFF
--- a/packages/nuxt/src/app/components/utils.ts
+++ b/packages/nuxt/src/app/components/utils.ts
@@ -115,7 +115,8 @@ export function vforToArray (source: any): any[] {
     const length = source > MAX_VFOR_LENGTH ? MAX_VFOR_LENGTH : source
     const array: number[] = []
     for (let i = 0; i < length; i++) {
-      array[i] = i
+      // Vue's `v-for` over a number is 1-based
+      array[i] = i + 1
     }
     return array
   } else if (isObject(source)) {

--- a/test/nuxt/component-utils.test.ts
+++ b/test/nuxt/component-utils.test.ts
@@ -1,6 +1,21 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { getFragmentHTML } from '../../packages/nuxt/src/app/components/utils'
+import { renderList } from 'vue'
+import { getFragmentHTML, vforToArray } from '../../packages/nuxt/src/app/components/utils'
+
+describe('vforToArray', () => {
+  it('matches renderList semantics for number sources', () => {
+    expect(vforToArray(3)).toEqual([1, 2, 3])
+    expect(vforToArray(3)).toEqual(renderList(3, (item: number) => item))
+  })
+
+  it('matches renderList semantics for string, array and iterable sources', () => {
+    expect(vforToArray('ab')).toEqual(renderList('ab', (item: string) => item))
+    expect(vforToArray(['a', 'b'])).toEqual(renderList(['a', 'b'], (item: string) => item))
+    expect(vforToArray(new Set(['a', 'b']))).toEqual(renderList(new Set(['a', 'b']), (item: string) => item))
+    expect(vforToArray({ a: 1, b: 2 })).toEqual(renderList({ a: 1, b: 2 }, (item: number) => item))
+  })
+})
 
 describe('getFragmentHTML', () => {
   afterEach(() => {

--- a/test/server-components.test.ts
+++ b/test/server-components.test.ts
@@ -338,13 +338,13 @@ describe('component islands', () => {
             "fallback": "<!--teleport start anchor--><!--[--><div style="display:contents;"><div> fallback slot -- index: 0</div></div><div style="display:contents;"><div> fallback slot -- index: 1</div></div><div style="display:contents;"><div> fallback slot -- index: 2</div></div><!--]--><!--teleport anchor-->",
             "props": [
               {
-                "t": 0,
-              },
-              {
                 "t": 1,
               },
               {
                 "t": 2,
+              },
+              {
+                "t": 3,
               },
             ],
           },


### PR DESCRIPTION
v-for="n in 3" renders 1,2,3 in Vue but vforToArray(3) returned [0,1,2]

### 📚 Description

I was playing around with vforToArray and I figured this just doesn't make sense, fixed and tested.