### PR TITLE
fix(nuxt): listen to `link:prefetch` hook before onNuxtReady

### DIFF
--- a/packages/nuxt/src/app/plugins/payload.client.ts
+++ b/packages/nuxt/src/app/plugins/payload.client.ts
@@ -52,10 +52,10 @@ const plugin: Plugin & ObjectPlugin = defineNuxtPlugin({
       }
     })
 
-    onNuxtReady(() => {
-      // Load payload into cache
-      const head = prefetchPreloadTags ? injectHead(nuxtApp) : null
-      nuxtApp.hooks.hook('link:prefetch', async (url) => {
+    // Load payload into cache
+    const head = prefetchPreloadTags ? injectHead(nuxtApp) : null
+    nuxtApp.hooks.hook('link:prefetch', (url) => {
+      onNuxtReady(async () => {
         const { hostname, pathname } = new URL(url, window.location.href)
         if (hostname !== window.location.hostname) { return }
         // TODO: use preloadPayload instead once we can support preloading islands too
@@ -73,6 +73,9 @@ const plugin: Plugin & ObjectPlugin = defineNuxtPlugin({
           forwardedPrefetchEntries.set(pathname, entry)
         }
       })
+    })
+
+    onNuxtReady(() => {
       // `navigator.connection` (Network Information API) is widely supported in
       // browsers but not part of the standard TS DOM lib.
       if (isAppManifestEnabled && (navigator as Navigator & { connection?: { effectiveType?: string } }).connection?.effectiveType !== 'slow-2g') {

--- a/test/nuxt/components.test.ts
+++ b/test/nuxt/components.test.ts
@@ -1,12 +1,53 @@
 /// <reference path="../fixtures/basic/.nuxt/nuxt.d.ts" />
 
 import { describe, expect, it, vi } from 'vitest'
+import { createHooks } from 'hookable'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { flushPromises } from '@vue/test-utils'
 
 import { nuxtLinkDefaults } from '#build/nuxt.config.mjs'
+import type { RuntimeNuxtHooks } from '#app/nuxt'
+import * as payload from '#app/composables/payload'
+import payloadPlugin from '#app/plugins/payload.client'
 
 describe('nuxt-link:prefetch', () => {
+  it('should prefetch a link payload after hydration when interacted with during hydration', async () => {
+    const component = defineNuxtLink(nuxtLinkDefaults)
+    const wrapper = await mountSuspended(component, { props: { to: '/to', prefetchOn: 'interaction' } })
+    const nuxtApp = useNuxtApp()
+    const router = useRouter()
+    const originalHooks = nuxtApp.hooks
+    const isHydrating = nuxtApp.isHydrating
+    const loadPayload = vi.spyOn(payload, 'loadPayload').mockResolvedValue({ data: {} })
+    const beforeResolve = vi.spyOn(router, 'beforeResolve').mockReturnValue(() => {})
+    const afterEach = vi.spyOn(router, 'afterEach').mockReturnValue(() => {})
+
+    vi.useFakeTimers()
+    nuxtApp.hooks = createHooks<RuntimeNuxtHooks>()
+    nuxtApp.isHydrating = true
+
+    try {
+      await nuxtApp.runWithContext(() => payloadPlugin.setup!(nuxtApp))
+      await wrapper.find('a').trigger('pointerenter')
+
+      expect(loadPayload).not.toHaveBeenCalled()
+
+      nuxtApp.isHydrating = false
+      await nuxtApp.hooks.callHook('app:suspense:resolve')
+
+      expect(loadPayload).toHaveBeenCalledExactlyOnceWith('/to')
+    } finally {
+      wrapper.unmount()
+      nuxtApp.hooks = originalHooks
+      nuxtApp.isHydrating = isHydrating
+      loadPayload.mockRestore()
+      beforeResolve.mockRestore()
+      afterEach.mockRestore()
+      vi.clearAllTimers()
+      vi.useRealTimers()
+    }
+  })
+
   it('should prefetch on visibility by default', async () => {
     const component = defineNuxtLink(nuxtLinkDefaults)
 


### PR DESCRIPTION
### 📚 Description

Current behavior makes the custom NuxtLink components to call the `link:prefetch` hook during mounting process (on hydration) being called before `onNuxtReady`, making the hooks ignored.

This PR solves this behavior by listening to hooks beforehand but keep the prefetching after nuxt is fully hydrated.