### PR TITLE
fix(nuxt): resolve layout hydration guard when unmounted early

### DIFF
--- a/packages/nuxt/src/app/components/nuxt-layout.ts
+++ b/packages/nuxt/src/app/components/nuxt-layout.ts
@@ -1,5 +1,5 @@
 import type { DefineComponent, ExtractPublicPropTypes, MaybeRef, PropType, VNode } from 'vue'
-import { Suspense, computed, defineComponent, h, inject, mergeProps, nextTick, onMounted, provide, shallowReactive, shallowRef, unref } from 'vue'
+import { Suspense, computed, defineComponent, h, inject, mergeProps, nextTick, onBeforeUnmount, onMounted, provide, shallowReactive, shallowRef, unref } from 'vue'
 import type { RouteLocationNormalizedLoaded } from 'vue-router'
 
 import type { NuxtLayouts, PageMeta } from '../../pages/runtime/composables'
@@ -76,11 +76,17 @@ export default defineComponent({
     context.expose({ layoutRef })
 
     const done = nuxtApp.deferHydration()
-    if (import.meta.client && nuxtApp.isHydrating) {
-      const removeErrorHook = nuxtApp.hooks.hookOnce('app:error', done)
-      const removeGuard = useRouter().beforeEach(() => {
-        removeErrorHook()
-        removeGuard()
+    if (import.meta.client) {
+      if (nuxtApp.isHydrating) {
+        const removeErrorHook = nuxtApp.hooks.hookOnce('app:error', done)
+        const removeGuard = useRouter().beforeEach(() => {
+          removeErrorHook()
+          removeGuard()
+        })
+      }
+      onBeforeUnmount(() => {
+        // Ensure hydration completes if unmounted before Suspense resolves
+        done()
       })
     }
 

--- a/test/nuxt/nuxt-layout.test.ts
+++ b/test/nuxt/nuxt-layout.test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vites
 
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import type { VueWrapper } from '@vue/test-utils'
-import { flushPromises } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { NuxtLayout, NuxtPage } from '#components'
 import layouts from '#build/layouts.mjs'
 import { useRoute } from '#app/composables/router'
@@ -300,5 +300,30 @@ describe('layout switching', () => {
     router.removeRoute('layout-switch-start')
     router.removeRoute('layout-switch-end')
     delete layouts['layout-async']
+  })
+})
+
+describe('layout hydration', () => {
+  it('should release the hydration guard when unmounted before its suspense resolves', async () => {
+    const nuxtApp = useNuxtApp()
+    const done = vi.fn()
+    const deferHydration = vi.spyOn(nuxtApp, 'deferHydration').mockReturnValue(done)
+
+    layouts['layout-pending'] = defineAsyncComponent(() => new Promise(() => {}))
+
+    const el = nuxtApp.runWithContext(() => mount({
+      setup: () => () => h(NuxtLayout, { name: 'layout-pending' }),
+    }))
+    await flushPromises()
+
+    expect(done).not.toHaveBeenCalled()
+
+    el.unmount()
+    await flushPromises()
+
+    expect(done).toHaveBeenCalled()
+
+    deferHydration.mockRestore()
+    delete layouts['layout-pending']
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this mirrors the fix from #34152 - previously a layout unmounted before suspense resolved left `isHydrating` stuck