### PR TITLE
fix(vite): rewrite `optimizeDeps.include` for installed layers

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -46,6 +46,7 @@
     "rolldown-string": "catalog:vite",
     "seroval": "catalog:build",
     "std-env": "catalog:build",
+    "tinyglobby": "catalog:build",
     "ufo": "catalog:build",
     "unenv": "catalog:build",
     "vite": "catalog:vite",

--- a/packages/vite/src/plugins/optimize-deps.ts
+++ b/packages/vite/src/plugins/optimize-deps.ts
@@ -1,7 +1,8 @@
 import type { Plugin } from 'vite'
 import type { Nuxt } from '@nuxt/schema'
 
-import { installedScanEntries, resolveOptimizeDepsInclude } from '../utils/optimize-deps.ts'
+import { toArray } from '../utils/index.ts'
+import { createOptimizeDepsIncludeResolver, installedScanEntries } from '../utils/optimize-deps.ts'
 import { userOptimizeDepsInclude } from './optimize-deps-hint.ts'
 
 /**
@@ -16,33 +17,28 @@ export function OptimizeDepsPlugin (nuxt: Nuxt): Plugin {
     name: 'nuxt:optimize-deps',
     enforce: 'post',
 
-    async configEnvironment (name, config) {
+    configEnvironment (name, config) {
       if (name !== 'client') { return }
 
       const scanEntries = installedScanEntries(nuxt)
-      if (!scanEntries.length) { return }
-
-      config.optimizeDeps ||= {}
-
-      const entries = config.optimizeDeps.entries
-      config.optimizeDeps.entries = [...typeof entries === 'string' ? [entries] : entries || [], ...scanEntries]
-
-      const include = config.optimizeDeps.include
-      if (include?.length) {
-        const resolved = await resolveOptimizeDepsInclude(nuxt, include)
-
-        // rewritten entries must stay attributable to the user in `NUXT_B7002`
-        const userInclude = userOptimizeDepsInclude.get(nuxt)
-        if (userInclude) {
-          for (const [index, entry] of include.entries()) {
-            if (resolved[index] !== entry && userInclude.includes(entry)) {
-              userInclude.push(resolved[index]!)
-            }
-          }
-        }
-
-        config.optimizeDeps.include = resolved
+      if (scanEntries.length) {
+        const optimizeDeps = config.optimizeDeps ||= {}
+        optimizeDeps.entries = [...optimizeDeps.entries ? toArray(optimizeDeps.entries) : [], ...scanEntries]
       }
+
+      const include = config.optimizeDeps?.include
+      if (!include?.length) { return }
+
+      const resolveInclude = createOptimizeDepsIncludeResolver(nuxt, {
+        // vite merges the top-level `resolve` into every environment but does not type it there
+        preserveSymlinks: (config.resolve as { preserveSymlinks?: boolean } | undefined)?.preserveSymlinks,
+      })
+
+      // rewritten entries must stay attributable to the user in `NUXT_B7002`
+      const userInclude = userOptimizeDepsInclude.get(nuxt)
+      userInclude?.push(...resolveInclude(userInclude).filter(entry => !userInclude.includes(entry)))
+
+      config.optimizeDeps!.include = resolveInclude(include)
     },
   }
 }

--- a/packages/vite/src/plugins/optimize-deps.ts
+++ b/packages/vite/src/plugins/optimize-deps.ts
@@ -2,7 +2,7 @@ import type { Plugin } from 'vite'
 import type { Nuxt } from '@nuxt/schema'
 
 import { toArray } from '../utils/index.ts'
-import { createOptimizeDepsIncludeResolver, installedScanEntries } from '../utils/optimize-deps.ts'
+import { installedScanEntries, resolveOptimizeDepsInclude } from '../utils/optimize-deps.ts'
 import { userOptimizeDepsInclude } from './optimize-deps-hint.ts'
 
 /**
@@ -21,24 +21,33 @@ export function OptimizeDepsPlugin (nuxt: Nuxt): Plugin {
       if (name !== 'client') { return }
 
       const scanEntries = installedScanEntries(nuxt)
-      if (scanEntries.length) {
-        const optimizeDeps = config.optimizeDeps ||= {}
-        optimizeDeps.entries = [...optimizeDeps.entries ? toArray(optimizeDeps.entries) : [], ...scanEntries]
+      if (!scanEntries.length) { return }
+
+      config.optimizeDeps ||= {}
+
+      const entries = config.optimizeDeps.entries
+      config.optimizeDeps.entries = [...entries ? toArray(entries) : [], ...scanEntries]
+
+      const include = config.optimizeDeps.include
+      if (include?.length) {
+        const resolved = resolveOptimizeDepsInclude(nuxt, include, {
+          // vite merges the top-level `resolve` into every environment but does not type it there
+          preserveSymlinks: (config.resolve as { preserveSymlinks?: boolean } | undefined)?.preserveSymlinks,
+        })
+
+        // rewritten entries must stay attributable to the user in `NUXT_B7002`
+        const userInclude = userOptimizeDepsInclude.get(nuxt)
+        if (userInclude) {
+          for (const [index, entry] of include.entries()) {
+            if (!userInclude.includes(entry)) { continue }
+            for (const resolvedEntry of resolved[index]!) {
+              if (!userInclude.includes(resolvedEntry)) { userInclude.push(resolvedEntry) }
+            }
+          }
+        }
+
+        config.optimizeDeps.include = resolved.flat()
       }
-
-      const include = config.optimizeDeps?.include
-      if (!include?.length) { return }
-
-      const resolveInclude = createOptimizeDepsIncludeResolver(nuxt, {
-        // vite merges the top-level `resolve` into every environment but does not type it there
-        preserveSymlinks: (config.resolve as { preserveSymlinks?: boolean } | undefined)?.preserveSymlinks,
-      })
-
-      // rewritten entries must stay attributable to the user in `NUXT_B7002`
-      const userInclude = userOptimizeDepsInclude.get(nuxt)
-      userInclude?.push(...resolveInclude(userInclude).filter(entry => !userInclude.includes(entry)))
-
-      config.optimizeDeps!.include = resolveInclude(include)
     },
   }
 }

--- a/packages/vite/src/utils/optimize-deps.ts
+++ b/packages/vite/src/utils/optimize-deps.ts
@@ -3,7 +3,7 @@ import { dirname, isAbsolute, join, normalize } from 'pathe'
 import { withTrailingSlash } from 'ufo'
 import { resolveModulePath } from 'exsolve'
 import { escapePath } from 'tinyglobby'
-import { getLayerDirectories } from '@nuxt/kit'
+import { getLayerDirectories, packageName } from '@nuxt/kit'
 import { parseNodeModulePath } from '@nuxt/kit/internal'
 import type { Nuxt } from '@nuxt/schema'
 
@@ -23,6 +23,7 @@ const SERVER_FILE_RE = /\.server\.(?:vue|js|jsx|mjs|ts|tsx|mts)$/
  */
 export function installedScanEntries (nuxt: Nuxt): string[] {
   const entries = new Set<string>()
+  const projectRoot = withTrailingSlash(nuxt.options.rootDir)
   const apps = Object.values(nuxt.apps)
   const serverFiles = apps.flatMap(app => [
     ...app.components.filter(c => c.mode === 'server').map(c => c.filePath),
@@ -36,7 +37,8 @@ export function installedScanEntries (nuxt: Nuxt): string[] {
     serverFiles.push(...Object.values(page.components || {}).map(normalize))
   }
 
-  for (const dirs of getLayerDirectories(nuxt).slice(1)) {
+  for (const dirs of getLayerDirectories(nuxt)) {
+    if (dirs.root === projectRoot) { continue }
     const app = withTrailingSlash(normalize(dirs.app))
     if (!app.includes(NODE_MODULES)) { continue }
     const dir = escapePath(app)
@@ -73,19 +75,19 @@ export function installedScanEntries (nuxt: Nuxt): string[] {
   return [...entries]
 }
 
-function packageName (entry: string) {
-  const segments = entry.split('/')
-  return entry.startsWith('@') ? segments.slice(0, 2).join('/') : segments[0]!
-}
-
 /**
- * Creates a cached resolver for Vite's nested dependency syntax. The layer graph and
- * package resolutions are shared across every include list for one Vite environment.
+ * Rewrites `optimizeDeps.include` entries that only resolve from an installed layer into
+ * Vite's nested `parent > dep` form, resolved relative to the parent package rather than
+ * the project root.
+ *
+ * One entry can resolve to several distinct copies of a package, so each input entry maps
+ * to an array of output entries, aligned by index.
  */
-export function createOptimizeDepsIncludeResolver (nuxt: Nuxt, options: { preserveSymlinks?: boolean } = {}) {
+export function resolveOptimizeDepsInclude (nuxt: Nuxt, include: string[], options: { preserveSymlinks?: boolean } = {}): string[][] {
   const rootDir = normalize(nuxt.options.rootDir)
+  const projectRoot = withTrailingSlash(rootDir)
   const realPathCache = new Map<string, string>()
-  const packageRootCache = new Map<string, string | undefined>()
+  const packageDirCache = new Map<string, string | undefined>()
 
   function realPath (path: string) {
     const normalized = normalize(path)
@@ -96,37 +98,40 @@ export function createOptimizeDepsIncludeResolver (nuxt: Nuxt, options: { preser
     return resolved
   }
 
-  function resolvePackageRoot (name: string, from: string) {
-    let directory = normalize(from)
+  /** Find the `node_modules` directory `name` installs into, searching up from `dir`. */
+  function resolvePackageDir (name: string, dir: string) {
+    let directory = normalize(dir)
     const key = `${directory}\0${name}`
-    if (packageRootCache.has(key)) { return packageRootCache.get(key) }
+    if (packageDirCache.has(key)) { return packageDirCache.get(key) }
 
     while (true) {
       const candidate = join(directory, 'node_modules', name)
       if (existsSync(candidate)) {
         const resolved = normalize(candidate)
-        packageRootCache.set(key, resolved)
+        packageDirCache.set(key, resolved)
         return resolved
       }
       const parent = dirname(directory)
       if (parent === directory) {
-        packageRootCache.set(key, undefined)
+        packageDirCache.set(key, undefined)
         return
       }
       directory = parent
     }
   }
 
-  function isResolvable (id: string, from: string) {
-    return !!resolveModulePath(id, { from, try: true, extensions: ['.mjs', '.js', '.cjs', '.json'] })
+  function isResolvableFrom (id: string, dir: string) {
+    return !!resolveModulePath(id, { from: dir, try: true, extensions: ['.mjs', '.js', '.cjs', '.json'] })
   }
 
-  function dependencyIdentity (root: string) {
-    return options.preserveSymlinks ? root : realPath(root)
+  // Vite resolves symlinked copies to one dependency unless `preserveSymlinks` is set.
+  function dependencyIdentity (dir: string) {
+    return options.preserveSymlinks ? dir : realPath(dir)
   }
 
   const layers: Array<{ name: string, root: string, identity: string }> = []
-  for (const dirs of getLayerDirectories(nuxt).slice(1)) {
+  for (const dirs of getLayerDirectories(nuxt)) {
+    if (dirs.root === projectRoot) { continue }
     // Vite needs the installed alias, which can differ from the package manifest name.
     const { dir, name } = parseNodeModulePath(dirs.root)
     if (!dir || !name || !existsSync(dir + name)) { continue }
@@ -135,45 +140,39 @@ export function createOptimizeDepsIncludeResolver (nuxt: Nuxt, options: { preser
 
   // Walk out from the project so every layer keeps the full chain Vite resolves it through.
   const layerChains = new Map<string, string[]>()
-  const queue: Array<{ root: string, chain: string[] }> = [{ root: rootDir, chain: [] }]
-  for (const { root, chain } of queue) {
+  const queue: Array<{ dir: string, chain: string[] }> = [{ dir: rootDir, chain: [] }]
+  for (const { dir, chain } of queue) {
     for (const layer of layers) {
       if (layerChains.has(layer.root)) { continue }
-      const packageRoot = resolvePackageRoot(layer.name, root)
-      if (!packageRoot || realPath(packageRoot) !== layer.identity) { continue }
+      const packageDir = resolvePackageDir(layer.name, dir)
+      if (!packageDir || realPath(packageDir) !== layer.identity) { continue }
       const layerChain = [...chain, layer.name]
       layerChains.set(layer.root, layerChain)
-      queue.push({ root: layer.root, chain: layerChain })
+      queue.push({ dir: layer.root, chain: layerChain })
     }
   }
 
-  if (!layerChains.size) { return (include: string[]) => include }
+  if (!layerChains.size) { return include.map(entry => [entry]) }
 
-  const entryCache = new Map<string, string[]>()
-  function resolveEntry (entry: string): string[] {
-    const cached = entryCache.get(entry)
-    if (cached) { return cached }
+  return include.map((entry) => {
     if (entry.includes('>') || entry.startsWith('.') || isAbsolute(entry)) { return [entry] }
 
-    const resolvedEntries = new Map<string, string>()
+    // one entry per distinct copy of the package, keyed by the identity Vite resolves it to
+    const resolved = new Map<string, string>()
     const name = packageName(entry)
-    const rootPackage = resolvePackageRoot(name, rootDir)
-    if (rootPackage && isResolvable(entry, rootDir)) {
-      resolvedEntries.set(dependencyIdentity(rootPackage), entry)
+    const rootPackage = resolvePackageDir(name, rootDir)
+    if (rootPackage && isResolvableFrom(entry, rootDir)) {
+      resolved.set(dependencyIdentity(rootPackage), entry)
     }
 
-    for (const [root, chain] of layerChains) {
-      const packageRoot = resolvePackageRoot(name, root)
-      if (!packageRoot) { continue }
-      const identity = dependencyIdentity(packageRoot)
-      if (resolvedEntries.has(identity) || !isResolvable(entry, root)) { continue }
-      resolvedEntries.set(identity, `${chain.join(' > ')} > ${entry}`)
+    for (const [layerRoot, chain] of layerChains) {
+      const packageDir = resolvePackageDir(name, layerRoot)
+      if (!packageDir) { continue }
+      const identity = dependencyIdentity(packageDir)
+      if (resolved.has(identity) || !isResolvableFrom(entry, layerRoot)) { continue }
+      resolved.set(identity, `${chain.join(' > ')} > ${entry}`)
     }
 
-    const entries = resolvedEntries.size ? [...resolvedEntries.values()] : [entry]
-    entryCache.set(entry, entries)
-    return entries
-  }
-
-  return (include: string[]) => include.flatMap(resolveEntry)
+    return resolved.size ? [...resolved.values()] : [entry]
+  })
 }

--- a/packages/vite/src/utils/optimize-deps.ts
+++ b/packages/vite/src/utils/optimize-deps.ts
@@ -1,10 +1,15 @@
-import { isAbsolute, join } from 'pathe'
+import { existsSync, realpathSync } from 'node:fs'
+import { dirname, isAbsolute, join, normalize } from 'pathe'
+import { withTrailingSlash } from 'ufo'
 import { resolveModulePath } from 'exsolve'
-import { readPackageJSON } from 'pkg-types'
+import { escapePath } from 'tinyglobby'
 import { getLayerDirectories } from '@nuxt/kit'
+import { parseNodeModulePath } from '@nuxt/kit/internal'
 import type { Nuxt } from '@nuxt/schema'
 
 const NODE_MODULES = '/node_modules/'
+const SCAN_EXTENSIONS = '{vue,js,jsx,mjs,ts,tsx,mts}'
+const SERVER_FILE_RE = /\.server\.(?:vue|js|jsx|mjs|ts|tsx|mts)$/
 
 /**
  * Scanner entries for app code that lives in `node_modules`, such as an installed layer
@@ -12,28 +17,48 @@ const NODE_MODULES = '/node_modules/'
  *
  * Vite does not pre-bundle a bare import whose importer is in `node_modules`, so without
  * these its dependencies are served raw, breaking if they are CJS-only.
+ *
+ * Vite matches every entry with picomatch, so paths are escaped: a package manager can
+ * install into a directory whose name contains glob characters, as pnpm does.
  */
 export function installedScanEntries (nuxt: Nuxt): string[] {
   const entries = new Set<string>()
+  const apps = Object.values(nuxt.apps)
+  const serverFiles = apps.flatMap(app => [
+    ...app.components.filter(c => c.mode === 'server').map(c => c.filePath),
+    ...app.plugins.filter(p => p.mode === 'server').map(p => p.src),
+  ]).map(normalize)
+  const pages = apps.flatMap(app => app.pages || [])
+  for (const page of pages) {
+    pages.push(...page.children || [])
+    if (page.mode !== 'server') { continue }
+    if (page.file) { serverFiles.push(normalize(page.file)) }
+    serverFiles.push(...Object.values(page.components || {}).map(normalize))
+  }
 
-  for (const dirs of getLayerDirectories(nuxt)) {
-    if (dirs.app !== nuxt.options.srcDir && dirs.app.includes(NODE_MODULES)) {
-      entries.add(join(dirs.app, '**/*.{vue,js,jsx,mjs,ts,tsx,mts}'))
-      // scanning the layer's own dependency tree is unnecessary and slow
-      entries.add('!' + join(dirs.app, '**/node_modules/**'))
+  for (const dirs of getLayerDirectories(nuxt).slice(1)) {
+    const app = withTrailingSlash(normalize(dirs.app))
+    if (!app.includes(NODE_MODULES)) { continue }
+    const dir = escapePath(app)
+    entries.add(`${dir}**/*.${SCAN_EXTENSIONS}`)
+    // scanning the layer's own dependency tree is unnecessary and slow
+    entries.add(`!${dir}**/node_modules/**`)
+    entries.add(`!${dir}**/*.server.${SCAN_EXTENSIONS}`)
+    for (const file of serverFiles) {
+      if (file.startsWith(app)) { entries.add('!' + escapePath(file)) }
     }
   }
 
-  for (const app of Object.values(nuxt.apps)) {
+  for (const app of apps) {
     const files = [
-      ...app.components.map(c => c.filePath),
-      ...app.plugins.map(p => p.src),
+      ...app.components.filter(c => c.mode !== 'server').map(c => c.filePath),
+      ...app.plugins.filter(p => p.mode !== 'server').map(p => p.src),
       ...app.middleware.map(m => m.path),
       ...Object.values(app.layouts || {}).map(l => l.file),
-    ]
+    ].map(normalize)
     for (const file of files) {
-      if (file.includes(NODE_MODULES)) {
-        entries.add(file)
+      if (file.includes(NODE_MODULES) && !SERVER_FILE_RE.test(file)) {
+        entries.add(escapePath(file))
       }
     }
   }
@@ -41,35 +66,107 @@ export function installedScanEntries (nuxt: Nuxt): string[] {
   return [...entries]
 }
 
-function isResolvableFrom (id: string, dir: string) {
-  return !!resolveModulePath(id, { from: dir, try: true, extensions: ['.mjs', '.js', '.cjs', '.json'] })
+function packageName (entry: string) {
+  const segments = entry.split('/')
+  return entry.startsWith('@') ? segments.slice(0, 2).join('/') : segments[0]!
 }
 
 /**
- * Rewrites `optimizeDeps.include` entries that only resolve from an installed layer into
- * Vite's nested `parent > dep` form, resolved relative to the parent package rather than
- * the project root.
+ * Creates a cached resolver for Vite's nested dependency syntax. The layer graph and
+ * package resolutions are shared across every include list for one Vite environment.
  */
-export async function resolveOptimizeDepsInclude (nuxt: Nuxt, include: string[]): Promise<string[]> {
-  const layers: Array<{ name: string, root: string }> = []
-  for (const dirs of getLayerDirectories(nuxt)) {
-    if (dirs.root === nuxt.options.rootDir + '/' || !dirs.root.includes(NODE_MODULES)) { continue }
-    const name = await readPackageJSON(dirs.root).then(pkg => pkg.name).catch(() => undefined)
-    if (name) { layers.push({ name, root: dirs.root }) }
+export function createOptimizeDepsIncludeResolver (nuxt: Nuxt, options: { preserveSymlinks?: boolean } = {}) {
+  const rootDir = normalize(nuxt.options.rootDir)
+  const realPathCache = new Map<string, string>()
+  const packageRootCache = new Map<string, string | undefined>()
+
+  function realPath (path: string) {
+    const normalized = normalize(path)
+    const cached = realPathCache.get(normalized)
+    if (cached) { return cached }
+    const resolved = normalize(realpathSync(normalized))
+    realPathCache.set(normalized, resolved)
+    return resolved
   }
 
-  if (!layers.length) { return include }
+  function resolvePackageRoot (name: string, from: string) {
+    let directory = normalize(from)
+    const key = `${directory}\0${name}`
+    if (packageRootCache.has(key)) { return packageRootCache.get(key) }
 
-  return include.map((entry) => {
-    if (entry.includes('>') || entry.startsWith('.') || isAbsolute(entry)) { return entry }
-    if (isResolvableFrom(entry, nuxt.options.rootDir + '/')) { return entry }
-
-    for (const layer of layers) {
-      if (isResolvableFrom(entry, layer.root)) {
-        return `${layer.name} > ${entry}`
+    while (true) {
+      const candidate = join(directory, 'node_modules', name)
+      if (existsSync(candidate)) {
+        const resolved = normalize(candidate)
+        packageRootCache.set(key, resolved)
+        return resolved
       }
+      const parent = dirname(directory)
+      if (parent === directory) {
+        packageRootCache.set(key, undefined)
+        return
+      }
+      directory = parent
+    }
+  }
+
+  function isResolvable (id: string, from: string) {
+    return !!resolveModulePath(id, { from, try: true, extensions: ['.mjs', '.js', '.cjs', '.json'] })
+  }
+
+  function dependencyIdentity (root: string) {
+    return options.preserveSymlinks ? root : realPath(root)
+  }
+
+  const layers: Array<{ name: string, root: string, identity: string }> = []
+  for (const dirs of getLayerDirectories(nuxt).slice(1)) {
+    // Vite needs the installed alias, which can differ from the package manifest name.
+    const { dir, name } = parseNodeModulePath(dirs.root)
+    if (!dir || !name || !existsSync(dir + name)) { continue }
+    layers.push({ name, root: normalize(dirs.root), identity: realPath(dir + name) })
+  }
+
+  // Walk out from the project so every layer keeps the full chain Vite resolves it through.
+  const layerChains = new Map<string, string[]>()
+  const queue: Array<{ root: string, chain: string[] }> = [{ root: rootDir, chain: [] }]
+  for (const { root, chain } of queue) {
+    for (const layer of layers) {
+      if (layerChains.has(layer.root)) { continue }
+      const packageRoot = resolvePackageRoot(layer.name, root)
+      if (!packageRoot || realPath(packageRoot) !== layer.identity) { continue }
+      const layerChain = [...chain, layer.name]
+      layerChains.set(layer.root, layerChain)
+      queue.push({ root: layer.root, chain: layerChain })
+    }
+  }
+
+  if (!layerChains.size) { return (include: string[]) => include }
+
+  const entryCache = new Map<string, string[]>()
+  function resolveEntry (entry: string): string[] {
+    const cached = entryCache.get(entry)
+    if (cached) { return cached }
+    if (entry.includes('>') || entry.startsWith('.') || isAbsolute(entry)) { return [entry] }
+
+    const resolvedEntries = new Map<string, string>()
+    const name = packageName(entry)
+    const rootPackage = resolvePackageRoot(name, rootDir)
+    if (rootPackage && isResolvable(entry, rootDir)) {
+      resolvedEntries.set(dependencyIdentity(rootPackage), entry)
     }
 
-    return entry
-  })
+    for (const [root, chain] of layerChains) {
+      const packageRoot = resolvePackageRoot(name, root)
+      if (!packageRoot) { continue }
+      const identity = dependencyIdentity(packageRoot)
+      if (resolvedEntries.has(identity) || !isResolvable(entry, root)) { continue }
+      resolvedEntries.set(identity, `${chain.join(' > ')} > ${entry}`)
+    }
+
+    const entries = resolvedEntries.size ? [...resolvedEntries.values()] : [entry]
+    entryCache.set(entry, entries)
+    return entries
+  }
+
+  return (include: string[]) => include.flatMap(resolveEntry)
 }

--- a/packages/vite/src/utils/optimize-deps.ts
+++ b/packages/vite/src/utils/optimize-deps.ts
@@ -43,6 +43,13 @@ export function installedScanEntries (nuxt: Nuxt): string[] {
     entries.add(`${dir}**/*.${SCAN_EXTENSIONS}`)
     // scanning the layer's own dependency tree is unnecessary and slow
     entries.add(`!${dir}**/node_modules/**`)
+    // a v3 layer has `srcDir === rootDir`, so its server and build-time code sits under the glob
+    for (const excluded of [dirs.server, dirs.modules, dirs.public]) {
+      const path = withTrailingSlash(normalize(excluded))
+      if (path !== app && path.startsWith(app) && existsSync(path)) {
+        entries.add(`!${escapePath(path)}**`)
+      }
+    }
     entries.add(`!${dir}**/*.server.${SCAN_EXTENSIONS}`)
     for (const file of serverFiles) {
       if (file.startsWith(app)) { entries.add('!' + escapePath(file)) }

--- a/packages/vite/src/utils/optimize-deps.ts
+++ b/packages/vite/src/utils/optimize-deps.ts
@@ -18,8 +18,8 @@ const SERVER_FILE_RE = /\.server\.(?:vue|js|jsx|mjs|ts|tsx|mts)$/
  * Vite does not pre-bundle a bare import whose importer is in `node_modules`, so without
  * these its dependencies are served raw, breaking if they are CJS-only.
  *
- * Vite matches every entry with picomatch, so paths are escaped: a package manager can
- * install into a directory whose name contains glob characters, as pnpm does.
+ * Vite matches every entry with picomatch, so paths are escaped. A project directory may
+ * contain parentheses, which picomatch reads as an extglob group and then matches nothing.
  */
 export function installedScanEntries (nuxt: Nuxt): string[] {
   const entries = new Set<string>()

--- a/packages/vite/src/utils/optimize-deps.ts
+++ b/packages/vite/src/utils/optimize-deps.ts
@@ -39,7 +39,7 @@ export function installedScanEntries (nuxt: Nuxt): string[] {
 
   for (const dirs of getLayerDirectories(nuxt)) {
     if (dirs.root === projectRoot) { continue }
-    const app = withTrailingSlash(normalize(dirs.app))
+    const app = withTrailingSlash(dirs.app)
     if (!app.includes(NODE_MODULES)) { continue }
     const dir = escapePath(app)
     entries.add(`${dir}**/*.${SCAN_EXTENSIONS}`)
@@ -47,7 +47,7 @@ export function installedScanEntries (nuxt: Nuxt): string[] {
     entries.add(`!${dir}**/node_modules/**`)
     // a v3 layer has `srcDir === rootDir`, so its server and build-time code sits under the glob
     for (const excluded of [dirs.server, dirs.modules, dirs.public]) {
-      const path = withTrailingSlash(normalize(excluded))
+      const path = withTrailingSlash(excluded)
       if (path !== app && path.startsWith(app) && existsSync(path)) {
         entries.add(`!${escapePath(path)}**`)
       }

--- a/packages/vite/src/utils/optimize-deps.ts
+++ b/packages/vite/src/utils/optimize-deps.ts
@@ -10,6 +10,7 @@ import type { Nuxt } from '@nuxt/schema'
 const NODE_MODULES = '/node_modules/'
 const SCAN_EXTENSIONS = '{vue,js,jsx,mjs,ts,tsx,mts}'
 const SERVER_FILE_RE = /\.server\.(?:vue|js|jsx|mjs|ts|tsx|mts)$/
+const SCAN_FILE_RE = /\.(?:vue|js|jsx|mjs|ts|tsx|mts)$/
 
 /**
  * Scanner entries for app code that lives in `node_modules`, such as an installed layer
@@ -69,9 +70,9 @@ export function installedScanEntries (nuxt: Nuxt): string[] {
       ...Object.values(app.layouts || {}).map(l => l.file),
     ].map(normalize)
     for (const file of files) {
-      if (file.includes(NODE_MODULES) && !file.startsWith(buildDir) && !SERVER_FILE_RE.test(file)) {
-        entries.add(escapePath(file))
-      }
+      if (!file.includes(NODE_MODULES) || file.startsWith(buildDir) || SERVER_FILE_RE.test(file)) { continue }
+      // Nuxt registers some app files without an extension, and Vite drops an entry that does not exist
+      entries.add(escapePath(file) + (SCAN_FILE_RE.test(file) ? '' : `.${SCAN_EXTENSIONS}`))
     }
   }
 

--- a/packages/vite/src/utils/optimize-deps.ts
+++ b/packages/vite/src/utils/optimize-deps.ts
@@ -58,6 +58,9 @@ export function installedScanEntries (nuxt: Nuxt): string[] {
     }
   }
 
+  // the build directory is often inside `node_modules`, and its templates are generated
+  // app code Vite already reaches through the entry
+  const buildDir = withTrailingSlash(nuxt.options.buildDir)
   for (const app of apps) {
     const files = [
       ...app.components.filter(c => c.mode !== 'server').map(c => c.filePath),
@@ -66,7 +69,7 @@ export function installedScanEntries (nuxt: Nuxt): string[] {
       ...Object.values(app.layouts || {}).map(l => l.file),
     ].map(normalize)
     for (const file of files) {
-      if (file.includes(NODE_MODULES) && !SERVER_FILE_RE.test(file)) {
+      if (file.includes(NODE_MODULES) && !file.startsWith(buildDir) && !SERVER_FILE_RE.test(file)) {
         entries.add(escapePath(file))
       }
     }

--- a/packages/vite/src/utils/optimize-deps.ts
+++ b/packages/vite/src/utils/optimize-deps.ts
@@ -46,7 +46,9 @@ export function installedScanEntries (nuxt: Nuxt): string[] {
     entries.add(`${dir}**/*.${SCAN_EXTENSIONS}`)
     // scanning the layer's own dependency tree is unnecessary and slow
     entries.add(`!${dir}**/node_modules/**`)
-    // a v3 layer has `srcDir === rootDir`, so its server and build-time code sits under the glob
+    // a v3 layer has `srcDir === rootDir`, so its build config and server code sit under the
+    // glob; `app.config` is the one root config that is app code
+    entries.add(`!${dir}!(app).config.${SCAN_EXTENSIONS}`)
     for (const excluded of [dirs.server, dirs.modules, dirs.public]) {
       const path = withTrailingSlash(excluded)
       if (path !== app && path.startsWith(app) && existsSync(path)) {

--- a/packages/vite/test/optimize-deps.test.ts
+++ b/packages/vite/test/optimize-deps.test.ts
@@ -1,11 +1,11 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { afterAll, describe, expect, it } from 'vitest'
 import { join } from 'pathe'
-import { createServer } from 'vite'
+import { type Plugin, createServer } from 'vite'
 import type { Nuxt } from '@nuxt/schema'
 
-import { installedScanEntries, resolveOptimizeDepsInclude } from '../src/utils/optimize-deps.ts'
+import { createOptimizeDepsIncludeResolver, installedScanEntries } from '../src/utils/optimize-deps.ts'
 import { OptimizeDepsPlugin } from '../src/plugins/optimize-deps.ts'
 import { userOptimizeDepsInclude } from '../src/plugins/optimize-deps-hint.ts'
 
@@ -13,8 +13,26 @@ const rootDir = await mkdtemp(join(tmpdir(), 'nuxt-optimize-deps-'))
 const srcDir = join(rootDir, 'app/')
 const layerRoot = join(rootDir, 'node_modules/installed-layer/')
 const layerSrcDir = join(layerRoot, 'app/')
+const subpathLayerPackageRoot = join(rootDir, 'node_modules/subpath-layer/')
+const subpathLayerRoot = join(subpathLayerPackageRoot, 'layers/child/')
+const aliasedLayerRoot = join(rootDir, 'node_modules/aliased-layer/')
+const parentLayerRoot = join(rootDir, 'node_modules/parent-layer/')
+const nestedLayerRoot = join(parentLayerRoot, 'node_modules/nested-layer/')
+const otherParentLayerRoot = join(rootDir, 'node_modules/other-parent-layer/')
+const otherNestedLayerRoot = join(otherParentLayerRoot, 'node_modules/nested-layer/')
+const linkedDependencyRoot = join(rootDir, 'linked-dependency/')
+const reachableCycleLayerRoot = join(rootDir, 'node_modules/reachable-cycle-layer/')
+const cycleLayerARoot = join(rootDir, 'isolated/node_modules/cycle-layer-a/')
+const cycleLayerBRoot = join(rootDir, 'isolated/node_modules/cycle-layer-b/')
+const parenLayerRoot = join(rootDir, 'node_modules/.pnpm/paren-layer@1.0.0(vue@3.5.0)/node_modules/paren-layer/')
+const parenLayerSrcDir = join(parenLayerRoot, 'app/')
 const moduleRuntime = join(rootDir, 'node_modules/installed-module/runtime/')
 const entry = join(srcDir, 'entry.mjs')
+const layerComponent = join(layerSrcDir, 'components/LayerComponent.vue')
+const unusedLayerComponent = join(layerSrcDir, 'components/UnusedLayerComponent.vue')
+const modeServerComponent = join(layerSrcDir, 'components/ModeServer.vue')
+const modeServerPlugin = join(layerSrcDir, 'plugins/mode-server.mjs')
+const modeServerPage = join(layerSrcDir, 'pages/mode-server.vue')
 
 const registered = {
   plugins: [{ src: join(moduleRuntime, 'plugin.mjs') }],
@@ -30,37 +48,72 @@ async function writePackage (dir: string, name: string, contents: string, main =
 }
 
 await mkdir(join(layerSrcDir, 'plugins'), { recursive: true })
+await mkdir(join(layerSrcDir, 'components'), { recursive: true })
+await mkdir(join(layerSrcDir, 'pages'), { recursive: true })
 await mkdir(srcDir, { recursive: true })
 await writeFile(join(rootDir, 'package.json'), JSON.stringify({ name: 'fixture', type: 'module' }))
 await writeFile(entry, 'export default 1\n')
 await writeFile(join(layerRoot, 'package.json'), JSON.stringify({ name: 'installed-layer', type: 'module' }))
 await writeFile(join(layerSrcDir, 'plugins/broken.mjs'), 'import { hello } from \'layer-dep\'\nexport default hello\n')
+await writeFile(layerComponent, '<script setup>\nimport x from \'layer-component-dep\'\n</script>\n')
+await writeFile(unusedLayerComponent, '<script setup>\nimport x from \'unused-layer-component-dep\'\n</script>\n')
+await writeFile(modeServerComponent, '<script setup>\nimport x from \'server-component-dep\'\n</script>\n')
+await writeFile(modeServerPlugin, 'import x from \'server-plugin-dep\'\nexport default x\n')
+await writeFile(modeServerPage, '<script setup>\nimport x from \'server-page-dep\'\n</script>\n')
 await writePackage(join(layerRoot, 'node_modules/layer-dep'), 'layer-dep', 'import cjs from \'cjs-only\'\nexport const hello = () => cjs()\n')
 await writePackage(join(layerRoot, 'node_modules/cjs-only'), 'cjs-only', 'module.exports = () => \'hi\'\n', 'index.js')
+await mkdir(join(layerRoot, 'node_modules/manifestless-dep'), { recursive: true })
+await writeFile(join(layerRoot, 'node_modules/manifestless-dep/index.js'), 'module.exports = 1\n')
 await writePackage(join(layerRoot, 'node_modules/hoisted-dep'), 'hoisted-dep', 'export default 1\n')
 await writePackage(join(layerSrcDir, 'node_modules/nested-pkg'), 'nested-pkg', 'import x from \'hoisted-dep\'\nexport default x\n')
+await writePackage(subpathLayerPackageRoot, 'subpath-layer', 'export default 1\n')
+await writePackage(join(subpathLayerPackageRoot, 'node_modules/subpath-dep'), 'subpath-dep', 'export default 1\n')
+await writePackage(aliasedLayerRoot, 'real-layer-name', 'export default 1\n')
+await writePackage(join(aliasedLayerRoot, 'node_modules/aliased-dep'), 'aliased-dep', 'export default 1\n')
 await writePackage(join(rootDir, 'node_modules/root-dep'), 'root-dep', 'export default 1\n')
+await writePackage(parentLayerRoot, 'parent-layer', 'export default 1\n')
+await writePackage(nestedLayerRoot, 'nested-layer', 'export default 1\n')
+await writePackage(join(nestedLayerRoot, 'node_modules/nested-dep'), 'nested-dep', 'export default 1\n')
+await writePackage(join(nestedLayerRoot, 'node_modules/root-dep'), 'root-dep', 'export default 2\n')
+await writePackage(otherParentLayerRoot, 'other-parent-layer', 'export default 1\n')
+await writePackage(otherNestedLayerRoot, 'nested-layer', 'export default 2\n')
+await writePackage(join(otherNestedLayerRoot, 'node_modules/nested-dep'), 'nested-dep', 'export default 2\n')
+await writePackage(linkedDependencyRoot, 'linked-dep', 'export default 1\n')
+await symlink(linkedDependencyRoot, join(rootDir, 'node_modules/linked-dep'), 'dir')
+await symlink(linkedDependencyRoot, join(nestedLayerRoot, 'node_modules/linked-dep'), 'dir')
+await mkdir(join(parenLayerSrcDir, 'plugins'), { recursive: true })
+await writeFile(join(parenLayerSrcDir, 'plugins/paren.mjs'), 'import x from \'paren-layer-dep\'\nexport default x\n')
+await writePackage(reachableCycleLayerRoot, 'reachable-cycle-layer', 'export default 1\n')
+await writePackage(cycleLayerARoot, 'cycle-layer-a', 'export default 1\n')
+await writePackage(cycleLayerBRoot, 'cycle-layer-b', 'export default 1\n')
+await writePackage(join(cycleLayerARoot, 'node_modules/cycle-dep-a'), 'cycle-dep-a', 'export default 1\n')
+await writePackage(join(cycleLayerBRoot, 'node_modules/cycle-dep-b'), 'cycle-dep-b', 'export default 1\n')
+await mkdir(join(reachableCycleLayerRoot, 'node_modules'), { recursive: true })
+await symlink(cycleLayerBRoot, join(reachableCycleLayerRoot, 'node_modules/cycle-layer-b'), 'dir')
+await symlink(cycleLayerARoot, join(cycleLayerBRoot, 'node_modules/cycle-layer-a'), 'dir')
+await symlink(cycleLayerBRoot, join(cycleLayerARoot, 'node_modules/cycle-layer-b'), 'dir')
 
 await mkdir(moduleRuntime, { recursive: true })
 await writeFile(join(moduleRuntime, 'plugin.mjs'), 'import x from \'plugin-dep\'\nexport default x\n')
 await writeFile(join(moduleRuntime, 'Component.vue'), '<script setup>\nimport x from \'component-dep\'\n</script>\n')
 await writeFile(join(moduleRuntime, 'middleware.mjs'), 'import x from \'middleware-dep\'\nexport default x\n')
 await writeFile(join(moduleRuntime, 'layout.vue'), '<script setup>\nimport x from \'layout-dep\'\n</script>\n')
-for (const dep of ['plugin-dep', 'component-dep', 'middleware-dep', 'layout-dep']) {
+for (const dep of ['plugin-dep', 'component-dep', 'layer-component-dep', 'unused-layer-component-dep', 'server-component-dep', 'server-plugin-dep', 'server-page-dep', 'middleware-dep', 'layout-dep', 'paren-layer-dep']) {
   await writePackage(join(rootDir, 'node_modules', dep), dep, 'export default 1\n')
 }
 
 afterAll(() => rm(rootDir, { recursive: true, force: true }))
 
-function createNuxt (layerDirs: Array<{ app: string, root: string }> = [], apps: Record<string, any> = { default: { components: [], plugins: [], middleware: [], layouts: {} } }) {
+function createNuxt (layerDirs: Array<{ app: string, root: string }> = [], apps: Record<string, any> = { default: { components: [], plugins: [], middleware: [], layouts: {} } }, root = rootDir, src = srcDir) {
   return {
     apps,
     options: {
-      rootDir,
-      srcDir,
+      rootDir: root,
+      srcDir: src,
       alias: {},
+      vite: {},
       _layers: [
-        { cwd: rootDir, config: { rootDir, srcDir } },
+        { cwd: root, config: { rootDir: root, srcDir: src } },
         ...layerDirs.map(dirs => ({ cwd: dirs.root, config: { rootDir: dirs.root, srcDir: dirs.app } })),
       ],
     },
@@ -68,13 +121,29 @@ function createNuxt (layerDirs: Array<{ app: string, root: string }> = [], apps:
 }
 
 const installedLayer = { app: layerSrcDir, root: layerRoot }
+const subpathLayer = { app: join(subpathLayerRoot, 'app/'), root: subpathLayerRoot }
+const aliasedLayer = { app: join(aliasedLayerRoot, 'app/'), root: aliasedLayerRoot }
+const parentLayer = { app: join(parentLayerRoot, 'app/'), root: parentLayerRoot }
+const nestedLayer = { app: join(nestedLayerRoot, 'app/'), root: nestedLayerRoot }
+const otherParentLayer = { app: join(otherParentLayerRoot, 'app/'), root: otherParentLayerRoot }
+const otherNestedLayer = { app: join(otherNestedLayerRoot, 'app/'), root: otherNestedLayerRoot }
+const parenLayer = { app: parenLayerSrcDir, root: parenLayerRoot }
+const reachableCycleLayer = { app: join(reachableCycleLayerRoot, 'app/'), root: reachableCycleLayerRoot }
+const cycleLayerA = { app: join(cycleLayerARoot, 'app/'), root: cycleLayerARoot }
+const cycleLayerB = { app: join(cycleLayerBRoot, 'app/'), root: cycleLayerBRoot }
 
-async function optimizedDeps (options: { entries?: string[], include?: string[] }) {
+function resolveOptimizeDepsInclude (nuxt: Nuxt, include: string[], options: { preserveSymlinks?: boolean } = {}) {
+  return createOptimizeDepsIncludeResolver(nuxt, options)(include)
+}
+
+async function optimizedDeps (options: { entries?: string[], include?: string[], plugins?: Plugin[], preserveSymlinks?: boolean }) {
   const server = await createServer({
     root: rootDir,
     configFile: false,
     logLevel: 'silent',
     server: { middlewareMode: true },
+    plugins: options.plugins,
+    resolve: { preserveSymlinks: options.preserveSymlinks },
     environments: {
       client: {
         optimizeDeps: {
@@ -106,7 +175,7 @@ describe('installedScanEntries', () => {
     await expect(optimizedDeps({ entries })).resolves.toContain('layer-dep')
   })
 
-  it('should scan app files that modules register from within node_modules', async () => {
+  it('should scan eager app files that modules register from within node_modules', async () => {
     const nuxt = createNuxt([], { default: registered })
 
     const entries = installedScanEntries(nuxt)
@@ -122,6 +191,43 @@ describe('installedScanEntries', () => {
     )
   })
 
+  it('should not scan client-inaccessible app files', () => {
+    const serverFile = join(moduleRuntime, 'plugin.server.mjs')
+    const nuxt = createNuxt([installedLayer], {
+      default: {
+        components: [{ filePath: join(moduleRuntime, 'Component.server.vue'), mode: 'server' }],
+        plugins: [{ src: serverFile, mode: 'server' }],
+        middleware: [{ path: join(moduleRuntime, 'middleware.server.mjs') }],
+        layouts: { installed: { file: join(moduleRuntime, 'layout.server.vue') } },
+      },
+    })
+
+    expect(installedScanEntries(nuxt)).toEqual([
+      join(layerSrcDir, '**/*.{vue,js,jsx,mjs,ts,tsx,mts}'),
+      '!' + join(layerSrcDir, '**/node_modules/**'),
+      '!' + join(layerSrcDir, '**/*.server.{vue,js,jsx,mjs,ts,tsx,mts}'),
+    ])
+  })
+
+  it('should not scan server-mode files from installed layers', async () => {
+    const nuxt = createNuxt([installedLayer], {
+      default: {
+        components: [{ filePath: modeServerComponent, mode: 'server' }],
+        plugins: [{ src: modeServerPlugin, mode: 'server' }],
+        middleware: [],
+        layouts: {},
+        pages: [{ path: '/parent', children: [{ path: 'server', file: modeServerPage, mode: 'server' }] }],
+      },
+    })
+
+    const entries = installedScanEntries(nuxt)
+
+    const deps = await optimizedDeps({ entries: [entry, ...entries] })
+    expect(deps).not.toContain('server-component-dep')
+    expect(deps).not.toContain('server-plugin-dep')
+    expect(deps).not.toContain('server-page-dep')
+  })
+
   it('should not scan app files that are part of the project', () => {
     const nuxt = createNuxt([], {
       default: {
@@ -133,6 +239,37 @@ describe('installedScanEntries', () => {
     })
 
     expect(installedScanEntries(nuxt)).toEqual([])
+  })
+
+  it('should normalize installed module paths on Windows', () => {
+    const nuxt = createNuxt([], {
+      default: {
+        components: [],
+        plugins: [{ src: 'C:\\project\\node_modules\\installed-module\\runtime\\plugin.mjs' }],
+        middleware: [],
+        layouts: {},
+      },
+    })
+
+    expect(installedScanEntries(nuxt)).toEqual(['C:/project/node_modules/installed-module/runtime/plugin.mjs'])
+  })
+
+  it('should normalize installed layer paths on Windows', () => {
+    const projectRoot = 'C:\\project\\'
+    const installedRoot = 'C:\\project\\node_modules\\installed-layer\\'
+    const nuxt = createNuxt([{ app: installedRoot + 'app\\', root: installedRoot }], undefined, projectRoot, projectRoot + 'app\\')
+
+    expect(installedScanEntries(nuxt)).toEqual([
+      'C:/project/node_modules/installed-layer/app/**/*.{vue,js,jsx,mjs,ts,tsx,mts}',
+      '!C:/project/node_modules/installed-layer/app/**/node_modules/**',
+      '!C:/project/node_modules/installed-layer/app/**/*.server.{vue,js,jsx,mjs,ts,tsx,mts}',
+    ])
+  })
+
+  it('should scan installed layers whose path contains glob characters', async () => {
+    const entries = installedScanEntries(createNuxt([parenLayer]))
+
+    await expect(optimizedDeps({ entries: [entry, ...entries] })).resolves.toContain('paren-layer-dep')
   })
 
   it('should not scan dependencies nested within the layer', async () => {
@@ -149,10 +286,6 @@ describe('OptimizeDepsPlugin', () => {
     await (plugin.configEnvironment as any).call(null, name, config, {})
     return config
   }
-
-  it('should keep its plugin name', () => {
-    expect(OptimizeDepsPlugin(createNuxt()).name).toBe('nuxt:optimize-deps')
-  })
 
   it('should rewrite include entries added after nuxt has built its config', async () => {
     const config = { optimizeDeps: { entries: [entry], include: ['layer-dep'] } }
@@ -179,37 +312,136 @@ describe('OptimizeDepsPlugin', () => {
 
     expect(userOptimizeDepsInclude.get(nuxt)).toEqual(['layer-dep', 'installed-layer > layer-dep'])
   })
+
+  it('should attribute every resolved dependency copy to the user', async () => {
+    const nuxt = createNuxt([parentLayer, nestedLayer, otherParentLayer, otherNestedLayer])
+    userOptimizeDepsInclude.set(nuxt, ['nested-dep'])
+
+    const config = await configureEnvironment(nuxt, 'client', { optimizeDeps: { include: ['nested-dep'] } })
+
+    expect(userOptimizeDepsInclude.get(nuxt)).toEqual([
+      'nested-dep',
+      'parent-layer > nested-layer > nested-dep',
+      'other-parent-layer > nested-layer > nested-dep',
+    ])
+    expect(config.optimizeDeps.include).toEqual(userOptimizeDepsInclude.get(nuxt)?.slice(1))
+  })
+
+  it('should scan components from installed layers', async () => {
+    const nuxt = createNuxt([installedLayer], {
+      default: {
+        components: [
+          { filePath: layerComponent },
+          { filePath: unusedLayerComponent },
+        ],
+        plugins: [],
+        middleware: [],
+        layouts: {},
+      },
+    })
+    const config = await configureEnvironment(nuxt, 'client', { optimizeDeps: { entries: [entry] } })
+
+    const deps = await optimizedDeps(config.optimizeDeps)
+    expect(deps).toEqual(expect.arrayContaining(['layer-component-dep', 'unused-layer-component-dep']))
+  })
 })
 
-describe('resolveOptimizeDepsInclude', () => {
-  it('should rewrite entries that only resolve from an installed layer', async () => {
+describe('createOptimizeDepsIncludeResolver', () => {
+  it('should rewrite entries that only resolve from an installed layer', () => {
     const nuxt = createNuxt([installedLayer])
 
-    await expect(resolveOptimizeDepsInclude(nuxt, ['layer-dep'])).resolves.toEqual(['installed-layer > layer-dep'])
+    expect(resolveOptimizeDepsInclude(nuxt, ['layer-dep'])).toEqual(['installed-layer > layer-dep'])
   })
 
-  it('should pre-bundle rewritten entries that vite cannot resolve as-is', async () => {
-    await expect(optimizedDeps({ include: ['layer-dep'] })).resolves.not.toContain('layer-dep')
-
-    await expect(optimizedDeps({ include: ['installed-layer > layer-dep'] })).resolves.toContain('installed-layer > layer-dep')
-  })
-
-  it('should leave entries that resolve from the project root untouched', async () => {
+  it('should rewrite packages without a manifest that resolve from an installed layer', () => {
     const nuxt = createNuxt([installedLayer])
 
-    await expect(resolveOptimizeDepsInclude(nuxt, ['root-dep'])).resolves.toEqual(['root-dep'])
+    expect(resolveOptimizeDepsInclude(nuxt, ['manifestless-dep'])).toEqual(['installed-layer > manifestless-dep'])
   })
 
-  it('should leave unresolvable, nested and path entries untouched', async () => {
+  it('should preserve the full package chain for nested installed layers', async () => {
+    const nuxt = createNuxt([parentLayer, nestedLayer])
+
+    const include = resolveOptimizeDepsInclude(nuxt, ['nested-dep'])
+
+    expect(include).toEqual(['parent-layer > nested-layer > nested-dep'])
+    await expect(optimizedDeps({ include })).resolves.toContain('parent-layer > nested-layer > nested-dep')
+  })
+
+  it('should resolve a layer rooted within an installed package', () => {
+    const nuxt = createNuxt([subpathLayer])
+
+    expect(resolveOptimizeDepsInclude(nuxt, ['subpath-dep'])).toEqual(['subpath-layer > subpath-dep'])
+  })
+
+  it('should use the installed alias as the parent package name', () => {
+    const nuxt = createNuxt([aliasedLayer])
+
+    expect(resolveOptimizeDepsInclude(nuxt, ['aliased-dep'])).toEqual(['aliased-layer > aliased-dep'])
+  })
+
+  it('should preserve separate dependency copies from different parent layers', async () => {
+    const nuxt = createNuxt([parentLayer, nestedLayer, otherParentLayer, otherNestedLayer])
+
+    const include = resolveOptimizeDepsInclude(nuxt, ['nested-dep'])
+
+    expect(include).toEqual([
+      'parent-layer > nested-layer > nested-dep',
+      'other-parent-layer > nested-layer > nested-dep',
+    ])
+    await expect(optimizedDeps({ include })).resolves.toEqual(expect.arrayContaining(include))
+  })
+
+  it('should preserve separate dependency copies from the project and a nested layer', async () => {
+    const nuxt = createNuxt([parentLayer, nestedLayer])
+
+    const include = resolveOptimizeDepsInclude(nuxt, ['root-dep'])
+
+    expect(include).toEqual([
+      'root-dep',
+      'parent-layer > nested-layer > root-dep',
+    ])
+    await expect(optimizedDeps({ include })).resolves.toEqual(expect.arrayContaining(include))
+  })
+
+  it('should follow Vite symlink identity when deduplicating dependency copies', async () => {
+    const nuxt = createNuxt([parentLayer, nestedLayer])
+
+    expect(resolveOptimizeDepsInclude(nuxt, ['linked-dep'])).toEqual(['linked-dep'])
+
+    const include = resolveOptimizeDepsInclude(nuxt, ['linked-dep'], { preserveSymlinks: true })
+    expect(include).toEqual([
+      'linked-dep',
+      'parent-layer > nested-layer > linked-dep',
+    ])
+    await expect(optimizedDeps({ include, preserveSymlinks: true })).resolves.toEqual(expect.arrayContaining(include))
+  })
+
+  it('should resolve reachable layer cycles independent of layer order', () => {
+    const nuxt = createNuxt([cycleLayerB, cycleLayerA, reachableCycleLayer])
+
+    expect(resolveOptimizeDepsInclude(nuxt, ['cycle-dep-b', 'cycle-dep-a'])).toEqual([
+      'reachable-cycle-layer > cycle-layer-b > cycle-dep-b',
+      'reachable-cycle-layer > cycle-layer-b > cycle-layer-a > cycle-dep-a',
+    ])
+  })
+
+  it('should leave entries that resolve from the project root untouched', () => {
+    const nuxt = createNuxt([installedLayer])
+
+    expect(resolveOptimizeDepsInclude(nuxt, ['root-dep'])).toEqual(['root-dep'])
+  })
+
+  it('should leave unresolvable, nested and path entries untouched', () => {
     const nuxt = createNuxt([installedLayer])
     const include = ['does-not-exist', 'some-pkg > layer-dep', './local-file.js', join(rootDir, 'absolute.js')]
 
-    await expect(resolveOptimizeDepsInclude(nuxt, include)).resolves.toEqual(include)
+    expect(resolveOptimizeDepsInclude(nuxt, include)).toEqual(include)
   })
 
-  it('should not rewrite anything when there are no installed layers', async () => {
+  it('should not rewrite anything when there are no installed layers', () => {
     const nuxt = createNuxt([{ app: join(rootDir, 'layers/local/app/'), root: join(rootDir, 'layers/local/') }])
 
-    await expect(resolveOptimizeDepsInclude(nuxt, ['layer-dep'])).resolves.toEqual(['layer-dep'])
+    expect(resolveOptimizeDepsInclude(nuxt, ['layer-dep'])).toEqual(['layer-dep'])
   })
 })

--- a/packages/vite/test/optimize-deps.test.ts
+++ b/packages/vite/test/optimize-deps.test.ts
@@ -24,6 +24,7 @@ const linkedDependencyRoot = join(rootDir, 'linked-dependency/')
 const reachableCycleLayerRoot = join(rootDir, 'node_modules/reachable-cycle-layer/')
 const cycleLayerARoot = join(rootDir, 'isolated/node_modules/cycle-layer-a/')
 const cycleLayerBRoot = join(rootDir, 'isolated/node_modules/cycle-layer-b/')
+const v3LayerRoot = join(rootDir, 'node_modules/v3-layer/')
 const parenLayerRoot = join(rootDir, 'node_modules/.pnpm/paren-layer@1.0.0(vue@3.5.0)/node_modules/paren-layer/')
 const parenLayerSrcDir = join(parenLayerRoot, 'app/')
 const moduleRuntime = join(rootDir, 'node_modules/installed-module/runtime/')
@@ -81,6 +82,14 @@ await writePackage(join(otherNestedLayerRoot, 'node_modules/nested-dep'), 'neste
 await writePackage(linkedDependencyRoot, 'linked-dep', 'export default 1\n')
 await symlink(linkedDependencyRoot, join(rootDir, 'node_modules/linked-dep'), 'dir')
 await symlink(linkedDependencyRoot, join(nestedLayerRoot, 'node_modules/linked-dep'), 'dir')
+await mkdir(join(v3LayerRoot, 'components'), { recursive: true })
+await mkdir(join(v3LayerRoot, 'server/api'), { recursive: true })
+await mkdir(join(v3LayerRoot, 'modules'), { recursive: true })
+await mkdir(join(v3LayerRoot, 'public'), { recursive: true })
+await writeFile(join(v3LayerRoot, 'components/V3.vue'), '<script setup>\nimport x from \'v3-client-dep\'\n</script>\n')
+await writeFile(join(v3LayerRoot, 'server/api/route.mjs'), 'import x from \'v3-server-dep\'\nexport default x\n')
+await writeFile(join(v3LayerRoot, 'modules/build.mjs'), 'import x from \'v3-module-dep\'\nexport default x\n')
+await writeFile(join(v3LayerRoot, 'public/widget.mjs'), 'import x from \'v3-public-dep\'\nexport default x\n')
 await mkdir(join(parenLayerSrcDir, 'plugins'), { recursive: true })
 await writeFile(join(parenLayerSrcDir, 'plugins/paren.mjs'), 'import x from \'paren-layer-dep\'\nexport default x\n')
 await writePackage(reachableCycleLayerRoot, 'reachable-cycle-layer', 'export default 1\n')
@@ -98,7 +107,7 @@ await writeFile(join(moduleRuntime, 'plugin.mjs'), 'import x from \'plugin-dep\'
 await writeFile(join(moduleRuntime, 'Component.vue'), '<script setup>\nimport x from \'component-dep\'\n</script>\n')
 await writeFile(join(moduleRuntime, 'middleware.mjs'), 'import x from \'middleware-dep\'\nexport default x\n')
 await writeFile(join(moduleRuntime, 'layout.vue'), '<script setup>\nimport x from \'layout-dep\'\n</script>\n')
-for (const dep of ['plugin-dep', 'component-dep', 'layer-component-dep', 'unused-layer-component-dep', 'server-component-dep', 'server-plugin-dep', 'server-page-dep', 'middleware-dep', 'layout-dep', 'paren-layer-dep']) {
+for (const dep of ['plugin-dep', 'component-dep', 'layer-component-dep', 'unused-layer-component-dep', 'server-component-dep', 'server-plugin-dep', 'server-page-dep', 'middleware-dep', 'layout-dep', 'paren-layer-dep', 'v3-client-dep', 'v3-server-dep', 'v3-module-dep', 'v3-public-dep']) {
   await writePackage(join(rootDir, 'node_modules', dep), dep, 'export default 1\n')
 }
 
@@ -127,6 +136,8 @@ const parentLayer = { app: join(parentLayerRoot, 'app/'), root: parentLayerRoot 
 const nestedLayer = { app: join(nestedLayerRoot, 'app/'), root: nestedLayerRoot }
 const otherParentLayer = { app: join(otherParentLayerRoot, 'app/'), root: otherParentLayerRoot }
 const otherNestedLayer = { app: join(otherNestedLayerRoot, 'app/'), root: otherNestedLayerRoot }
+// a v3-style layer has no `app/` directory: its srcDir is the package root
+const v3Layer = { app: v3LayerRoot, root: v3LayerRoot }
 const parenLayer = { app: parenLayerSrcDir, root: parenLayerRoot }
 const reachableCycleLayer = { app: join(reachableCycleLayerRoot, 'app/'), root: reachableCycleLayerRoot }
 const cycleLayerA = { app: join(cycleLayerARoot, 'app/'), root: cycleLayerARoot }
@@ -264,6 +275,27 @@ describe('installedScanEntries', () => {
       '!C:/project/node_modules/installed-layer/app/**/node_modules/**',
       '!C:/project/node_modules/installed-layer/app/**/*.server.{vue,js,jsx,mjs,ts,tsx,mts}',
     ])
+  })
+
+  it('should not scan the server, module and public directories of a v3-style layer', async () => {
+    const nuxt = createNuxt([v3Layer])
+
+    const entries = installedScanEntries(nuxt)
+
+    expect(entries).toEqual([
+      join(v3LayerRoot, '**/*.{vue,js,jsx,mjs,ts,tsx,mts}'),
+      '!' + join(v3LayerRoot, '**/node_modules/**'),
+      '!' + join(v3LayerRoot, 'server/**'),
+      '!' + join(v3LayerRoot, 'modules/**'),
+      '!' + join(v3LayerRoot, 'public/**'),
+      '!' + join(v3LayerRoot, '**/*.server.{vue,js,jsx,mjs,ts,tsx,mts}'),
+    ])
+
+    const deps = await optimizedDeps({ entries: [entry, ...entries] })
+    expect(deps).toContain('v3-client-dep')
+    expect(deps).not.toContain('v3-server-dep')
+    expect(deps).not.toContain('v3-module-dep')
+    expect(deps).not.toContain('v3-public-dep')
   })
 
   it('should scan installed layers whose path contains glob characters', async () => {

--- a/packages/vite/test/optimize-deps.test.ts
+++ b/packages/vite/test/optimize-deps.test.ts
@@ -91,8 +91,9 @@ await mkdir(moduleRuntime, { recursive: true })
 await writeFile(join(moduleRuntime, 'plugin.mjs'), 'import x from \'plugin-dep\'\nexport default x\n')
 await writeFile(join(moduleRuntime, 'Component.vue'), '<script setup>\nimport x from \'component-dep\'\n</script>\n')
 await writeFile(join(moduleRuntime, 'middleware.mjs'), 'import x from \'middleware-dep\'\nexport default x\n')
+await writeFile(join(moduleRuntime, 'extensionless.mjs'), 'import x from \'extensionless-dep\'\nexport default x\n')
 await writeFile(join(moduleRuntime, 'layout.vue'), '<script setup>\nimport x from \'layout-dep\'\n</script>\n')
-for (const dep of ['plugin-dep', 'component-dep', 'server-component-dep', 'server-plugin-dep', 'server-page-dep', 'middleware-dep', 'layout-dep', 'paren-layer-dep', 'v3-client-dep', 'v3-server-dep', 'v3-module-dep', 'v3-public-dep']) {
+for (const dep of ['plugin-dep', 'component-dep', 'server-component-dep', 'server-plugin-dep', 'server-page-dep', 'middleware-dep', 'layout-dep', 'extensionless-dep', 'paren-layer-dep', 'v3-client-dep', 'v3-server-dep', 'v3-module-dep', 'v3-public-dep']) {
   await writePackage(join(rootDir, 'node_modules', dep), dep, 'export default 1\n')
 }
 
@@ -177,6 +178,22 @@ describe('installedScanEntries', () => {
     await expect(optimizedDeps({ entries: [entry, ...entries] })).resolves.toEqual(
       expect.arrayContaining(['plugin-dep', 'component-dep', 'middleware-dep', 'layout-dep']),
     )
+  })
+
+  it('should scan app files that are registered without an extension', async () => {
+    const nuxt = createNuxt([], {
+      default: {
+        components: [],
+        plugins: [],
+        middleware: [{ path: join(moduleRuntime, 'extensionless') }],
+        layouts: {},
+      },
+    })
+
+    const entries = installedScanEntries(nuxt)
+
+    expect(entries).toEqual([join(moduleRuntime, 'extensionless.{vue,js,jsx,mjs,ts,tsx,mts}')])
+    await expect(optimizedDeps({ entries: [entry, ...entries] })).resolves.toContain('extensionless-dep')
   })
 
   it('should not scan generated files from a build directory inside node_modules', () => {

--- a/packages/vite/test/optimize-deps.test.ts
+++ b/packages/vite/test/optimize-deps.test.ts
@@ -5,7 +5,7 @@ import { join } from 'pathe'
 import { type Plugin, createServer } from 'vite'
 import type { Nuxt } from '@nuxt/schema'
 
-import { createOptimizeDepsIncludeResolver, installedScanEntries } from '../src/utils/optimize-deps.ts'
+import { installedScanEntries, resolveOptimizeDepsInclude } from '../src/utils/optimize-deps.ts'
 import { OptimizeDepsPlugin } from '../src/plugins/optimize-deps.ts'
 import { userOptimizeDepsInclude } from '../src/plugins/optimize-deps-hint.ts'
 
@@ -143,8 +143,8 @@ const reachableCycleLayer = { app: join(reachableCycleLayerRoot, 'app/'), root: 
 const cycleLayerA = { app: join(cycleLayerARoot, 'app/'), root: cycleLayerARoot }
 const cycleLayerB = { app: join(cycleLayerBRoot, 'app/'), root: cycleLayerBRoot }
 
-function resolveOptimizeDepsInclude (nuxt: Nuxt, include: string[], options: { preserveSymlinks?: boolean } = {}) {
-  return createOptimizeDepsIncludeResolver(nuxt, options)(include)
+function resolveInclude (nuxt: Nuxt, include: string[], options: { preserveSymlinks?: boolean } = {}) {
+  return resolveOptimizeDepsInclude(nuxt, include, options).flat()
 }
 
 async function optimizedDeps (options: { entries?: string[], include?: string[], plugins?: Plugin[], preserveSymlinks?: boolean }) {
@@ -378,23 +378,23 @@ describe('OptimizeDepsPlugin', () => {
   })
 })
 
-describe('createOptimizeDepsIncludeResolver', () => {
+describe('resolveOptimizeDepsInclude', () => {
   it('should rewrite entries that only resolve from an installed layer', () => {
     const nuxt = createNuxt([installedLayer])
 
-    expect(resolveOptimizeDepsInclude(nuxt, ['layer-dep'])).toEqual(['installed-layer > layer-dep'])
+    expect(resolveInclude(nuxt, ['layer-dep'])).toEqual(['installed-layer > layer-dep'])
   })
 
   it('should rewrite packages without a manifest that resolve from an installed layer', () => {
     const nuxt = createNuxt([installedLayer])
 
-    expect(resolveOptimizeDepsInclude(nuxt, ['manifestless-dep'])).toEqual(['installed-layer > manifestless-dep'])
+    expect(resolveInclude(nuxt, ['manifestless-dep'])).toEqual(['installed-layer > manifestless-dep'])
   })
 
   it('should preserve the full package chain for nested installed layers', async () => {
     const nuxt = createNuxt([parentLayer, nestedLayer])
 
-    const include = resolveOptimizeDepsInclude(nuxt, ['nested-dep'])
+    const include = resolveInclude(nuxt, ['nested-dep'])
 
     expect(include).toEqual(['parent-layer > nested-layer > nested-dep'])
     await expect(optimizedDeps({ include })).resolves.toContain('parent-layer > nested-layer > nested-dep')
@@ -403,19 +403,19 @@ describe('createOptimizeDepsIncludeResolver', () => {
   it('should resolve a layer rooted within an installed package', () => {
     const nuxt = createNuxt([subpathLayer])
 
-    expect(resolveOptimizeDepsInclude(nuxt, ['subpath-dep'])).toEqual(['subpath-layer > subpath-dep'])
+    expect(resolveInclude(nuxt, ['subpath-dep'])).toEqual(['subpath-layer > subpath-dep'])
   })
 
   it('should use the installed alias as the parent package name', () => {
     const nuxt = createNuxt([aliasedLayer])
 
-    expect(resolveOptimizeDepsInclude(nuxt, ['aliased-dep'])).toEqual(['aliased-layer > aliased-dep'])
+    expect(resolveInclude(nuxt, ['aliased-dep'])).toEqual(['aliased-layer > aliased-dep'])
   })
 
   it('should preserve separate dependency copies from different parent layers', async () => {
     const nuxt = createNuxt([parentLayer, nestedLayer, otherParentLayer, otherNestedLayer])
 
-    const include = resolveOptimizeDepsInclude(nuxt, ['nested-dep'])
+    const include = resolveInclude(nuxt, ['nested-dep'])
 
     expect(include).toEqual([
       'parent-layer > nested-layer > nested-dep',
@@ -427,7 +427,7 @@ describe('createOptimizeDepsIncludeResolver', () => {
   it('should preserve separate dependency copies from the project and a nested layer', async () => {
     const nuxt = createNuxt([parentLayer, nestedLayer])
 
-    const include = resolveOptimizeDepsInclude(nuxt, ['root-dep'])
+    const include = resolveInclude(nuxt, ['root-dep'])
 
     expect(include).toEqual([
       'root-dep',
@@ -439,9 +439,9 @@ describe('createOptimizeDepsIncludeResolver', () => {
   it('should follow Vite symlink identity when deduplicating dependency copies', async () => {
     const nuxt = createNuxt([parentLayer, nestedLayer])
 
-    expect(resolveOptimizeDepsInclude(nuxt, ['linked-dep'])).toEqual(['linked-dep'])
+    expect(resolveInclude(nuxt, ['linked-dep'])).toEqual(['linked-dep'])
 
-    const include = resolveOptimizeDepsInclude(nuxt, ['linked-dep'], { preserveSymlinks: true })
+    const include = resolveInclude(nuxt, ['linked-dep'], { preserveSymlinks: true })
     expect(include).toEqual([
       'linked-dep',
       'parent-layer > nested-layer > linked-dep',
@@ -452,7 +452,7 @@ describe('createOptimizeDepsIncludeResolver', () => {
   it('should resolve reachable layer cycles independent of layer order', () => {
     const nuxt = createNuxt([cycleLayerB, cycleLayerA, reachableCycleLayer])
 
-    expect(resolveOptimizeDepsInclude(nuxt, ['cycle-dep-b', 'cycle-dep-a'])).toEqual([
+    expect(resolveInclude(nuxt, ['cycle-dep-b', 'cycle-dep-a'])).toEqual([
       'reachable-cycle-layer > cycle-layer-b > cycle-dep-b',
       'reachable-cycle-layer > cycle-layer-b > cycle-layer-a > cycle-dep-a',
     ])
@@ -461,19 +461,19 @@ describe('createOptimizeDepsIncludeResolver', () => {
   it('should leave entries that resolve from the project root untouched', () => {
     const nuxt = createNuxt([installedLayer])
 
-    expect(resolveOptimizeDepsInclude(nuxt, ['root-dep'])).toEqual(['root-dep'])
+    expect(resolveInclude(nuxt, ['root-dep'])).toEqual(['root-dep'])
   })
 
   it('should leave unresolvable, nested and path entries untouched', () => {
     const nuxt = createNuxt([installedLayer])
     const include = ['does-not-exist', 'some-pkg > layer-dep', './local-file.js', join(rootDir, 'absolute.js')]
 
-    expect(resolveOptimizeDepsInclude(nuxt, include)).toEqual(include)
+    expect(resolveInclude(nuxt, include)).toEqual(include)
   })
 
   it('should not rewrite anything when there are no installed layers', () => {
     const nuxt = createNuxt([{ app: join(rootDir, 'layers/local/app/'), root: join(rootDir, 'layers/local/') }])
 
-    expect(resolveOptimizeDepsInclude(nuxt, ['layer-dep'])).toEqual(['layer-dep'])
+    expect(resolveInclude(nuxt, ['layer-dep'])).toEqual(['layer-dep'])
   })
 })

--- a/packages/vite/test/optimize-deps.test.ts
+++ b/packages/vite/test/optimize-deps.test.ts
@@ -24,6 +24,7 @@ const linkedDependencyRoot = join(rootDir, 'linked-dependency/')
 const v3LayerRoot = join(rootDir, 'node_modules/v3-layer/')
 const parenLayerRoot = join(rootDir, 'Nuxt Projects (old)/node_modules/paren-layer/')
 const parenLayerSrcDir = join(parenLayerRoot, 'app/')
+const buildDir = join(rootDir, 'node_modules/.cache/nuxt/.nuxt/')
 const moduleRuntime = join(rootDir, 'node_modules/installed-module/runtime/')
 const entry = join(srcDir, 'entry.mjs')
 const modeServerComponent = join(layerSrcDir, 'components/ModeServer.vue')
@@ -103,6 +104,7 @@ function createNuxt (layerDirs: Array<{ app: string, root: string }> = [], apps:
     options: {
       rootDir,
       srcDir,
+      buildDir,
       alias: {},
       vite: {},
       _layers: [
@@ -175,6 +177,19 @@ describe('installedScanEntries', () => {
     await expect(optimizedDeps({ entries: [entry, ...entries] })).resolves.toEqual(
       expect.arrayContaining(['plugin-dep', 'component-dep', 'middleware-dep', 'layout-dep']),
     )
+  })
+
+  it('should not scan generated files from a build directory inside node_modules', () => {
+    const nuxt = createNuxt([], {
+      default: {
+        components: [],
+        plugins: [{ src: join(buildDir, 'components.plugin.mjs') }],
+        middleware: [],
+        layouts: {},
+      },
+    })
+
+    expect(installedScanEntries(nuxt)).toEqual([])
   })
 
   it('should not scan client-inaccessible app files', () => {

--- a/packages/vite/test/optimize-deps.test.ts
+++ b/packages/vite/test/optimize-deps.test.ts
@@ -21,16 +21,11 @@ const nestedLayerRoot = join(parentLayerRoot, 'node_modules/nested-layer/')
 const otherParentLayerRoot = join(rootDir, 'node_modules/other-parent-layer/')
 const otherNestedLayerRoot = join(otherParentLayerRoot, 'node_modules/nested-layer/')
 const linkedDependencyRoot = join(rootDir, 'linked-dependency/')
-const reachableCycleLayerRoot = join(rootDir, 'node_modules/reachable-cycle-layer/')
-const cycleLayerARoot = join(rootDir, 'isolated/node_modules/cycle-layer-a/')
-const cycleLayerBRoot = join(rootDir, 'isolated/node_modules/cycle-layer-b/')
 const v3LayerRoot = join(rootDir, 'node_modules/v3-layer/')
 const parenLayerRoot = join(rootDir, 'node_modules/.pnpm/paren-layer@1.0.0(vue@3.5.0)/node_modules/paren-layer/')
 const parenLayerSrcDir = join(parenLayerRoot, 'app/')
 const moduleRuntime = join(rootDir, 'node_modules/installed-module/runtime/')
 const entry = join(srcDir, 'entry.mjs')
-const layerComponent = join(layerSrcDir, 'components/LayerComponent.vue')
-const unusedLayerComponent = join(layerSrcDir, 'components/UnusedLayerComponent.vue')
 const modeServerComponent = join(layerSrcDir, 'components/ModeServer.vue')
 const modeServerPlugin = join(layerSrcDir, 'plugins/mode-server.mjs')
 const modeServerPage = join(layerSrcDir, 'pages/mode-server.vue')
@@ -56,8 +51,6 @@ await writeFile(join(rootDir, 'package.json'), JSON.stringify({ name: 'fixture',
 await writeFile(entry, 'export default 1\n')
 await writeFile(join(layerRoot, 'package.json'), JSON.stringify({ name: 'installed-layer', type: 'module' }))
 await writeFile(join(layerSrcDir, 'plugins/broken.mjs'), 'import { hello } from \'layer-dep\'\nexport default hello\n')
-await writeFile(layerComponent, '<script setup>\nimport x from \'layer-component-dep\'\n</script>\n')
-await writeFile(unusedLayerComponent, '<script setup>\nimport x from \'unused-layer-component-dep\'\n</script>\n')
 await writeFile(modeServerComponent, '<script setup>\nimport x from \'server-component-dep\'\n</script>\n')
 await writeFile(modeServerPlugin, 'import x from \'server-plugin-dep\'\nexport default x\n')
 await writeFile(modeServerPage, '<script setup>\nimport x from \'server-page-dep\'\n</script>\n')
@@ -92,37 +85,28 @@ await writeFile(join(v3LayerRoot, 'modules/build.mjs'), 'import x from \'v3-modu
 await writeFile(join(v3LayerRoot, 'public/widget.mjs'), 'import x from \'v3-public-dep\'\nexport default x\n')
 await mkdir(join(parenLayerSrcDir, 'plugins'), { recursive: true })
 await writeFile(join(parenLayerSrcDir, 'plugins/paren.mjs'), 'import x from \'paren-layer-dep\'\nexport default x\n')
-await writePackage(reachableCycleLayerRoot, 'reachable-cycle-layer', 'export default 1\n')
-await writePackage(cycleLayerARoot, 'cycle-layer-a', 'export default 1\n')
-await writePackage(cycleLayerBRoot, 'cycle-layer-b', 'export default 1\n')
-await writePackage(join(cycleLayerARoot, 'node_modules/cycle-dep-a'), 'cycle-dep-a', 'export default 1\n')
-await writePackage(join(cycleLayerBRoot, 'node_modules/cycle-dep-b'), 'cycle-dep-b', 'export default 1\n')
-await mkdir(join(reachableCycleLayerRoot, 'node_modules'), { recursive: true })
-await symlink(cycleLayerBRoot, join(reachableCycleLayerRoot, 'node_modules/cycle-layer-b'), 'dir')
-await symlink(cycleLayerARoot, join(cycleLayerBRoot, 'node_modules/cycle-layer-a'), 'dir')
-await symlink(cycleLayerBRoot, join(cycleLayerARoot, 'node_modules/cycle-layer-b'), 'dir')
 
 await mkdir(moduleRuntime, { recursive: true })
 await writeFile(join(moduleRuntime, 'plugin.mjs'), 'import x from \'plugin-dep\'\nexport default x\n')
 await writeFile(join(moduleRuntime, 'Component.vue'), '<script setup>\nimport x from \'component-dep\'\n</script>\n')
 await writeFile(join(moduleRuntime, 'middleware.mjs'), 'import x from \'middleware-dep\'\nexport default x\n')
 await writeFile(join(moduleRuntime, 'layout.vue'), '<script setup>\nimport x from \'layout-dep\'\n</script>\n')
-for (const dep of ['plugin-dep', 'component-dep', 'layer-component-dep', 'unused-layer-component-dep', 'server-component-dep', 'server-plugin-dep', 'server-page-dep', 'middleware-dep', 'layout-dep', 'paren-layer-dep', 'v3-client-dep', 'v3-server-dep', 'v3-module-dep', 'v3-public-dep']) {
+for (const dep of ['plugin-dep', 'component-dep', 'server-component-dep', 'server-plugin-dep', 'server-page-dep', 'middleware-dep', 'layout-dep', 'paren-layer-dep', 'v3-client-dep', 'v3-server-dep', 'v3-module-dep', 'v3-public-dep']) {
   await writePackage(join(rootDir, 'node_modules', dep), dep, 'export default 1\n')
 }
 
 afterAll(() => rm(rootDir, { recursive: true, force: true }))
 
-function createNuxt (layerDirs: Array<{ app: string, root: string }> = [], apps: Record<string, any> = { default: { components: [], plugins: [], middleware: [], layouts: {} } }, root = rootDir, src = srcDir) {
+function createNuxt (layerDirs: Array<{ app: string, root: string }> = [], apps: Record<string, any> = { default: { components: [], plugins: [], middleware: [], layouts: {} } }) {
   return {
     apps,
     options: {
-      rootDir: root,
-      srcDir: src,
+      rootDir,
+      srcDir,
       alias: {},
       vite: {},
       _layers: [
-        { cwd: root, config: { rootDir: root, srcDir: src } },
+        { cwd: rootDir, config: { rootDir, srcDir } },
         ...layerDirs.map(dirs => ({ cwd: dirs.root, config: { rootDir: dirs.root, srcDir: dirs.app } })),
       ],
     },
@@ -139,9 +123,6 @@ const otherNestedLayer = { app: join(otherNestedLayerRoot, 'app/'), root: otherN
 // a v3-style layer has no `app/` directory: its srcDir is the package root
 const v3Layer = { app: v3LayerRoot, root: v3LayerRoot }
 const parenLayer = { app: parenLayerSrcDir, root: parenLayerRoot }
-const reachableCycleLayer = { app: join(reachableCycleLayerRoot, 'app/'), root: reachableCycleLayerRoot }
-const cycleLayerA = { app: join(cycleLayerARoot, 'app/'), root: cycleLayerARoot }
-const cycleLayerB = { app: join(cycleLayerBRoot, 'app/'), root: cycleLayerBRoot }
 
 function resolveInclude (nuxt: Nuxt, include: string[], options: { preserveSymlinks?: boolean } = {}) {
   return resolveOptimizeDepsInclude(nuxt, include, options).flat()
@@ -172,12 +153,6 @@ async function optimizedDeps (options: { entries?: string[], include?: string[],
 }
 
 describe('installedScanEntries', () => {
-  it('should not scan layers that are part of the project', () => {
-    const nuxt = createNuxt([{ app: join(rootDir, 'layers/local/app/'), root: join(rootDir, 'layers/local/') }])
-
-    expect(installedScanEntries(nuxt)).toEqual([])
-  })
-
   it('should pre-bundle dependencies only reachable through an installed layer', async () => {
     await expect(optimizedDeps({})).resolves.toEqual([])
 
@@ -265,18 +240,6 @@ describe('installedScanEntries', () => {
     expect(installedScanEntries(nuxt)).toEqual(['C:/project/node_modules/installed-module/runtime/plugin.mjs'])
   })
 
-  it('should normalize installed layer paths on Windows', () => {
-    const projectRoot = 'C:\\project\\'
-    const installedRoot = 'C:\\project\\node_modules\\installed-layer\\'
-    const nuxt = createNuxt([{ app: installedRoot + 'app\\', root: installedRoot }], undefined, projectRoot, projectRoot + 'app\\')
-
-    expect(installedScanEntries(nuxt)).toEqual([
-      'C:/project/node_modules/installed-layer/app/**/*.{vue,js,jsx,mjs,ts,tsx,mts}',
-      '!C:/project/node_modules/installed-layer/app/**/node_modules/**',
-      '!C:/project/node_modules/installed-layer/app/**/*.server.{vue,js,jsx,mjs,ts,tsx,mts}',
-    ])
-  })
-
   it('should not scan the server, module and public directories of a v3-style layer', async () => {
     const nuxt = createNuxt([v3Layer])
 
@@ -336,45 +299,23 @@ describe('OptimizeDepsPlugin', () => {
     expect(config.optimizeDeps).toEqual({ entries: [entry], include: ['layer-dep'] })
   })
 
-  it('should keep rewritten entries attributed to the user', async () => {
-    const nuxt = createNuxt([installedLayer])
-    userOptimizeDepsInclude.set(nuxt, ['layer-dep'])
-
-    await configureEnvironment(nuxt, 'client', { optimizeDeps: { include: ['layer-dep', 'root-dep'] } })
-
-    expect(userOptimizeDepsInclude.get(nuxt)).toEqual(['layer-dep', 'installed-layer > layer-dep'])
-  })
-
   it('should attribute every resolved dependency copy to the user', async () => {
     const nuxt = createNuxt([parentLayer, nestedLayer, otherParentLayer, otherNestedLayer])
     userOptimizeDepsInclude.set(nuxt, ['nested-dep'])
 
-    const config = await configureEnvironment(nuxt, 'client', { optimizeDeps: { include: ['nested-dep'] } })
+    const config = await configureEnvironment(nuxt, 'client', { optimizeDeps: { include: ['nested-dep', 'root-dep'] } })
 
+    // `root-dep` came from elsewhere, so its rewrites must not be attributed to the user
     expect(userOptimizeDepsInclude.get(nuxt)).toEqual([
       'nested-dep',
       'parent-layer > nested-layer > nested-dep',
       'other-parent-layer > nested-layer > nested-dep',
     ])
-    expect(config.optimizeDeps.include).toEqual(userOptimizeDepsInclude.get(nuxt)?.slice(1))
-  })
-
-  it('should scan components from installed layers', async () => {
-    const nuxt = createNuxt([installedLayer], {
-      default: {
-        components: [
-          { filePath: layerComponent },
-          { filePath: unusedLayerComponent },
-        ],
-        plugins: [],
-        middleware: [],
-        layouts: {},
-      },
-    })
-    const config = await configureEnvironment(nuxt, 'client', { optimizeDeps: { entries: [entry] } })
-
-    const deps = await optimizedDeps(config.optimizeDeps)
-    expect(deps).toEqual(expect.arrayContaining(['layer-component-dep', 'unused-layer-component-dep']))
+    expect(config.optimizeDeps.include).toEqual([
+      ...userOptimizeDepsInclude.get(nuxt)!.slice(1),
+      'root-dep',
+      'parent-layer > nested-layer > root-dep',
+    ])
   })
 })
 
@@ -397,6 +338,8 @@ describe('resolveOptimizeDepsInclude', () => {
     const include = resolveInclude(nuxt, ['nested-dep'])
 
     expect(include).toEqual(['parent-layer > nested-layer > nested-dep'])
+    // a nested layer may be listed before its parent and must still get the full chain
+    expect(resolveInclude(createNuxt([nestedLayer, parentLayer]), ['nested-dep'])).toEqual(include)
     await expect(optimizedDeps({ include })).resolves.toContain('parent-layer > nested-layer > nested-dep')
   })
 
@@ -447,15 +390,6 @@ describe('resolveOptimizeDepsInclude', () => {
       'parent-layer > nested-layer > linked-dep',
     ])
     await expect(optimizedDeps({ include, preserveSymlinks: true })).resolves.toEqual(expect.arrayContaining(include))
-  })
-
-  it('should resolve reachable layer cycles independent of layer order', () => {
-    const nuxt = createNuxt([cycleLayerB, cycleLayerA, reachableCycleLayer])
-
-    expect(resolveInclude(nuxt, ['cycle-dep-b', 'cycle-dep-a'])).toEqual([
-      'reachable-cycle-layer > cycle-layer-b > cycle-dep-b',
-      'reachable-cycle-layer > cycle-layer-b > cycle-layer-a > cycle-dep-a',
-    ])
   })
 
   it('should leave entries that resolve from the project root untouched', () => {

--- a/packages/vite/test/optimize-deps.test.ts
+++ b/packages/vite/test/optimize-deps.test.ts
@@ -81,6 +81,9 @@ await mkdir(join(v3LayerRoot, 'server/api'), { recursive: true })
 await mkdir(join(v3LayerRoot, 'modules'), { recursive: true })
 await mkdir(join(v3LayerRoot, 'public'), { recursive: true })
 await writeFile(join(v3LayerRoot, 'components/V3.vue'), '<script setup>\nimport x from \'v3-client-dep\'\n</script>\n')
+await writeFile(join(v3LayerRoot, 'nuxt.config.ts'), 'import x from \'v3-config-dep\'\nexport default { x }\n')
+await writeFile(join(v3LayerRoot, 'eslint.config.js'), 'import x from \'v3-config-dep\'\nexport default [x]\n')
+await writeFile(join(v3LayerRoot, 'app.config.ts'), 'import x from \'v3-app-config-dep\'\nexport default { x }\n')
 await writeFile(join(v3LayerRoot, 'server/api/route.mjs'), 'import x from \'v3-server-dep\'\nexport default x\n')
 await writeFile(join(v3LayerRoot, 'modules/build.mjs'), 'import x from \'v3-module-dep\'\nexport default x\n')
 await writeFile(join(v3LayerRoot, 'public/widget.mjs'), 'import x from \'v3-public-dep\'\nexport default x\n')
@@ -93,7 +96,7 @@ await writeFile(join(moduleRuntime, 'Component.vue'), '<script setup>\nimport x 
 await writeFile(join(moduleRuntime, 'middleware.mjs'), 'import x from \'middleware-dep\'\nexport default x\n')
 await writeFile(join(moduleRuntime, 'extensionless.mjs'), 'import x from \'extensionless-dep\'\nexport default x\n')
 await writeFile(join(moduleRuntime, 'layout.vue'), '<script setup>\nimport x from \'layout-dep\'\n</script>\n')
-for (const dep of ['plugin-dep', 'component-dep', 'server-component-dep', 'server-plugin-dep', 'server-page-dep', 'middleware-dep', 'layout-dep', 'extensionless-dep', 'paren-layer-dep', 'v3-client-dep', 'v3-server-dep', 'v3-module-dep', 'v3-public-dep']) {
+for (const dep of ['plugin-dep', 'component-dep', 'server-component-dep', 'server-plugin-dep', 'server-page-dep', 'middleware-dep', 'layout-dep', 'extensionless-dep', 'paren-layer-dep', 'v3-client-dep', 'v3-server-dep', 'v3-module-dep', 'v3-public-dep', 'v3-config-dep', 'v3-app-config-dep']) {
   await writePackage(join(rootDir, 'node_modules', dep), dep, 'export default 1\n')
 }
 
@@ -223,6 +226,7 @@ describe('installedScanEntries', () => {
     expect(installedScanEntries(nuxt)).toEqual([
       join(layerSrcDir, '**/*.{vue,js,jsx,mjs,ts,tsx,mts}'),
       '!' + join(layerSrcDir, '**/node_modules/**'),
+      '!' + join(layerSrcDir, '!(app).config.{vue,js,jsx,mjs,ts,tsx,mts}'),
       '!' + join(layerSrcDir, '**/*.server.{vue,js,jsx,mjs,ts,tsx,mts}'),
     ])
   })
@@ -272,7 +276,7 @@ describe('installedScanEntries', () => {
     expect(installedScanEntries(nuxt)).toEqual(['C:/project/node_modules/installed-module/runtime/plugin.mjs'])
   })
 
-  it('should not scan the server, module and public directories of a v3-style layer', async () => {
+  it('should not scan the config, server, module and public files of a v3-style layer', async () => {
     const nuxt = createNuxt([v3Layer])
 
     const entries = installedScanEntries(nuxt)
@@ -280,6 +284,7 @@ describe('installedScanEntries', () => {
     expect(entries).toEqual([
       join(v3LayerRoot, '**/*.{vue,js,jsx,mjs,ts,tsx,mts}'),
       '!' + join(v3LayerRoot, '**/node_modules/**'),
+      '!' + join(v3LayerRoot, '!(app).config.{vue,js,jsx,mjs,ts,tsx,mts}'),
       '!' + join(v3LayerRoot, 'server/**'),
       '!' + join(v3LayerRoot, 'modules/**'),
       '!' + join(v3LayerRoot, 'public/**'),
@@ -291,6 +296,8 @@ describe('installedScanEntries', () => {
     expect(deps).not.toContain('v3-server-dep')
     expect(deps).not.toContain('v3-module-dep')
     expect(deps).not.toContain('v3-public-dep')
+    expect(deps).not.toContain('v3-config-dep')
+    expect(deps).toContain('v3-app-config-dep')
   })
 
   it('should scan installed layers whose path contains parentheses', async () => {

--- a/packages/vite/test/optimize-deps.test.ts
+++ b/packages/vite/test/optimize-deps.test.ts
@@ -22,7 +22,7 @@ const otherParentLayerRoot = join(rootDir, 'node_modules/other-parent-layer/')
 const otherNestedLayerRoot = join(otherParentLayerRoot, 'node_modules/nested-layer/')
 const linkedDependencyRoot = join(rootDir, 'linked-dependency/')
 const v3LayerRoot = join(rootDir, 'node_modules/v3-layer/')
-const parenLayerRoot = join(rootDir, 'node_modules/.pnpm/paren-layer@1.0.0(vue@3.5.0)/node_modules/paren-layer/')
+const parenLayerRoot = join(rootDir, 'Nuxt Projects (old)/node_modules/paren-layer/')
 const parenLayerSrcDir = join(parenLayerRoot, 'app/')
 const moduleRuntime = join(rootDir, 'node_modules/installed-module/runtime/')
 const entry = join(srcDir, 'entry.mjs')
@@ -261,7 +261,7 @@ describe('installedScanEntries', () => {
     expect(deps).not.toContain('v3-public-dep')
   })
 
-  it('should scan installed layers whose path contains glob characters', async () => {
+  it('should scan installed layers whose path contains parentheses', async () => {
     const entries = installedScanEntries(createNuxt([parenLayer]))
 
     await expect(optimizedDeps({ entries: [entry, ...entries] })).resolves.toContain('paren-layer-dep')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1613,6 +1613,9 @@ importers:
       std-env:
         specifier: catalog:build
         version: 4.2.0
+      tinyglobby:
+        specifier: catalog:build
+        version: 0.2.17
       ufo:
         specifier: catalog:build
         version: 1.6.4


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

A few issues on the PR while testing against my personal sites.

- Broke when there was a layer dep chain of parent layer > child layer > dep
- Server components were included in the scan
- v3 app dir setups would scan incorrectly

<details><summary>AI Generated Summary</summary>
<p>

- Used the package.json name for the parent instead of the installed folder name, so aliased installs didn't resolve
- Stopped at the first match, so a second copy of a dep inside a layer never got bundled
- Treated every node_modules layer as a parent, even ones vite can't resolve from the root
- Paths weren't escaped, so a project path with parens in it matched nothing
- Paths weren't normalised; addComponent and addRouteMiddleware don't do it, only addPlugin does
- Skipped the include rewrite entirely when there were no scan entries
- buildDir lives inside node_modules, so generated templates got scanned, and only on a warm boot
- Files registered without an extension got dropped by vite and never scanned at all
- v3 layers have srcDir === rootDir, so server/, modules/ and public/ were scanned as client code
- Same for nuxt.config and any other build config the layer ships


</p>
</details> 


<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
