### PR TITLE
fix(nitro): honour `import.meta.test` in server + prefer `define`

### DIFF
--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -22,7 +22,7 @@ import { resolveModulePath } from 'exsolve'
 import { runtimeDependencies } from 'nitro/meta'
 
 import nitroBuilder from '../package.json' with { type: 'json' }
-import { NUXT_BUILD_OUTPUT_MAP, distDir, getLayerNodeModulesExcludePattern, getSsrResolveConditions, toArray } from './utils.ts'
+import { NUXT_BUILD_OUTPUT_MAP, distDir, getLayerNodeModulesExcludePattern, getServerReplacements, getSsrResolveConditions, toArray } from './utils.ts'
 import { setupNitroViteEnvironment } from './vite.ts'
 import { setupLegacyDevAndBuild } from './legacy.ts'
 import { LOOPBACK_HOSTS, isLocalDevRequest, isLoopbackPeer } from './dev-request.ts'
@@ -337,9 +337,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
       // Paths
       '#internal/nuxt/paths': resolve(distDir, 'runtime/utils/paths'),
     },
-    replace: {
-      '__VUE_PROD_DEVTOOLS__': String(false),
-    },
+    replace: nuxt.options.experimental.nitroViteEnvironment ? {} : getServerReplacements(nuxt),
     rollupConfig: {
       output: {
         generatedCode: {

--- a/packages/nitro-server/src/templates.ts
+++ b/packages/nitro-server/src/templates.ts
@@ -24,6 +24,9 @@ import type { LogObject } from 'consola'
 import type { NuxtIslandContext, NuxtIslandResponse, NuxtRenderChunkContext, NuxtRenderCloseContext, NuxtRenderHTMLContext, NuxtRenderRouteContext } from '#app/types'
 
 declare module 'nitro/types' {
+  interface NitroImportMeta {
+    test?: boolean
+  }
   interface NitroRuntimeConfigApp {
     baseURL: string
     buildAssetsDir: string

--- a/packages/nitro-server/src/utils.ts
+++ b/packages/nitro-server/src/utils.ts
@@ -1,7 +1,17 @@
 import { fileURLToPath } from 'node:url'
 import { dirname } from 'pathe'
 import escapeRE from 'escape-string-regexp'
-import type { NuxtBuildOutputs } from '@nuxt/schema'
+import type { Nuxt, NuxtBuildOutputs } from '@nuxt/schema'
+
+/**
+ * Compile-time constants the server bundle needs which Nitro does not inject itself.
+ */
+export function getServerReplacements (nuxt: Nuxt): Record<string, string> {
+  return {
+    '__VUE_PROD_DEVTOOLS__': String(false),
+    'import.meta.test': String(!!nuxt.options.test),
+  }
+}
 
 export function toArray<T> (value: T | T[]): T[] {
   return Array.isArray(value) ? value : [value]

--- a/packages/nitro-server/src/vite.ts
+++ b/packages/nitro-server/src/vite.ts
@@ -14,7 +14,7 @@ import remapping from '@ampproject/remapping'
 import type { Nitro } from 'nitro/types'
 import type { Nuxt, NuxtBuildOutputs } from '@nuxt/schema'
 
-import { NUXT_BUILD_OUTPUT_MAP, distDir } from './utils.ts'
+import { NUXT_BUILD_OUTPUT_MAP, distDir, getServerReplacements } from './utils.ts'
 
 const IS_CSS_RE = /\.(?:css|scss|sass|postcss|pcss|less|stylus|styl)(?:\?[^.]+)?$/
 
@@ -86,6 +86,7 @@ function collectDevCss (nuxt: Nuxt, moduleGraph: EnvironmentModuleGraph): string
 export function setupNitroViteEnvironment (nuxt: Nuxt & { _nitro?: Nitro }, nitro: Nitro): void {
   addVitePlugin(NuxtBuildOutputsPlugin(nuxt))
   addVitePlugin(NitroVirtualBridge(nitro))
+  addVitePlugin(NitroDefinePlugin(nuxt))
 
   // `nitro/vite` calls `build:before` before it derives its bundler config,
   // which is where the legacy path calls `nitro:build:before`: consumers use it
@@ -407,6 +408,23 @@ function DevClientCssPlugin (nuxt: Nuxt): VitePlugin {
         if (this.environment.name === 'ssr' && IS_CSS_RE.test(id)) { push?.() }
       },
     },
+  }
+}
+
+/**
+ * Apply the server-only compile-time constants to the `nitro` environment as
+ * `define`, so they are substituted in dev as well as in a build.
+ */
+function NitroDefinePlugin (nuxt: Nuxt): VitePlugin {
+  return {
+    name: 'nuxt:nitro-define',
+    config: () => ({
+      environments: {
+        nitro: {
+          define: getServerReplacements(nuxt),
+        },
+      },
+    }),
   }
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

we type this as present, so we should ensure we replace it. we also prefer using vite's `define` if we're using the nitro vite builder