### PR TITLE
feat(nuxt): add `ShallowRef` type to vue preset

### DIFF
--- a/packages/nuxt/src/imports/presets.ts
+++ b/packages/nuxt/src/imports/presets.ts
@@ -278,6 +278,7 @@ const vueTypesPreset = defineUnimportPreset({
     'Ref',
     'MaybeRef',
     'MaybeRefOrGetter',
+    'ShallowRef',
     'VNode',
     'WritableComputedRef',
   ],


### PR DESCRIPTION
### 📚 Description

Adds `ShallowRef` type to the vue preset, so that it is available without having to import it explicitly.