### PR TITLE
fix(kit,nuxt,schema,vite-server): let vite plugins own the deploy target

### DIFF
--- a/docs/3.guide/6.going-further/8.builders.md
+++ b/docs/3.guide/6.going-further/8.builders.md
@@ -219,6 +219,28 @@ For a custom builder you only need to satisfy the generic contract. The Vite Env
 
 Which of the two paths is in use is decided by the *server* builder, not by the flag directly: a server builder declares whether its build is a pass of its own, run after the app build, or an environment of the app builder's build. `@nuxt/nitro-server` declares it from `experimental.nitroViteEnvironment`, and a server builder with no build pass of its own (such as `@nuxt/vite-server`) declares that Vite is building everything.
 
+## Describing the Build to a Deploy Target
+
+A server builder describes what it produced, so that tooling that deploys or previews the build does not have to know which builder ran. The description lives on `nuxt.serverBuild`, and is read with `useServerBuild()` from `@nuxt/kit/internal`:
+
+```ts
+import { useServerBuild } from '@nuxt/kit/internal'
+
+const build = useServerBuild()
+
+build.output.root() // the project root: where a target's own config file lives
+build.output.dir() // the build output directory
+build.output.publicDir() // the deployable static assets within it
+```
+
+Every path is a function, because a builder may only resolve it while initialising, so call them from a hook that runs after the server builder has run.
+
+`output.root()` is deliberately not a bundler root. Nuxt points Vite's `root` at [`srcDir`](/docs/4.x/api/nuxt-config#srcdir), so a deploy target that resolves its configuration file (or the paths written inside it) from the bundler's root looks inside your app directory rather than at the root of your project. A target that reads the description resolves both correctly.
+
+::warning
+`nuxt.serverBuild` and the `setServerBuild()` / `useServerBuild()` helpers are experimental and exported from `@nuxt/kit/internal`. The shape will change without a major release while a second server builder is being built out.
+::
+
 ::read-more{to="/docs/4.x/guide/going-further/internals"}
 Learn more about the Nuxt interface and the build vs. runtime split.
 ::

--- a/packages/kit/src/diagnostics/bundler.ts
+++ b/packages/kit/src/diagnostics/bundler.ts
@@ -121,5 +121,10 @@ export const bundlerDiagnostics = /* #__PURE__ */ defineDiagnostics({
       fix: 'Relative directories are resolved against your project root. Correct the `dir` or remove the entry.',
       docs: false,
     },
+    NUXT_B7024: {
+      why: (p: { outDir: string, publicDir: string }) => `The client build output directory is set to \`${p.outDir}\`, but the server builder writes the client build to \`${p.publicDir}\`, so the override is ignored.`,
+      fix: 'Remove the `vite.$client.build.outDir` override from your `nuxt.config`, and set `nitro.output.publicDir` to move the whole public output instead.',
+      docs: false,
+    },
   },
 })

--- a/packages/kit/src/diagnostics/bundler.ts
+++ b/packages/kit/src/diagnostics/bundler.ts
@@ -126,5 +126,10 @@ export const bundlerDiagnostics = /* #__PURE__ */ defineDiagnostics({
       fix: 'Remove the `vite.$client.build.outDir` override from your `nuxt.config`, and set `nitro.output.publicDir` to move the whole public output instead.',
       docs: false,
     },
+    NUXT_B7025: {
+      why: (p: { input: string }) => `The client build input is set to \`${p.input}\`, which cannot carry the document the server builder emits, so the override is ignored.`,
+      fix: 'Pass an object to `vite.$client.build.rolldownOptions.input` if you need additional inputs, or add an `index.html` at the root of your app directory to take over the document itself.',
+      docs: false,
+    },
   },
 })

--- a/packages/kit/src/internal/server-build.ts
+++ b/packages/kit/src/internal/server-build.ts
@@ -55,6 +55,7 @@ export function createServerBuild (options: NuxtOptions): NuxtServerBuild {
     name: typeof options.server?.builder === 'string' ? options.server.builder : 'custom',
     buildsSeparately: !options.experimental?.nitroViteEnvironment,
     output: {
+      root: () => options.rootDir,
       dir: () => resolve(options.rootDir, outputDir()),
       publicDir: () => resolve(options.rootDir, options.nitro?.output?.publicDir || join(outputDir(), 'public')),
     },

--- a/packages/nuxt/schema.d.ts
+++ b/packages/nuxt/schema.d.ts
@@ -9,6 +9,8 @@ import type {
   NuxtHooks as _NuxtHooks,
   NuxtOptions as _NuxtOptions,
   NuxtPage as _NuxtPage,
+  ServerRoutes as _ServerRoutes,
+  ServerTypes as _ServerTypes,
   SharedAppConfig as _SharedAppConfig,
   ViteOptions as _ViteOptions,
 } from '@nuxt/schema'
@@ -39,4 +41,8 @@ declare module 'nuxt/schema' {
   interface NuxtDebugOptions extends _NuxtDebugOptions {}
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type
   interface ViteOptions extends _ViteOptions {}
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  interface ServerTypes extends _ServerTypes {}
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  interface ServerRoutes extends _ServerRoutes {}
 }

--- a/packages/schema/src/types/nuxt.ts
+++ b/packages/schema/src/types/nuxt.ts
@@ -150,6 +150,16 @@ export interface NuxtBuildOutputs {
  * @internal
  */
 export interface NuxtServerBuildOutput {
+  /**
+   * Absolute path to the root of the project the build belongs to, without a trailing
+   * slash: where a deploy target's own configuration file lives and what the paths in it
+   * are written relative to.
+   *
+   * This is the project root rather than a bundler's notion of a root, which need not be
+   * the same directory: Nuxt points Vite's `root` at `srcDir`, so a target resolving its
+   * configuration from there looks in the wrong place.
+   */
+  root: () => string
   /** Absolute path to the build output directory, without a trailing slash. */
   dir: () => string
   /**

--- a/packages/vite-server/src/dev.ts
+++ b/packages/vite-server/src/dev.ts
@@ -10,16 +10,18 @@ import { publicDirs } from './output.ts'
 /**
  * Vite runs in middleware mode, so it creates no HTTP server of its own and leaves
  * `server.httpServer` null. Nuxt does listen, and its middlewares are served from that
- * listener, so it is exposes it Vite so other plugins can attach to it.
+ * listener, so the listener is exposed to Vite for other plugins to attach to.
  */
 export function DevServerListenerPlugin (nuxt: Nuxt): Plugin {
   return {
     name: 'nuxt:vite-server:dev-listener',
-    // before any plugin that reads the server while configuring itself
     enforce: 'pre',
     apply: 'serve',
-    configureServer (server) {
-      server.httpServer ||= nuxt._devServerListener ?? null
+    configureServer: {
+      order: 'pre',
+      handler (server) {
+        server.httpServer ||= nuxt._devServerListener ?? null
+      },
     },
   }
 }

--- a/packages/vite-server/src/dev.ts
+++ b/packages/vite-server/src/dev.ts
@@ -2,10 +2,27 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { Nuxt } from '@nuxt/schema'
 import { NodeRequest, sendNodeResponse } from 'srvx/node'
 import { serveStatic } from 'srvx/static'
-import type { ViteDevServer } from 'vite'
+import type { Plugin, ViteDevServer } from 'vite'
 
 import { resolveDocument } from './document.ts'
 import { publicDirs } from './output.ts'
+
+/**
+ * Vite runs in middleware mode, so it creates no HTTP server of its own and leaves
+ * `server.httpServer` null. Nuxt does listen, and its middlewares are served from that
+ * listener, so it is exposes it Vite so other plugins can attach to it.
+ */
+export function DevServerListenerPlugin (nuxt: Nuxt): Plugin {
+  return {
+    name: 'nuxt:vite-server:dev-listener',
+    // before any plugin that reads the server while configuring itself
+    enforce: 'pre',
+    apply: 'serve',
+    configureServer (server) {
+      server.httpServer ||= nuxt._devServerListener ?? null
+    },
+  }
+}
 
 export function setupDevServer (nuxt: Nuxt): void {
   let viteServer: ViteDevServer | undefined

--- a/packages/vite-server/src/document.ts
+++ b/packages/vite-server/src/document.ts
@@ -97,7 +97,7 @@ export function BuildEnvironmentsPlugin (nuxt: Nuxt): Plugin {
     name: 'nuxt:vite-server:build-environments',
     apply: 'build',
     buildApp: {
-      order: 'pre',
+      order: 'post',
       async handler (builder) {
         const ssr = builder.environments.ssr
         if (ssr && nuxt.options.ssr === false) {

--- a/packages/vite-server/src/index.ts
+++ b/packages/vite-server/src/index.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs'
 import { resolve } from 'pathe'
 import { addTemplate, addVitePlugin, getLayerDirectories, logger } from '@nuxt/kit'
-import { setServerBuild } from '@nuxt/kit/internal'
+import { bundlerDiagnostics, setServerBuild } from '@nuxt/kit/internal'
 import { defu } from 'defu'
 import { resolveModulePath } from 'exsolve'
 import type { Nuxt } from '@nuxt/schema'
@@ -88,13 +88,23 @@ export function bundle (nuxt: Nuxt): Promise<void> {
     //
     // the client build writes straight into the public directory of the output, so that a
     // target reading the client environment's `outDir` finds the deployable assets there
-    nuxt.options.vite.$client = defu(nuxt.options.vite.$client, {
+    const client = defu(nuxt.options.vite.$client, {
       build: {
         outDir: publicDir,
         emptyOutDir: true,
         rolldownOptions: { input: { index: documentPath(nuxt) } },
       },
     })
+
+    // the client output directory belongs to the build rather than to the project: it is
+    // the directory `output.publicDir()` reports and the one the output is finished in
+    // place from, so a configured value is reported and replaced rather than merged
+    if (resolve(nuxt.options.rootDir, client.build.outDir) !== publicDir) {
+      bundlerDiagnostics.NUXT_B7024({ outDir: client.build.outDir, publicDir })
+      client.build.outDir = publicDir
+    }
+
+    nuxt.options.vite.$client = client
     addVitePlugin(() => [DocumentPlugin(nuxt), EntryImportMapPlugin()], { server: false })
   }
 

--- a/packages/vite-server/src/index.ts
+++ b/packages/vite-server/src/index.ts
@@ -85,8 +85,15 @@ export function bundle (nuxt: Nuxt): Promise<void> {
     // the document is a real HTML build input, so vite links the entry chunk, injects its
     // stylesheets and module preloads, and runs the `transformIndexHtml` hook of every
     // configured plugin over it
+    //
+    // the client build writes straight into the public directory of the output, so that a
+    // target reading the client environment's `outDir` finds the deployable assets there
     nuxt.options.vite.$client = defu(nuxt.options.vite.$client, {
-      build: { rolldownOptions: { input: { index: documentPath(nuxt) } } },
+      build: {
+        outDir: publicDir,
+        emptyOutDir: true,
+        rolldownOptions: { input: { index: documentPath(nuxt) } },
+      },
     })
     addVitePlugin(() => [DocumentPlugin(nuxt), EntryImportMapPlugin()], { server: false })
   }

--- a/packages/vite-server/src/index.ts
+++ b/packages/vite-server/src/index.ts
@@ -7,7 +7,7 @@ import { resolveModulePath } from 'exsolve'
 import type { Nuxt } from '@nuxt/schema'
 
 import { distDir } from './dirs.ts'
-import { setupDevServer } from './dev.ts'
+import { DevServerListenerPlugin, setupDevServer } from './dev.ts'
 import { BuildEnvironmentsPlugin, DocumentPlugin, EntryImportMapPlugin, documentPath } from './document.ts'
 import { writeStaticOutput } from './output.ts'
 
@@ -79,7 +79,7 @@ export function bundle (nuxt: Nuxt): Promise<void> {
   // Registered at the root rather than through `addVitePlugin`, which scopes plugins to
   // an environment, where an app-level `buildApp` hook is never called.
   nuxt.options.vite.plugins ||= []
-  nuxt.options.vite.plugins.push(BuildEnvironmentsPlugin(nuxt))
+  nuxt.options.vite.plugins.push(BuildEnvironmentsPlugin(nuxt), DevServerListenerPlugin(nuxt))
 
   if (!nuxt.options.dev) {
     // the document is a real HTML build input, so vite links the entry chunk, injects its

--- a/packages/vite-server/src/index.ts
+++ b/packages/vite-server/src/index.ts
@@ -104,6 +104,14 @@ export function bundle (nuxt: Nuxt): Promise<void> {
       client.build.outDir = publicDir
     }
 
+    // an input that is not a set of named inputs replaces the document rather than adding
+    // to it, and takes the app entry with it, so it is reported and replaced too
+    const input = client.build.rolldownOptions.input
+    if (typeof input !== 'object' || Array.isArray(input)) {
+      bundlerDiagnostics.NUXT_B7025({ input: JSON.stringify(input) })
+      client.build.rolldownOptions.input = { index: documentPath(nuxt) }
+    }
+
     nuxt.options.vite.$client = client
     addVitePlugin(() => [DocumentPlugin(nuxt), EntryImportMapPlugin()], { server: false })
   }

--- a/packages/vite-server/src/output.ts
+++ b/packages/vite-server/src/output.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs'
-import { cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { cp, readFile, rm, writeFile } from 'node:fs/promises'
 import { join, resolve } from 'pathe'
 import { getLayerDirectories, logger } from '@nuxt/kit'
 import { bundlerDiagnostics } from '@nuxt/kit/internal'
@@ -13,25 +13,21 @@ import { template as defaultSpaLoadingTemplate } from './templates/spa-loading-i
 const SPA_FALLBACK_FILES = ['index.html', '200.html', '404.html']
 
 export async function writeStaticOutput (nuxt: Nuxt, publicDir: string): Promise<void> {
-  const clientDir = resolve(nuxt.options.buildDir, 'dist/client')
-  const document = resolve(clientDir, 'index.html')
+  const document = resolve(publicDir, 'index.html')
 
   if (!existsSync(document)) {
     throw new Error(`[nuxt:vite-server] Expected \`${document}\` to exist. Did the client build run?`)
   }
 
   const html = await readFile(document, 'utf-8')
-  await rm(resolve(clientDir, 'manifest.json'), { force: true })
+  await rm(resolve(publicDir, 'manifest.json'), { force: true })
 
-  await mkdir(publicDir, { recursive: true })
-
+  // copied after the build, which writes into this directory and empties it first
   for (const dirs of getLayerDirectories(nuxt)) {
     if (existsSync(dirs.public)) {
       await cp(dirs.public, publicDir, { recursive: true })
     }
   }
-
-  await cp(clientDir, publicDir, { recursive: true })
 
   for (const file of SPA_FALLBACK_FILES) {
     await writeFile(join(publicDir, file), html, 'utf-8')

--- a/test/vite-server-spa.test.ts
+++ b/test/vite-server-spa.test.ts
@@ -1,5 +1,6 @@
 import { fileURLToPath } from 'node:url'
-import { readFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { readFile, rm } from 'node:fs/promises'
 import { join } from 'pathe'
 import { beforeAll, describe, expect, it } from 'vitest'
 import { buildNuxt, loadNuxt } from '@nuxt/kit'
@@ -130,5 +131,34 @@ describe.skipIf(!runsOnceInMatrix)('server environment', () => {
 
   it('still emits a client document', async () => {
     expect(await readFile(join(outputDir, 'public/index.html'), 'utf-8')).toContain('<div id="__nuxt">')
+  })
+})
+
+describe.skipIf(!runsOnceInMatrix)('configured client output directory', () => {
+  const buildDir = join(rootDir, 'node_modules/.cache/nuxt/.nuxt-client-outdir')
+  const outputDir = join(rootDir, 'node_modules/.cache/nuxt/.output-client-outdir')
+  const configuredDir = join(rootDir, 'node_modules/.cache/nuxt/.client-outdir-override')
+
+  beforeAll(async () => {
+    await rm(configuredDir, { recursive: true, force: true })
+    const nuxt = await loadNuxt({
+      cwd: rootDir,
+      ready: true,
+      overrides: {
+        buildDir,
+        nitro: { output: { dir: outputDir } },
+        vite: { $client: { build: { outDir: configuredDir } } },
+      },
+    })
+    try {
+      await buildNuxt(nuxt)
+    } finally {
+      await nuxt.close()
+    }
+  }, 240 * 1000)
+
+  it('writes the client build to the public directory of the output', async () => {
+    expect(await readFile(join(outputDir, 'public/index.html'), 'utf-8')).toContain('<div id="__nuxt">')
+    expect(existsSync(configuredDir)).toBe(false)
   })
 })

--- a/test/vite-server-spa.test.ts
+++ b/test/vite-server-spa.test.ts
@@ -112,9 +112,10 @@ describe.skipIf(!runsOnceInMatrix)('pure vite static SPA build', () => {
 
 describe.skipIf(!runsOnceInMatrix)('server environment', () => {
   const buildDir = join(rootDir, 'node_modules/.cache/nuxt/.nuxt-ssr')
+  const outputDir = join(rootDir, 'node_modules/.cache/nuxt/.output-ssr')
 
   beforeAll(async () => {
-    const nuxt = await loadNuxt({ cwd: rootDir, ready: true, overrides: { ssr: true, buildDir } })
+    const nuxt = await loadNuxt({ cwd: rootDir, ready: true, overrides: { ssr: true, buildDir, nitro: { output: { dir: outputDir } } } })
     try {
       await buildNuxt(nuxt)
     } finally {
@@ -128,6 +129,6 @@ describe.skipIf(!runsOnceInMatrix)('server environment', () => {
   })
 
   it('still emits a client document', async () => {
-    expect(await readFile(join(buildDir, 'dist/client/index.html'), 'utf-8')).toContain('<div id="__nuxt">')
+    expect(await readFile(join(outputDir, 'public/index.html'), 'utf-8')).toContain('<div id="__nuxt">')
   })
 })

--- a/test/vite-server-spa.test.ts
+++ b/test/vite-server-spa.test.ts
@@ -134,9 +134,9 @@ describe.skipIf(!runsOnceInMatrix)('server environment', () => {
   })
 })
 
-describe.skipIf(!runsOnceInMatrix)('configured client output directory', () => {
-  const buildDir = join(rootDir, 'node_modules/.cache/nuxt/.nuxt-client-outdir')
-  const outputDir = join(rootDir, 'node_modules/.cache/nuxt/.output-client-outdir')
+describe.skipIf(!runsOnceInMatrix)('overridden client build options', () => {
+  const buildDir = join(rootDir, 'node_modules/.cache/nuxt/.nuxt-client-overrides')
+  const outputDir = join(rootDir, 'node_modules/.cache/nuxt/.output-client-overrides')
   const configuredDir = join(rootDir, 'node_modules/.cache/nuxt/.client-outdir-override')
 
   beforeAll(async () => {
@@ -147,7 +147,14 @@ describe.skipIf(!runsOnceInMatrix)('configured client output directory', () => {
       overrides: {
         buildDir,
         nitro: { output: { dir: outputDir } },
-        vite: { $client: { build: { outDir: configuredDir } } },
+        vite: {
+          $client: {
+            build: {
+              outDir: configuredDir,
+              rolldownOptions: { input: join(rootDir, 'app/app.vue') },
+            },
+          },
+        },
       },
     })
     try {
@@ -160,5 +167,12 @@ describe.skipIf(!runsOnceInMatrix)('configured client output directory', () => {
   it('writes the client build to the public directory of the output', async () => {
     expect(await readFile(join(outputDir, 'public/index.html'), 'utf-8')).toContain('<div id="__nuxt">')
     expect(existsSync(configuredDir)).toBe(false)
+  })
+
+  it('keeps the document and the app entry as build inputs', async () => {
+    const html = await readFile(join(outputDir, 'public/index.html'), 'utf-8')
+
+    expect(html).toMatch(/<script type="module"[^>]* src="\.\/_nuxt\/[^"]+\.js">/)
+    expect(html).toContain('"#entry"')
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

follows on from #36223

### 📚 Description

spotted a few issues when testing with vite plugins which provide a server environment

1. the client environment was built twice when plugins brought their own `builder.buildApp`
2. `build.outDir` is now where we emit static files so other vite plugins are aware of them
3. we expose the nuxt dev server to vite plugins
4. `ServerTypes` and `ServerRoutes` were missing from the bridge in `packages/nuxt/schema.d.ts` that the other registries already go through
5. finally, `output.root()` on the server build descriptor now points to the project root (= `rootDir`) as opposed to a bundler's root (= `srcDir`)