### PR TITLE
fix(nuxt): support `definePageMeta` at the top level of `setup()`

### DIFF
--- a/packages/kit/src/diagnostics/pages.ts
+++ b/packages/kit/src/diagnostics/pages.ts
@@ -43,7 +43,7 @@ export const pageDiagnostics = /* #__PURE__ */ defineDiagnostics({
     },
     NUXT_B4007: {
       why: (p: { fnName: string, file: string }) => `\`${p.fnName}\` is called conditionally or used as an expression in \`${p.file}\`, but it is a compiler macro that is extracted at build time and always applies.`,
-      fix: (p: { fnName: string }) => `Call \`${p.fnName}({ ... })\` once, as a statement at the top level of the \`<script setup>\` block.`,
+      fix: (p: { fnName: string }) => `Call \`${p.fnName}({ ... })\` once, as a statement at the top level of the \`<script setup>\` block (or of \`setup()\` in a page that does not use \`<script setup>\`).`,
       docs: false,
     },
     NUXT_B4008: {

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -327,7 +327,7 @@ function findOptionsApiSetupBody (program: ESTree.Program): Array<ESTree.Node> |
     if (declaration?.type !== 'ObjectExpression') { return }
 
     for (const property of declaration.properties) {
-      if (property.type !== 'Property' || property.computed) { continue }
+      if (property.type !== 'Property' || property.computed || property.kind !== 'init') { continue }
       const key = property.key.type === 'Identifier' ? property.key.name : property.key.type === 'Literal' ? property.key.value : undefined
       if (key !== 'setup') { continue }
       const value = property.value

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -302,6 +302,43 @@ function unwrapStaticExpression (node: ESTree.Node | undefined): ESTree.Node | u
   return current
 }
 
+function collectStatementCalls (body: Array<ESTree.Node>, into: Set<ESTree.Node>) {
+  for (const statement of body) {
+    if (statement.type !== 'ExpressionStatement') { continue }
+    const expression = unwrapStaticExpression(statement.expression)
+    if (expression?.type === 'CallExpression') {
+      into.add(expression)
+    }
+  }
+}
+
+/**
+ * The body of the `setup()` option of an Options API default export, if the module has one.
+ */
+function findOptionsApiSetupBody (program: ESTree.Program): Array<ESTree.Node> | undefined {
+  for (const statement of program.body) {
+    if (statement.type !== 'ExportDefaultDeclaration') { continue }
+
+    let declaration = unwrapStaticExpression(statement.declaration as ESTree.Node)
+    // `export default defineComponent({ ... })` and friends
+    if (declaration?.type === 'CallExpression') {
+      declaration = unwrapStaticExpression(declaration.arguments[0])
+    }
+    if (declaration?.type !== 'ObjectExpression') { return }
+
+    for (const property of declaration.properties) {
+      if (property.type !== 'Property' || property.computed) { continue }
+      const key = property.key.type === 'Identifier' ? property.key.name : property.key.type === 'Literal' ? property.key.value : undefined
+      if (key !== 'setup') { continue }
+      const value = property.value
+      if ((value.type === 'FunctionExpression' || value.type === 'ArrowFunctionExpression') && value.body?.type === 'BlockStatement') {
+        return value.body.body
+      }
+    }
+    return
+  }
+}
+
 /**
  * The keys of `definePageMeta` whose values are read at build time, given the user's
  * `experimental.extraPageMetaExtractionKeys`.
@@ -471,12 +508,12 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
     })
 
     const topLevelCalls = new Set<ESTree.Node>()
-    for (const statement of program.body) {
-      if (statement.type !== 'ExpressionStatement') { continue }
-      const expression = unwrapStaticExpression(statement.expression)
-      if (expression?.type === 'CallExpression') {
-        topLevelCalls.add(expression)
-      }
+    collectStatementCalls(program.body, topLevelCalls)
+    // A page written without `<script setup>` has no other place to call the macros than the top
+    // level of its `setup()`, so a call there is as unconditional as a top-level one.
+    const setupBody = findOptionsApiSetupBody(program)
+    if (setupBody) {
+      collectStatementCalls(setupBody, topLevelCalls)
     }
 
     const extractedMacros = new Set<string>()

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -555,6 +555,46 @@ describe('page metadata macro position', () => {
     expect(warn).not.toHaveBeenCalled()
   })
 
+  it('should not warn when a macro is called at the top level of an Options API `setup()`', () => {
+    getRouteMeta(`
+    <script>
+    export default {
+      setup () {
+        definePageMeta({ middleware: ['authenticated'] })
+      },
+    }
+    </script>
+    `, '/app/pages/options-api.vue')
+
+    getRouteMeta(`
+    <script lang="ts">
+    export default defineComponent({
+      async setup () {
+        definePageMeta({ middleware: ['authenticated'] })
+      },
+    })
+    </script>
+    `, '/app/pages/define-component.vue')
+
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('should warn when a macro is called conditionally inside an Options API `setup()`', () => {
+    getRouteMeta(`
+    <script>
+    export default {
+      setup () {
+        if (condition) {
+          definePageMeta({ middleware: ['authenticated'] })
+        }
+      },
+    }
+    </script>
+    `, '/app/pages/options-api-conditional.vue')
+
+    expect(warn).toHaveBeenCalledWith({ fnName: 'definePageMeta', file: expect.stringMatching(/app\/pages\/options-api-conditional\.vue:6:11$/) })
+  })
+
   it('should warn when a macro is called conditionally', () => {
     getRouteMeta(`
     <script setup>


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/36226

### 📚 Description

this searches for a `setup()` to accept `definePageMeta` present there, for support with pure `<script>` blocks