### PR TITLE
fix(kit): declare `@nuxt/schema` as an optional peer dependency

### DIFF
--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -51,6 +51,7 @@
     "verkit": "catalog:build"
   },
   "peerDependencies": {
+    "@nuxt/schema": "^4.6.0 || ^5.0.0-0",
     "confbox": "catalog:build",
     "dotenv": "catalog:build",
     "giget": "catalog:build",
@@ -60,6 +61,9 @@
     "rolldown": ">=1.0.0"
   },
   "peerDependenciesMeta": {
+    "@nuxt/schema": {
+      "optional": true
+    },
     "confbox": {
       "optional": true
     },


### PR DESCRIPTION
### 🔗 Linked issue

resolves #36241 

### 📚 Description

this declares `@nuxt/schema` as an optional peer - not sure why this wasn't the case before! 🤦 
