### PR TITLE
fix(kit): include top-level test directories in typechecking

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -196,6 +196,9 @@ export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: stri
   const relativeModulesDir = relativeWithDot(projectBuildDir, dirs.modules)
   const relativeSharedDir = relativeWithDot(projectBuildDir, dirs.shared)
   const relativeServerDir = relativeWithDot(projectBuildDir, dirs.server)
+  const topLevelTestPaths = ['test', 'tests']
+    .filter(dir => existsSync(resolve(dirs.root, dir)))
+    .map(dir => join(relativeRootDir, `${dir}/**/*`))
   return {
     nuxt: [
       join(relativeSrcDir, '**/*'),
@@ -212,6 +215,7 @@ export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: stri
       join(relativeRootDir, `layers/*/modules/*/runtime/server/**/*`),
     ],
     node: [
+      ...topLevelTestPaths,
       join(relativeModulesDir, `*.*`),
       join(relativeRootDir, `nuxt.config.*`),
       join(relativeRootDir, `.config/nuxt.*`),

--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -199,6 +199,21 @@ export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: stri
   const topLevelTestPaths = ['test', 'tests']
     .filter(dir => existsSync(resolve(dirs.root, dir)))
     .map(dir => join(relativeRootDir, `${dir}/**/*`))
+  // Keep Nuxt-specific tests in the nuxt context only. Exclude
+  // test/nuxt and tests/nuxt from the node globs before they are
+  // spread into tsconfig.node.json; all other test files remain included.
+  const nuxtTestExcludeForNode = [
+    join(relativeRootDir, 'test/nuxt/**/*'),
+    join(relativeRootDir, 'tests/nuxt/**/*'),
+  ]
+  // Explicitly filter before spreading (broad globs like test/**/* would
+  // otherwise also match test/nuxt/**/*). The filtered list preserves
+  // inclusion of all other test files; nuxt context stays responsible
+  // for the excluded tests and nodeExclude handles the actual tsconfig
+  // exclusion (see _generateTypes).
+  const filteredTopLevelTestPaths = topLevelTestPaths.filter(p => !nuxtTestExcludeForNode.includes(p))
+  // filteredTopLevelTestPaths is spread below (excludes test/nuxt and tests/nuxt)
+  // but broad globs like test/**/* still require nodeExclude handling in _generateTypes
   return {
     nuxt: [
       join(relativeSrcDir, '**/*'),
@@ -215,7 +230,7 @@ export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: stri
       join(relativeRootDir, `layers/*/modules/*/runtime/server/**/*`),
     ],
     node: [
-      ...topLevelTestPaths,
+      ...filteredTopLevelTestPaths,
       join(relativeModulesDir, `*.*`),
       join(relativeRootDir, `nuxt.config.*`),
       join(relativeRootDir, `.config/nuxt.*`),
@@ -399,6 +414,14 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
     exclude.add(serverGlob)
     nodeExclude.add(serverGlob)
     legacyExclude.add(serverGlob)
+  }
+
+  // Ensure Nuxt-specific tests remain in nuxt context only.
+  // Top-level `test/**/*` / `tests/**/*` are in nodeInclude, but
+  // test/nuxt and tests/nuxt must be excluded from tsconfig.node.json
+  // before spreading; preserve all other test files.
+  for (const p of [join(relativeWithDot(typesDir, nuxt.options.rootDir), 'test/nuxt/**/*'), join(relativeWithDot(typesDir, nuxt.options.rootDir), 'tests/nuxt/**/*')]) {
+    nodeExclude.add(p)
   }
 
   const moduleEntryPaths: string[] = []


### PR DESCRIPTION
﻿Fixes #34756

**Problem:** Running `nuxt typecheck` does not report type errors in test files like `tests/utils.test.ts` because only `test/nuxt/**/*` and `tests/nuxt/**/*` are included in the generated TypeScript context. A file such as `const a: number = "asdf"` under `tests/` is silently ignored.

**Root cause:** `resolveLayerPaths()` in `packages/kit/src/template.ts` only adds `test/nuxt/**` and `tests/nuxt/**` to the Nuxt app context. Top-level `test/` and `tests/` directories are not part of any generated tsconfig, so they are not typechecked at all.

**Solution:** Add `test/**/*` and `tests/**/*` (when those directories exist on disk) to the `node` type context. This ensures `pnpm nuxt typecheck` covers those files via `tsconfig.node.json` without leaking Nuxt auto-imports or aliases into non-Nuxt unit tests. `test/nuxt/` and `tests/nuxt/` remain in the Nuxt app context as before.

This matches maintainer feedback that we should not expand the Nuxt glob, but still ensure top-level tests are typechecked - scoped to the node project instead.

**Verification:**
- Verified template.ts now includes top-level test paths in node when directories exist
- Existing generate-types.spec logic remains compatible
- Manual check: a tests/utils.test.ts with a type error is now included in parsed tsconfig.node.json

---
Disclosure: This contribution was prepared with assistance from an AI agent and reviewed by a human (Weza Mwiwa, devwez) who understands the change and can explain it, per the repository contribution policy.
