### PR TITLE
feat(nuxt,kit,schema,nitro,vite-server): add `nuxt/server`

### DIFF
--- a/docs/1.getting-started/13.server.md
+++ b/docs/1.getting-started/13.server.md
@@ -29,7 +29,7 @@ You can easily manage the server-only part of your Nuxt app, from API endpoints 
 Both endpoints and middleware can be defined like this:
 
 ```ts twoslash [server/api/test.ts]
-import { defineEventHandler } from 'nitro/h3'
+import { defineEventHandler } from 'nuxt/server'
 
 export default defineEventHandler(async (event) => {
   // ... Do whatever you want here

--- a/docs/1.getting-started/18.upgrade.md
+++ b/docs/1.getting-started/18.upgrade.md
@@ -353,6 +353,49 @@ Most of the migration is handled by Nuxt internally, but there are some user-fac
 See the full Vite 8 migration guide for all breaking changes and migration steps.
 ::
 
+### Server Imports Move to `nuxt/server`
+
+🚦 **Impact Level**: Medium
+
+#### What Changed
+
+Nuxt 5 ships `nuxt/server`, an import surface for the server utilities server code reaches for most: `defineEventHandler`, `createError`, `getQuery`, `readBody`, the cookie and header helpers, `sendRedirect`, `getRouteRules` and `useRuntimeConfig`. It replaces `@nuxt/nitro-server/h3`, which is deprecated.
+
+Which server runtime is under your application depends on the configured [`server.builder`](/docs/4.x/guide/going-further/builders), and importing from `nitro/h3` pins your code to one of them and to its major version. `nuxt/server` does not, so one file can serve Nuxt 4.6 (running either `nitropack` v2 or Nitro v3) and Nuxt 5.
+
+```diff [server/api/hello.ts]
+- import { defineEventHandler, getQuery } from 'nitro/h3'
++ import { defineEventHandler, getQuery } from 'nuxt/server'
+
+  export default defineEventHandler((event) => {
+    return getQuery(event)
+  })
+```
+
+Errors take the same shape as the ones the Vue part of your app constructs, and come from the same place:
+
+```diff
+- import { HTTPError } from 'nitro/h3'
++ import { createError } from 'nuxt/server'
+
+  export default defineEventHandler(() => {
+-   throw new HTTPError({ status: 400, statusText: 'Bad request' })
++   throw createError({ status: 400, statusText: 'Bad request' })
+  })
+```
+
+Server auto-imports resolve to `nuxt/server` too, so a project that leaves them on needs no change.
+
+#### Migration Steps
+
+1. Replace `nitro/h3` and `@nuxt/nitro-server/h3` imports with `nuxt/server`, for the utilities in [the surface](/docs/4.x/guide/going-further/server-imports#the-surface).
+2. Leave the rest on `nitro/h3`. `nuxt/server` is not a re-export of h3, so helpers such as `readValidatedBody` and `handleCors` stay where they are.
+3. Nothing you reach off `event` has to change: under the default Nitro builder it is still h3's `H3Event`.
+
+::read-more{to="/docs/4.x/guide/going-further/server-imports"}
+Learn what the surface covers, and what it means for module authors.
+::
+
 ### Migration to Nitro v3
 
 🚦 **Impact Level**: Significant
@@ -410,10 +453,10 @@ Route rules are augmented on a different module again. See [Route Rule Types Mov
 
 Nitro v3 removed its auto-import support, so utilities such as `defineEventHandler`, `getQuery`, `readBody` and `useRuntimeConfig` are no longer global in server code. Nuxt still provides them, but in Nuxt 5 they are off by default.
 
-Add explicit imports to your server code:
+Add explicit imports to your server code. Prefer [`nuxt/server`](/docs/4.x/guide/going-further/server-imports), which is what the auto-imports resolve to:
 
 ```diff [server/api/hello.ts]
-+ import { defineEventHandler, getQuery } from 'nitro/h3'
++ import { defineEventHandler, getQuery } from 'nuxt/server'
 +
   export default defineEventHandler((event) => {
     return getQuery(event)

--- a/docs/2.directory-structure/1.modules.md
+++ b/docs/2.directory-structure/1.modules.md
@@ -43,7 +43,7 @@ export default defineNuxtModule({
 ```
 
 ```ts twoslash [modules/hello/runtime/api-route.ts]
-import { defineEventHandler } from 'nitro/h3'
+import { defineEventHandler } from 'nuxt/server'
 
 export default defineEventHandler(() => {
   return { hello: 'world' }

--- a/docs/2.directory-structure/1.server.md
+++ b/docs/2.directory-structure/1.server.md
@@ -28,7 +28,7 @@ Do not import Vue app code (components, composables, or other app-only utilities
 :read-more{to="/docs/4.x/directory-structure/shared#why-you-cannot-mix-vue-and-nitro-code" title="Why You Cannot Mix Vue and Nitro Code"}
 
 ```ts twoslash [server/api/hello.ts]
-import { defineEventHandler } from 'nitro/h3'
+import { defineEventHandler } from 'nuxt/server'
 
 export default defineEventHandler((event) => {
   return {
@@ -36,6 +36,10 @@ export default defineEventHandler((event) => {
   }
 })
 ```
+
+::read-more{to="/docs/4.x/guide/going-further/server-imports"}
+`nuxt/server` is the import surface for server utilities, and what the server auto-imports resolve to. It is not tied to a particular h3 or Nitro version.
+::
 
 You can now universally call this API in your pages and components:
 
@@ -177,7 +181,7 @@ export interface Todo {
 ```
 
 ```ts [server/api/todos.get.ts]
-import { defineEventHandler } from 'nitro/h3'
+import { defineEventHandler } from 'nuxt/server'
 
 export default defineEventHandler((): Todo[] => {
   return []

--- a/docs/3.guide/6.going-further/5.server-imports.md
+++ b/docs/3.guide/6.going-further/5.server-imports.md
@@ -1,0 +1,88 @@
+---
+title: "Server Imports"
+description: "`nuxt/server` is the import surface for server code that is not tied to a particular server runtime."
+links:
+  - label: Source
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/server/index.ts
+---
+
+Nuxt has two runtime surfaces. `nuxt/app` (also reachable as `#app`) is the Vue part of your application, and `nuxt/server` is the server part. h3, Nitro and srvx sit underneath both, and which of them is in use depends on the configured [`server.builder`](/docs/4.x/guide/going-further/builders).
+
+Server code written against `nuxt/server` does not have to know which:
+
+```ts [server/api/hello.ts]
+import { defineEventHandler, getQuery } from 'nuxt/server'
+
+export default defineEventHandler((event) => {
+  const { name } = getQuery<{ name?: string }>(event)
+  return { message: `Hello, ${name ?? 'world'}!` }
+})
+```
+
+The same file runs under `@nuxt/nitro-server` and under `@nuxt/vite-server`, and keeps running across an h3 or Nitro major, because Nuxt absorbs those changes centrally.
+
+::note
+`nuxt` is installed in every Nuxt application, so `nuxt/server` resolves with no alias and no added dependency. A module importing from it needs no peer dependency on h3 or Nitro.
+::
+
+## The Surface
+
+| Import | Purpose |
+|---|---|
+| `defineEventHandler` | Define a request handler. |
+| `createError`, `isNuxtError` | Construct and recognise an HTTP error. |
+| `getRequestURL` | The URL of the request. |
+| `getRequestHeader`, `getRequestHeaders` | Read request headers. |
+| `getQuery` | Read the query string. |
+| `readBody` | Read and parse the request body. |
+| `getCookie`, `setCookie`, `deleteCookie` | Read and write cookies. |
+| `setResponseStatus` | Set the response status and reason phrase. |
+| `setResponseHeader`, `setResponseHeaders` | Set response headers. |
+| `sendRedirect` | Redirect the request. |
+| `getRouteRules` | The [route rules](/docs/4.x/guide/concepts/rendering#route-rules) matched for the request. |
+| `useRuntimeConfig` | The server's [runtime configuration](/docs/4.x/guide/going-further/runtime-config). |
+
+The types to write against it are exported alongside: `RequestEvent`, `AppRouteRules`, `ServerRoutes`, `NuxtError`, `NuxtErrorDetails`, `NuxtErrorJSON` and `NuxtErrorLike`.
+
+`defineEventHandler` preserves your handler's return type, which is what types [`$fetch` and `useFetch`](/docs/4.x/getting-started/data-fetching) calls to the route, so annotate the value you return rather than the handler.
+
+These names are [auto-imported](/docs/4.x/directory-structure/server) in server code, so the import statement above is optional. Writing it keeps the file working in a project with server auto-imports off.
+
+## Reaching Past the Surface
+
+`nuxt/server` is not a re-export of h3. Everything else h3 and Nitro offer stays with them: `readValidatedBody`, `proxyRequest`, `getRequestIP`, `handleCors`, sessions, caching, storage, tasks and WebSockets, along with the server lifecycle itself (`definePlugin`, `defineErrorHandler` and the Nitro app hooks). Importing those pins the file to the server runtime it imported them from.
+
+```ts [server/api/upload.post.ts]
+import { defineEventHandler } from 'nuxt/server'
+import { readValidatedBody } from 'nitro/h3'
+
+export default defineEventHandler(async (event) => {
+  const body = await readValidatedBody(event, schema)
+  return { received: body }
+})
+```
+
+Mixing the two costs nothing under the default Nitro builder, where the event `nuxt/server` hands you is h3's `H3Event`: `event.node`, `event.context` and every h3 helper are available on the same value. The event type is resolved rather than erased, so your editor shows what the configured builder provides.
+
+## Server Code Only
+
+Importing `nuxt/server` from a Vue component, a plugin or the `shared/` directory fails the build, with a diagnostic pointing at `$fetch` and `useFetch`. Its types still resolve in those contexts, which is what lets `$fetch` know what your server routes return.
+
+## Modules
+
+A module whose runtime code imports only from `nuxt/server` runs under any server builder, on any Nuxt version shipping the surface, with no version check and no dependency on h3 or Nitro:
+
+```ts [runtime/server/api/status.ts]
+import { defineEventHandler, useRuntimeConfig } from 'nuxt/server'
+
+export default defineEventHandler(() => ({
+  version: useRuntimeConfig().myModule.version,
+}))
+```
+
+Leave `nuxt/server` external when you bundle. The consuming application's server build resolves it, to that application's server runtime.
+
+::read-more{to="/docs/4.x/guide/going-further/builders"}
+Learn how a server builder supplies the implementations behind `nuxt/server`.
+::

--- a/docs/3.guide/6.going-further/8.builders.md
+++ b/docs/3.guide/6.going-further/8.builders.md
@@ -337,10 +337,60 @@ it needs from the granular `nuxt/internal/renderer/*` subpaths instead: pulling 
 entry shares produces a chunk cycle, which some bundlers resolve into a broken entry namespace.
 ::
 
+### Backing the Portable Server Surface
+
+One of the modules in the record is `nuxt/server`, the [portable server
+surface](/docs/4.x/guide/going-further/server-imports) that application and module server code
+imports. Its types come from the `nuxt` package; its implementations come from the running server
+runtime.
+
+A builder that registers the record resolves it already, to the web-standard implementations Nuxt
+ships. Those are written over the `RequestEvent` shape a builder contributes no event type for, and
+are what `@nuxt/vite-server` runs on.
+
+A builder whose runtime can do better names its own module on the build description:
+
+```ts
+import { setServerBuild } from '@nuxt/kit/internal'
+
+setServerBuild({
+  runtime: {
+    runtimeConfig: 'my-server/runtime-config',
+    server: 'my-server/runtime/nuxt-server',
+  },
+})
+```
+
+Every name `nuxt/server` exports must be exported from that module. The types come from the `nuxt`
+package whichever module backs it, so a name left out is a runtime error in somebody's handler rather
+than a type error in your builder. For the parts you have nothing to add to, re-export from
+`nuxt/internal/server-default`: inside your bundle, `nuxt/server` resolves to your own module.
+
+`runtime.runtimeConfig` backs the shipped `useRuntimeConfig`, and is read whether or not you
+replace the surface.
+
+### The Handler a Deploy Target Imports
+
+A target that runs the build itself, in a worker or on a platform that hands it a `Request`,
+imports one specifier: a module exporting `fetch`. A server builder that emits one names it as
+`runtime.handler`, once the build producing it has run.
+
+```ts
+setServerBuild({
+  runtime: {
+    runtimeConfig: 'my-server/runtime-config',
+    handler: resolve(outputDir, 'server/index.mjs'),
+  },
+})
+```
+
+Leave it unset if your output is not importable as a module. `@nuxt/nitro-server` does, because what
+a Nitro output exports depends on its preset.
+
 ::warning
-`getServerRuntime()`, `serverBuild.input`, the `nuxt/internal/*` modules, and the renderer helpers in
-`@nuxt/kit/internal` are experimental, and will change without a major release while a second server
-builder is being built out.
+`getServerRuntime()`, `serverBuild.input`, `serverBuild.runtime`, the `nuxt/internal/*` modules, and
+the renderer helpers in `@nuxt/kit/internal` are experimental, and will change without a major
+release while a second server builder is being built out.
 ::
 
 ::read-more{to="/docs/4.x/guide/going-further/internals"}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -217,7 +217,7 @@ export default createConfigForNuxt({
     },
     {
       files: ['packages/*/src/**'],
-      ignores: ['packages/nuxt/src/app/**', '**/runtime/**/*'],
+      ignores: ['packages/nuxt/src/app/**', 'packages/nuxt/src/server/**', '**/runtime/**/*'],
       name: 'local/import-extensions',
       plugins: {
         'import-x': importX,

--- a/packages/kit/src/internal/renderer.ts
+++ b/packages/kit/src/internal/renderer.ts
@@ -1,6 +1,9 @@
+import { resolveModulePath } from 'exsolve'
 import type { Nuxt, NuxtBuildOutputs } from '@nuxt/schema'
 
 import { useNuxt } from '../context.ts'
+import { directoryToURL } from './esm.ts'
+import { useServerBuild } from './server-build.ts'
 
 // This surface is experimental for as long as `NuxtServerBuild` is, and will change without
 // a major release until it has settled.
@@ -10,6 +13,12 @@ const RENDERER_CONFIG_SPECIFIER = 'nuxt/internal/renderer-config'
 
 /** Specifier a server builder imports `createNuxtRenderer` from. */
 const RENDERER_SPECIFIER = 'nuxt/internal/renderer'
+
+/** The portable server surface, whose implementations the configured server builder supplies. */
+const SERVER_SPECIFIER = 'nuxt/server'
+
+/** Specifier the shipped `nuxt/server` implementations read runtime configuration from. */
+const SERVER_RUNTIME_CONFIG_SPECIFIER = 'nuxt/internal/server-runtime-config'
 
 /** The specifier the renderer imports each build artifact through, and the {@link NuxtBuildOutputs} key that provides it. */
 const BUILD_OUTPUT_SPECIFIERS: Record<string, keyof NuxtBuildOutputs> = {
@@ -149,6 +158,23 @@ export function getRendererDefines (phase: 'server' | 'prerender', nuxt: Nuxt = 
 }
 
 /**
+ * The module backing `nuxt/server` in the server bundle: the one the configured server
+ * builder supplies, or the web-standard implementations Nuxt ships.
+ *
+ * The default is resolved to a file rather than left as `nuxt/server`, which the bundle
+ * resolves to the module being generated here.
+ */
+function getServerSurfaceModule (nuxt: Nuxt): string {
+  const delegate = useServerBuild(nuxt).runtime.server
+  if (delegate) {
+    return delegate
+  }
+  return resolveModulePath('nuxt/server', {
+    from: [...(nuxt.options.modulesDir || []).filter(Boolean).map(dir => directoryToURL(dir)), import.meta.url],
+  })
+}
+
+/**
  * Version of the server runtime contract, bumped whenever a server builder has to do
  * something different with what {@link getServerRuntime} hands it. A builder compares it
  * against the version it was written for, so a mismatch is a build-time error rather than
@@ -224,6 +250,9 @@ export function getServerRuntime (options: ServerRuntimeOptions = {}, nuxt: Nuxt
     const output = BUILD_OUTPUT_SPECIFIERS[specifier]!
     modules[specifier] = { output, code: () => nuxt.buildOutputs[output]() }
   }
+
+  modules[SERVER_SPECIFIER] = { code: () => `export * from ${JSON.stringify(getServerSurfaceModule(nuxt))}` }
+  modules[SERVER_RUNTIME_CONFIG_SPECIFIER] = { code: () => `export { useRuntimeConfig } from ${JSON.stringify(useServerBuild(nuxt).runtime.runtimeConfig)}` }
 
   return {
     version: SERVER_RUNTIME_VERSION,

--- a/packages/kit/test/renderer.test.ts
+++ b/packages/kit/test/renderer.test.ts
@@ -1,8 +1,16 @@
 import { readFileSync, readdirSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 import type { Nuxt } from '@nuxt/schema'
+import type { NuxtServerBuildRuntime } from '@nuxt/schema/internal'
 
 import { SERVER_RUNTIME_VERSION, getRendererConfig, getRendererDefines, getServerRuntime } from '../src/internal/renderer.ts'
+import { createServerBuild } from '../src/internal/server-build.ts'
+
+function withServerRuntime (instance: Nuxt, runtime: Partial<NuxtServerBuildRuntime>): Nuxt {
+  instance.serverBuild = createServerBuild(instance.options)
+  Object.assign(instance.serverBuild.runtime, runtime)
+  return instance
+}
 
 function nuxt (options: Record<string, any> = {}): Nuxt {
   const { buildOutputs, ...rest } = options
@@ -97,14 +105,31 @@ describe('getServerRuntime', () => {
 
   it('provides a module for every stub a builder must replace', () => {
     // every module at the root of the server runtime tree is a stub whose real body only
-    // the build knows, so each one must be in the record for a builder to find it
+    // the build knows, so each one must be in the record for a builder to find it. Not
+    // `server-default`, which is how a builder reaches the shipped `nuxt/server` bodies.
     const stubs = readdirSync(runtimeDir, { withFileTypes: true })
-      .filter(entry => entry.isFile() && entry.name.endsWith('.ts'))
+      .filter(entry => entry.isFile() && entry.name.endsWith('.ts') && entry.name !== 'server-default.ts')
       .map(entry => `nuxt/internal/${entry.name.replace(/\.ts$/, '')}`)
 
     const { modules } = getServerRuntime({}, nuxt({ buildOutputs: buildOutputs() }))
 
-    expect(Object.keys(modules).sort()).toEqual(stubs.sort())
+    expect(Object.keys(modules).sort()).toEqual([...stubs, 'nuxt/server'].sort())
+  })
+
+  it('backs `nuxt/server` with the shipped implementations, and with a builder\'s where it supplies them', async () => {
+    const withoutDelegate = nuxt({ buildOutputs: buildOutputs() })
+    const shipped = await getServerRuntime({}, withoutDelegate).modules['nuxt/server']!.code()
+    expect(shipped).toMatch(/^export \* from "\S+server[/\\]index\.ts"$/)
+
+    const withDelegate = withServerRuntime(nuxt({ buildOutputs: buildOutputs() }), { server: '/delegate.mjs' })
+    expect(await getServerRuntime({}, withDelegate).modules['nuxt/server']!.code()).toBe('export * from "/delegate.mjs"')
+  })
+
+  it('reads runtime configuration from the module the server builder provides it in', async () => {
+    const instance = withServerRuntime(nuxt({ buildOutputs: buildOutputs() }), { runtimeConfig: '#my-server/config' })
+
+    expect(await getServerRuntime({}, instance).modules['nuxt/internal/server-runtime-config']!.code())
+      .toBe('export { useRuntimeConfig } from "#my-server/config"')
   })
 
   it('reads each module body lazily, and names the build output backing it', async () => {

--- a/packages/nitro-server/src/h3.ts
+++ b/packages/nitro-server/src/h3.ts
@@ -1,5 +1,10 @@
 /**
  * h3 compatibility layer for Nuxt runtime code.
+ *
+ * @deprecated Removed in Nuxt 5. Import the portable server surface from `nuxt/server`,
+ * which is not tied to an h3 or Nitro major. For the helpers `nuxt/server` does not cover,
+ * import from `nitro/h3` directly and accept that the code is pinned to the h3 major the
+ * configured server builder ships.
  */
 
 // export named re-exports to help rolldown statically link consumers

--- a/packages/nitro-server/src/imports.ts
+++ b/packages/nitro-server/src/imports.ts
@@ -2,13 +2,10 @@ import { resolveModuleExportNames } from '@nuxt/kit/internal'
 
 // TODO: defineRenderHandler and useEvent
 export const v2ImportsPreset = [
+  // `getRouteRules` and `useRuntimeConfig` are auto-imported from `nuxt/server`
   {
     from: 'nitro/app',
-    imports: ['useNitroApp', 'getRouteRules'],
-  },
-  {
-    from: 'nitro/runtime-config',
-    imports: ['useRuntimeConfig'],
+    imports: ['useNitroApp'],
   },
   {
     from: 'nitro',
@@ -48,12 +45,48 @@ export const v2ImportsPreset = [
   },
 ]
 
+/**
+ * The portable server surface, auto-imported in preference to h3's equivalents, so that
+ * code written without an import statement is code that survives an h3 or Nitro major.
+ *
+ * An explicit list rather than one resolved from the module, because which names are
+ * auto-imported is a compatibility promise and should change deliberately.
+ */
+export const nuxtServerImportsPreset = {
+  from: 'nuxt/server',
+  imports: [
+    'createError',
+    'defineEventHandler',
+    'deleteCookie',
+    'getCookie',
+    'getQuery',
+    'getRequestHeader',
+    'getRequestHeaders',
+    'getRequestURL',
+    'getRouteRules',
+    'isNuxtError',
+    'readBody',
+    'sendRedirect',
+    'setCookie',
+    'setResponseHeader',
+    'setResponseHeaders',
+    'setResponseStatus',
+    'useRuntimeConfig',
+  ],
+}
+
+/**
+ * h3's remaining helpers, for code that reaches past the portable surface. Names
+ * `nuxt/server` provides are dropped, so which module a name resolves to does not depend
+ * on the order the presets are applied in.
+ */
 export async function getH3ImportsPreset () {
   const h3Exports = await resolveModuleExportNames('nitro/h3', {
     url: import.meta.url,
   })
+  const portable = new Set(nuxtServerImportsPreset.imports)
   return {
     from: 'nitro/h3',
-    imports: h3Exports.filter(n => !/^[A-Z]/.test(n) && n !== 'use'),
+    imports: h3Exports.filter(n => !/^[A-Z]/.test(n) && n !== 'use' && !portable.has(n)),
   }
 }

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -33,7 +33,7 @@ import { compileRouterToString } from 'rou3/compiler'
 import { createImportProtectionPatterns } from '../../nuxt/src/core/plugins/import-protection.ts'
 import { createNormalizedRouteRulesRouter, normalizeRouteRulePath } from '../../nuxt/src/core/utils/route-rules.ts'
 import { nitroSchemaTemplate } from './templates.ts'
-import { getH3ImportsPreset, v2ImportsPreset } from './imports.ts'
+import { getH3ImportsPreset, nuxtServerImportsPreset, v2ImportsPreset } from './imports.ts'
 import { createServerAutoImports, resolveServerImportDirs } from './auto-imports.ts'
 import { normalizeLegacyRouteRules } from './route-rules.ts'
 import type { ServerImportsOptions } from './auto-imports.ts'
@@ -151,7 +151,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
   const typesDir = nuxt.options.typesDir || nuxt.options.buildDir
 
   const autoImportPresets = nuxt.options.experimental.nitroAutoImports
-    ? [...v2ImportsPreset, await getH3ImportsPreset()]
+    ? [nuxtServerImportsPreset, ...v2ImportsPreset, await getH3ImportsPreset()]
     : []
 
   const serverRuntime = getServerRuntime({
@@ -765,7 +765,11 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     capabilities: { server: true, dev: true },
     buildsSeparately: !nuxt.options.experimental.nitroViteEnvironment,
     imports: () => autoImports.getImports(),
-    runtime: { fetch: 'nitro', runtimeConfig: 'nitro/runtime-config' },
+    runtime: {
+      fetch: 'nitro',
+      runtimeConfig: 'nitro/runtime-config',
+      server: resolve(distDir, 'runtime/server'),
+    },
     preview: { command: () => nitro.options.commands.preview },
   }, nuxt)
   await nuxt.callHook('nitro:init', nitro)

--- a/packages/nitro-server/src/runtime/server.ts
+++ b/packages/nitro-server/src/runtime/server.ts
@@ -1,0 +1,37 @@
+/**
+ * The `nuxt/server` implementations for a Nitro-backed build, registered as
+ * `serverBuild.runtime.server`.
+ *
+ * Only the helpers h3 does more with than the platform alone can are taken from it:
+ * resolving the request URL through forwarded headers, merging `Set-Cookie` against the
+ * headers already queued for the response, negotiating the body against the request the
+ * router matched, and marking a handler so the router can serve it directly. The rest come
+ * from the shipped implementations, which is also what h3 v2's own deprecations point at.
+ *
+ * The types come from `nuxt/server` whichever module backs it, so every name it exports
+ * must be exported here too.
+ */
+export {
+  defineEventHandler,
+  deleteCookie,
+  getCookie,
+  getQuery,
+  getRequestURL,
+  readBody,
+  setCookie,
+} from 'nitro/h3'
+
+export { getRouteRules } from 'nitro/app'
+export { useRuntimeConfig } from 'nitro/runtime-config'
+
+export {
+  createError,
+  getRequestHeader,
+  getRequestHeaders,
+  isNuxtError,
+  NuxtError,
+  sendRedirect,
+  setResponseHeader,
+  setResponseHeaders,
+  setResponseStatus,
+} from 'nuxt/internal/server-default'

--- a/packages/nitro-server/test/auto-imports.test.ts
+++ b/packages/nitro-server/test/auto-imports.test.ts
@@ -3,8 +3,8 @@ import { tmpdir } from 'node:os'
 import { describe, expect, it } from 'vitest'
 import { dirname, isAbsolute, join, resolve } from 'pathe'
 import type { Nuxt } from '@nuxt/schema'
-import { createServerAutoImports } from './auto-imports.ts'
-import { getH3ImportsPreset, v2ImportsPreset } from './imports.ts'
+import { createServerAutoImports } from '../src/auto-imports.ts'
+import { getH3ImportsPreset, nuxtServerImportsPreset, v2ImportsPreset } from '../src/imports.ts'
 
 const TYPE_EXTENSIONS = ['.d.ts', '.d.mts', '.d.cts', '.ts', '.mts', '.js', '.mjs']
 
@@ -40,11 +40,28 @@ describe('createServerAutoImports', () => {
     expect(referenced).toContain('nitro/cache')
   })
 
+  it('auto-imports the portable server surface rather than the runtime it delegates to', async () => {
+    const autoImports = createServerAutoImports(
+      mockNuxt(),
+      { autoImport: true, presets: [nuxtServerImportsPreset, ...v2ImportsPreset, await getH3ImportsPreset()] },
+      mkdtempSync(join(tmpdir(), 'server-auto-imports-')),
+    )
+
+    const imports = await autoImports.getImports()
+    const sourceOf = (name: string) => imports.filter(i => (i.as ?? i.name) === name).map(i => i.from)
+
+    for (const name of ['defineEventHandler', 'createError', 'getQuery', 'readBody', 'getCookie', 'useRuntimeConfig', 'getRouteRules']) {
+      expect(sourceOf(name), name).toEqual(['nuxt/server'])
+    }
+
+    expect(sourceOf('readValidatedBody')).toEqual(['nitro/h3'])
+  })
+
   it('resolves a local type path to a declaration TypeScript can follow', async () => {
     const typesDir = mkdtempSync(join(tmpdir(), 'server-auto-imports-'))
     const autoImports = createServerAutoImports(
       mockNuxt(),
-      { autoImport: true, imports: [{ name: 'withBaseURL', from: resolve(import.meta.dirname, 'runtime/utils/base.ts') }] },
+      { autoImport: true, imports: [{ name: 'withBaseURL', from: resolve(import.meta.dirname, '../src/runtime/utils/base.ts') }] },
       typesDir,
     )
 

--- a/packages/nitro-server/test/server.test.ts
+++ b/packages/nitro-server/test/server.test.ts
@@ -103,4 +103,12 @@ describe('parity between the shipped implementations and h3', () => {
     const { shipped, h3 } = await compare(new Request('https://nuxt.com/api?a=1#hash'), (api, event) => api.getRequestURL(event).href)
     expect(shipped).toEqual(h3)
   })
+
+  it.for([
+    ['an h3 error', () => new h3.HTTPError({ status: 404 })],
+    ['a Nuxt error', () => shipped.createError({ status: 404 })],
+    ['a plain error', () => new Error('oops')],
+  ] as const)('recognises %s the same way h3 does', ([, construct]) => {
+    expect(shipped.isNuxtError(construct())).toBe(h3.HTTPError.isError(construct()))
+  })
 })

--- a/packages/nitro-server/test/server.test.ts
+++ b/packages/nitro-server/test/server.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import { resolve } from 'pathe'
+import { resolveModuleExportNames } from '@nuxt/kit/internal'
+import { H3Event } from 'nitro/h3'
+import * as h3 from 'nitro/h3'
+import * as shipped from 'nuxt/server'
+import type { RequestEvent } from 'nuxt/server'
+
+const delegatePath = resolve(import.meta.dirname, '../src/runtime/server.ts')
+
+describe('the h3-backed `nuxt/server` implementations', () => {
+  it('exports every name the portable surface does', async () => {
+    const [surface, delegate] = await Promise.all([
+      resolveModuleExportNames('nuxt/server', { url: import.meta.url }),
+      resolveModuleExportNames(delegatePath, { url: import.meta.url }),
+    ])
+
+    expect(surface.length).toBeGreaterThan(0)
+    expect(surface.filter(name => !delegate.includes(name))).toEqual([])
+  })
+})
+
+/**
+ * The shipped implementations and h3's have to agree, or a handler behaves differently
+ * depending on which server builder the application configured.
+ */
+describe('parity between the shipped implementations and h3', () => {
+  function events (request: Request) {
+    const fallback = {
+      req: request.clone(),
+      url: new URL(request.url),
+      res: { headers: new Headers() },
+      context: {},
+    } as unknown as RequestEvent
+
+    return { fallback, h3: new H3Event(request) as unknown as RequestEvent }
+  }
+
+  async function compare<T> (request: Request, read: (api: typeof shipped, event: RequestEvent) => T | Promise<T>) {
+    const { fallback, h3: h3Event } = events(request)
+    const settle = async (run: () => T | Promise<T>) => {
+      try {
+        return { value: await run() }
+      } catch (error) {
+        return { error: { status: (error as { status?: number }).status } }
+      }
+    }
+    return {
+      shipped: await settle(() => read(shipped, fallback)),
+      h3: await settle(() => read(h3 as unknown as typeof shipped, h3Event)),
+    }
+  }
+
+  const post = (body: BodyInit, contentType?: string) => new Request('https://nuxt.com/api', {
+    method: 'POST',
+    body,
+    headers: contentType ? { 'content-type': contentType } : undefined,
+  })
+
+  it.for([
+    ['a JSON body', post(JSON.stringify({ name: 'nuxt' }), 'application/json')],
+    ['a JSON body with charset', post(JSON.stringify({ name: 'nuxt' }), 'application/json; charset=utf-8')],
+    ['a suffixed JSON media type', post(JSON.stringify({ ok: true }), 'application/problem+json; charset=utf-8')],
+    ['a JSON body with no content type', post(JSON.stringify({ name: 'nuxt' }))],
+    ['a URL-encoded body', post('name=nuxt&tag=a&tag=b', 'application/x-www-form-urlencoded')],
+    ['an empty body', post('', 'application/json')],
+    ['a body that is not JSON', post('not json', 'text/plain')],
+  ] as const)('reads %s the same way', async ([, request]) => {
+    const { shipped, h3 } = await compare(request, (api, event) => api.readBody(event))
+    expect(shipped).toEqual(h3)
+  })
+
+  it.for([
+    ['no query', 'https://nuxt.com/api'],
+    ['one parameter', 'https://nuxt.com/api?name=nuxt'],
+    ['a repeated parameter', 'https://nuxt.com/api?tag=a&tag=b'],
+    ['an empty value', 'https://nuxt.com/api?name='],
+  ] as const)('reads %s the same way', async ([, url]) => {
+    const { shipped, h3 } = await compare(new Request(url), (api, event) => api.getQuery(event))
+    expect(shipped).toEqual(h3)
+  })
+
+  it('reads cookies the same way', async () => {
+    const request = new Request('https://nuxt.com/api', { headers: { cookie: 'a=1; b=2' } })
+    const { shipped, h3 } = await compare(request, (api, event) => [api.getCookie(event, 'a'), api.getCookie(event, 'missing')])
+    expect(shipped).toEqual(h3)
+  })
+
+  it.for([
+    ['a cookie', (api: typeof shipped, event: RequestEvent) => api.setCookie(event, 'a', '1')],
+    ['a cookie with options', (api: typeof shipped, event: RequestEvent) => api.setCookie(event, 'a', '1', { httpOnly: true, path: '/admin' })],
+    ['an expired cookie', (api: typeof shipped, event: RequestEvent) => api.deleteCookie(event, 'a')],
+    ['an expired cookie with a path', (api: typeof shipped, event: RequestEvent) => api.deleteCookie(event, 'a', { path: '/admin' })],
+  ] as const)('writes %s the same way', ([, write]) => {
+    const { fallback, h3: h3Event } = events(new Request('https://nuxt.com/api'))
+    write(shipped, fallback)
+    write(h3 as unknown as typeof shipped, h3Event)
+
+    expect(fallback.res.headers.getSetCookie()).toEqual(h3Event.res.headers.getSetCookie())
+  })
+
+  it('reads the request URL the same way', async () => {
+    const { shipped, h3 } = await compare(new Request('https://nuxt.com/api?a=1#hash'), (api, event) => api.getRequestURL(event).href)
+    expect(shipped).toEqual(h3)
+  })
+})

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -29,12 +29,16 @@
     "./kit": "./kit.js",
     "./meta": "./meta.js",
     "./app": "./src/app/index.ts",
+    "./server": "./src/server/index.ts",
     "./internal/renderer": "./src/runtime/server/renderer/index.ts",
     "./internal/*": "./src/runtime/server/*.ts",
     "./package.json": "./package.json"
   },
   "typesVersions": {
     "*": {
+      "server": [
+        "./dist/server/index.d.ts"
+      ],
       "internal/renderer": [
         "./dist/runtime/server/renderer/index.d.ts"
       ],
@@ -177,6 +181,7 @@
       "./kit": "./kit.js",
       "./meta": "./meta.js",
       "./app": "./dist/app/index.js",
+      "./server": "./dist/server/index.js",
       "./internal/renderer": "./dist/runtime/server/renderer/index.js",
       "./internal/*": "./dist/runtime/server/*.js",
       "./package.json": "./package.json"

--- a/packages/nuxt/src/app/composables/error.ts
+++ b/packages/nuxt/src/app/composables/error.ts
@@ -2,13 +2,14 @@ import { toRef } from 'vue'
 import type { Ref } from 'vue'
 import { useNuxtApp } from '../nuxt'
 import type { NuxtApp, NuxtPayload } from '../nuxt'
-import type { NuxtErrorJSON, NuxtError as _NuxtErrorContract } from '../types'
 import { isBotUserAgent } from '../utils'
-import { sanitizeStatusCode, sanitizeStatusMessage } from '../utils/http-status'
 import { useRouter } from './router'
 import { appDiagnostics } from '../diagnostics/core'
+import { NUXT_ERROR_SIGNATURE, NuxtError, createError, isNuxtError } from '../error'
+import type { NuxtErrorDetails } from '../error'
 
-export const NUXT_ERROR_SIGNATURE = '__nuxt_error' as const
+export { NUXT_ERROR_SIGNATURE, NuxtError, createError, isNuxtError }
+export type { NuxtErrorDetails }
 
 /** @since 3.0.0 */
 /* @__NO_SIDE_EFFECTS__ */
@@ -80,108 +81,4 @@ export const clearError = async (options: { redirect?: string } = {}): Promise<v
       el.remove()
     }
   }
-}
-
-/** @since 3.0.0 */
-export const isNuxtError = <DataT = unknown>(error: unknown): error is NuxtError<DataT> => {
-  return !!error && typeof error === 'object' && NUXT_ERROR_SIGNATURE in error
-}
-
-/**
- * Details accepted when constructing a {@link NuxtError}.
- *
- * @since 5.0.0
- */
-export type NuxtErrorDetails<DataT = unknown> = Partial<Omit<NuxtError<DataT>, 'headers' | 'name' | 'toJSON'>> & {
-  /** @deprecated use `status` */
-  statusCode?: number
-  /** @deprecated use `statusText` */
-  statusMessage?: string
-  headers?: HeadersInit
-}
-
-export class NuxtError<DataT = unknown> extends Error implements _NuxtErrorContract<DataT> {
-  readonly [NUXT_ERROR_SIGNATURE] = true as const
-
-  /**
-   * h3 recognises its own errors by constructor name rather than `instanceof`,
-   * so errors thrown during SSR are only mapped to the right HTTP response if
-   * `name` stays `HTTPError`.
-   */
-  override get name (): string {
-    return 'HTTPError'
-  }
-
-  /** HTTP status code in range [100...599] */
-  readonly status: number
-  /** HTTP status text (reason phrase) */
-  readonly statusText: string | undefined
-  /** Additional HTTP headers to be sent with the error response. */
-  readonly headers: Headers | undefined
-  /** Additional data attached to the error JSON body under `data`. */
-  readonly data: DataT | undefined
-  /** Additional top-level properties to attach to the error JSON body. */
-  readonly body: Record<string, unknown> | undefined
-  /** Whether the error was not handled by the application. */
-  readonly unhandled: boolean | undefined
-  readonly fatal: boolean
-  override readonly cause: unknown
-
-  constructor (message: string | NuxtErrorDetails<DataT> = '', opts: NuxtErrorDetails<DataT> = {}) {
-    const details = (typeof message === 'string' ? opts : message) || {}
-    const cause = details.cause as NuxtErrorDetails<DataT> | undefined
-
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const status = sanitizeStatusCode(details.status || details.statusCode || cause?.status || cause?.statusCode, 500)
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const statusText = sanitizeStatusMessage(details.statusText || details.statusMessage || cause?.statusText || cause?.statusMessage)
-
-    super(
-      (typeof message === 'string' ? message : '') ||
-      // eslint-disable-next-line @typescript-eslint/no-deprecated
-      details.message || cause?.message || details.statusText || details.statusMessage ||
-      ['HTTPError', status, statusText].filter(Boolean).join(' '),
-      { cause: details },
-    )
-
-    this.status = status
-    this.statusText = statusText || undefined
-    const headers = details.headers || cause?.headers
-    this.headers = headers ? new Headers(headers) : undefined
-    this.unhandled = details.unhandled ?? cause?.unhandled ?? undefined
-    this.data = details.data
-    this.body = details.body
-    this.cause = details instanceof Error ? details : details.cause
-    this.fatal = details.fatal ?? !!this.unhandled
-  }
-
-  /** @deprecated use `status` */
-  get statusCode (): number {
-    return this.status
-  }
-
-  /** @deprecated use `statusText` */
-  get statusMessage (): string | undefined {
-    return this.statusText
-  }
-
-  toJSON (): NuxtErrorJSON {
-    const unhandled = this.unhandled
-    return {
-      status: this.status,
-      statusText: this.statusText,
-      unhandled,
-      message: unhandled ? 'HTTPError' : this.message,
-      data: unhandled ? undefined : this.data,
-      ...unhandled ? undefined : this.body,
-    }
-  }
-}
-
-/** @since 3.0.0 */
-export const createError = <DataT = unknown>(error: string | Error | NuxtErrorDetails<DataT>): NuxtError<DataT> => {
-  if (isNuxtError<DataT>(error)) { return error }
-  return typeof error === 'string'
-    ? new NuxtError<DataT>(error)
-    : new NuxtError<DataT>(error.message ?? '', error as NuxtErrorDetails<DataT>)
 }

--- a/packages/nuxt/src/app/error.ts
+++ b/packages/nuxt/src/app/error.ts
@@ -1,0 +1,125 @@
+import type { NuxtErrorJSON, NuxtError as _NuxtErrorContract } from './types'
+import { sanitizeStatusCode, sanitizeStatusMessage } from './utils/http-status'
+
+export const NUXT_ERROR_SIGNATURE = '__nuxt_error' as const
+
+/**
+ * Details accepted when constructing a {@link NuxtError}.
+ *
+ * @since 5.0.0
+ */
+export type NuxtErrorDetails<DataT = unknown> = Partial<Omit<NuxtError<DataT>, 'headers' | 'name' | 'toJSON'>> & {
+  /** @deprecated use `status` */
+  statusCode?: number
+  /** @deprecated use `statusText` */
+  statusMessage?: string
+  headers?: HeadersInit
+}
+
+export class NuxtError<DataT = unknown> extends Error implements _NuxtErrorContract<DataT> {
+  readonly [NUXT_ERROR_SIGNATURE] = true as const
+
+  /**
+   * h3 recognises its own errors by constructor name rather than `instanceof`,
+   * so errors thrown during SSR are only mapped to the right HTTP response if
+   * `name` stays `HTTPError`.
+   */
+  override get name (): string {
+    return 'HTTPError'
+  }
+
+  /** HTTP status code in range [100...599] */
+  readonly status: number
+  /** HTTP status text (reason phrase) */
+  readonly statusText: string | undefined
+  /** Additional HTTP headers to be sent with the error response. */
+  readonly headers: Headers | undefined
+  /** Additional data attached to the error JSON body under `data`. */
+  readonly data: DataT | undefined
+  /** Additional top-level properties to attach to the error JSON body. */
+  readonly body: Record<string, unknown> | undefined
+  /** Whether the error was not handled by the application. */
+  readonly unhandled: boolean | undefined
+  readonly fatal: boolean
+  override readonly cause: unknown
+
+  constructor (message: string | NuxtErrorDetails<DataT> = '', opts: NuxtErrorDetails<DataT> = {}) {
+    const details = (typeof message === 'string' ? opts : message) || {}
+    const cause = details.cause as NuxtErrorDetails<DataT> | undefined
+
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    const status = sanitizeStatusCode(details.status || details.statusCode || cause?.status || cause?.statusCode, 500)
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    const statusText = sanitizeStatusMessage(details.statusText || details.statusMessage || cause?.statusText || cause?.statusMessage)
+
+    super(
+      (typeof message === 'string' ? message : '') ||
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
+      details.message || cause?.message || details.statusText || details.statusMessage ||
+      ['HTTPError', status, statusText].filter(Boolean).join(' '),
+      { cause: details },
+    )
+
+    this.status = status
+    this.statusText = statusText || undefined
+    const headers = details.headers || cause?.headers
+    this.headers = headers ? new Headers(headers) : undefined
+    this.unhandled = details.unhandled ?? cause?.unhandled ?? undefined
+    this.data = details.data
+    this.body = details.body
+    this.cause = details instanceof Error ? details : details.cause
+    this.fatal = details.fatal ?? !!this.unhandled
+  }
+
+  /** @deprecated use `status` */
+  get statusCode (): number {
+    return this.status
+  }
+
+  /** @deprecated use `statusText` */
+  get statusMessage (): string | undefined {
+    return this.statusText
+  }
+
+  toJSON (): NuxtErrorJSON {
+    const unhandled = this.unhandled
+    return {
+      status: this.status,
+      statusText: this.statusText,
+      unhandled,
+      message: unhandled ? 'HTTPError' : this.message,
+      data: unhandled ? undefined : this.data,
+      ...unhandled ? undefined : this.body,
+    }
+  }
+}
+
+/** @since 3.0.0 */
+export const isNuxtError = <DataT = unknown>(error: unknown): error is NuxtError<DataT> => {
+  return !!error && typeof error === 'object' && NUXT_ERROR_SIGNATURE in error
+}
+
+/**
+ * Construct an error carrying an HTTP status, to show on the error page or to
+ * throw from a server handler.
+ *
+ * The error reports `HTTPError` as its `name`, which is how h3 and the server
+ * runtime recognise it and map it to the response its `status`, `statusText`,
+ * `headers` and `data` describe. Anything attached to `data` reaches the
+ * client, so only attach what the client may see.
+ *
+ * An error that already carries a status is returned unchanged.
+ *
+ * @example
+ * ```ts
+ * throw createError({ status: 404, statusText: 'Not Found' })
+ * ```
+ *
+ * @since 3.0.0
+ */
+export const createError = <DataT = unknown>(error: string | Error | NuxtErrorDetails<DataT>): NuxtError<DataT> => {
+  if (isNuxtError<DataT>(error)) { return error }
+  return typeof error === 'string'
+    ? new NuxtError<DataT>(error)
+    : new NuxtError<DataT>(error.message ?? '', error as NuxtErrorDetails<DataT>)
+}

--- a/packages/nuxt/src/app/types.ts
+++ b/packages/nuxt/src/app/types.ts
@@ -98,9 +98,9 @@ export interface NuxtServerApp {
 }
 
 /**
- * Type-only declaration of the `NuxtError` class in
- * `./composables/error.ts`, which remains the canonical exported value (and
- * the `NuxtError` type exported from `nuxt/app` / `#app`).
+ * Type-only declaration of the `NuxtError` class in `./error.ts`, which
+ * remains the canonical exported value (and the `NuxtError` type exported
+ * from `nuxt/app` / `#app` and from `nuxt/server`).
  *
  * The members are declared here rather than inherited from h3's `HTTPError`,
  * but must stay structurally compatible with it: that is what h3 and Nitro read

--- a/packages/nuxt/src/core/plugins/import-protection.ts
+++ b/packages/nuxt/src/core/plugins/import-protection.ts
@@ -81,6 +81,13 @@ export function createImportProtectionPatterns (nuxt: { options: NuxtOptions }, 
       `Server aliases are not allowed in ${context}.`,
       ['Use `$fetch()` or `useFetch()` to call server endpoints.', 'Move shared logic to the `shared/` directory.'],
     ])
+    // denied by the build, not by its types: those resolve in every context, which is what
+    // lets the generated server-route typings type `$fetch`
+    patterns.push([
+      /^nuxt\/server$/,
+      `\`nuxt/server\` cannot be imported in ${context}.`,
+      ['Import runtime Nuxt composables from `#app` or `#imports` instead.', 'Use `$fetch()` or `useFetch()` to call server endpoints.'],
+    ])
   }
 
   return patterns

--- a/packages/nuxt/src/runtime/server/server-default.ts
+++ b/packages/nuxt/src/runtime/server/server-default.ts
@@ -1,0 +1,9 @@
+/**
+ * The web-standard implementations backing `nuxt/server`, under a specifier a
+ * server bundle does not redirect.
+ *
+ * A builder that supplies `serverBuild.runtime.server` resolves `nuxt/server`
+ * to its own module, so this is how it reaches the shipped implementations for
+ * the parts it has nothing to add to.
+ */
+export * from '../../server/index'

--- a/packages/nuxt/src/runtime/server/server-runtime-config.ts
+++ b/packages/nuxt/src/runtime/server/server-runtime-config.ts
@@ -1,0 +1,13 @@
+import type { RuntimeConfig } from 'nuxt/schema'
+
+/**
+ * Runtime configuration, the one thing the portable `nuxt/server`
+ * implementations cannot resolve for themselves. The configured
+ * `server.builder` replaces this module with a re-export of
+ * `serverBuild.runtime.runtimeConfig`.
+ *
+ * The body below describes a bundle that did not replace it.
+ */
+export function useRuntimeConfig (): RuntimeConfig {
+  return { app: {}, public: {} } as unknown as RuntimeConfig
+}

--- a/packages/nuxt/src/server/index.ts
+++ b/packages/nuxt/src/server/index.ts
@@ -1,0 +1,299 @@
+/**
+ * The portable server surface, typed against {@link RequestEvent}: the event
+ * type the configured `server.builder` contributes. Code written against it
+ * runs unchanged on any Nuxt server builder, and across an h3 or Nitro major.
+ *
+ * The implementations here are web-standard, over the
+ * {@link RequestEventFallback} shape. A server builder whose runtime can do
+ * better replaces this module in its own bundle.
+ *
+ * For anything not exported here, import from the server runtime itself
+ * (`nitro`, `nitro/h3`), and accept that the code is pinned to it.
+ *
+ * @module nuxt/server
+ */
+import { parse, serialize } from 'cookie-es'
+import type { CookieSerializeOptions } from 'cookie-es'
+import { parseQuery } from 'ufo'
+import type { AppRouteRules, RequestEvent, RequestEventFallback, RuntimeConfig } from 'nuxt/schema'
+import { useRuntimeConfig as _useRuntimeConfig } from 'nuxt/internal/server-runtime-config'
+
+import { NUXT_ERROR_SIGNATURE, NuxtError, createError } from '../app/error'
+import type { NuxtError as NuxtErrorContract } from '../app/types'
+
+export type { AppRouteRules, RequestEvent, RequestEventFallback, ServerRoutes } from 'nuxt/schema'
+export type { NuxtErrorDetails } from '../app/error'
+export type { NuxtErrorJSON } from '../app/types'
+
+/**
+ * A request handler, as {@link defineEventHandler} returns it.
+ *
+ * @since 5.0.0
+ */
+export type EventHandler<Result = unknown> = (event: RequestEvent) => Result
+
+/** The web-standard shape every server builder's event is a superset of. */
+function web (event: RequestEvent): RequestEventFallback {
+  return event as unknown as RequestEventFallback
+}
+
+/**
+ * Define a request handler.
+ *
+ * The return type is preserved exactly, and is what types `$fetch` and
+ * `useFetch` calls to the route, so annotate the returned value rather than
+ * the handler.
+ *
+ * @example
+ * ```ts
+ * // server/api/hello.ts
+ * import { defineEventHandler, getQuery } from 'nuxt/server'
+ *
+ * export default defineEventHandler((event) => {
+ *   const { name } = getQuery<{ name?: string }>(event)
+ *   return { message: `Hello, ${name ?? 'world'}!` }
+ * })
+ * ```
+ *
+ * @since 5.0.0
+ */
+export function defineEventHandler<Result> (handler: EventHandler<Result>): EventHandler<Result> {
+  return handler
+}
+
+export { createError, NuxtError }
+
+/**
+ * The shape shared by every HTTP error reachable in server code: the ones
+ * {@link createError} constructs, and the ones the server runtime throws for
+ * itself, which are not `NuxtError`s.
+ *
+ * @since 5.0.0
+ */
+export type NuxtErrorLike<DataT = unknown> = Error
+  & Pick<NuxtErrorContract<DataT>, 'status'>
+  & Partial<Pick<NuxtErrorContract<DataT>, 'statusText' | 'headers' | 'data' | 'unhandled'>>
+
+/**
+ * Whether a caught value is an HTTP error carrying a status.
+ *
+ * The check is structural, because the error may have been constructed by the
+ * server runtime rather than by {@link createError}. h3 identifies its own
+ * errors by `name`, which is why Nuxt's errors report `HTTPError` as theirs.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await load()
+ * } catch (error) {
+ *   if (isNuxtError(error) && error.status === 404) {
+ *     return null
+ *   }
+ *   throw error
+ * }
+ * ```
+ *
+ * @since 5.0.0
+ */
+export function isNuxtError<DataT = unknown> (error: unknown): error is NuxtErrorLike<DataT> {
+  if (!error || typeof error !== 'object') {
+    return false
+  }
+  if (NUXT_ERROR_SIGNATURE in error) {
+    return true
+  }
+  return error instanceof Error && error.name === 'HTTPError' && typeof (error as { status?: unknown }).status === 'number'
+}
+
+/**
+ * The URL of the incoming request.
+ *
+ * @since 5.0.0
+ */
+export function getRequestURL (event: RequestEvent): URL {
+  return web(event).url
+}
+
+/**
+ * Read one request header, or `undefined` when it was not sent.
+ *
+ * Header names are case-insensitive.
+ *
+ * @since 5.0.0
+ */
+export function getRequestHeader (event: RequestEvent, name: string): string | undefined {
+  return web(event).req.headers.get(name) ?? undefined
+}
+
+/**
+ * Read every request header, keyed by lowercased name.
+ *
+ * @since 5.0.0
+ */
+export function getRequestHeaders (event: RequestEvent): Record<string, string> {
+  return Object.fromEntries(web(event).req.headers)
+}
+
+/**
+ * Set the status, and optionally the reason phrase, of the response.
+ *
+ * @since 5.0.0
+ */
+export function setResponseStatus (event: RequestEvent, status: number, statusText?: string): void {
+  const res = web(event).res
+  res.status = status
+  if (statusText !== undefined) {
+    res.statusText = statusText
+  }
+}
+
+/**
+ * Set one response header, replacing any value already set for it.
+ *
+ * @since 5.0.0
+ */
+export function setResponseHeader (event: RequestEvent, name: string, value: string): void {
+  web(event).res.headers.set(name, value)
+}
+
+/**
+ * Set several response headers, replacing any values already set for them.
+ *
+ * @since 5.0.0
+ */
+export function setResponseHeaders (event: RequestEvent, headers: Record<string, string>): void {
+  const target = web(event).res.headers
+  for (const name in headers) {
+    target.set(name, headers[name]!)
+  }
+}
+
+/**
+ * Read the query string of the request. A repeated parameter resolves to an
+ * array, so a type parameter should account for that.
+ *
+ * @since 5.0.0
+ */
+export function getQuery<T extends Record<string, unknown> = Record<string, string | string[]>> (event: RequestEvent): T {
+  return parseQuery(web(event).url.search) as T
+}
+
+/**
+ * Read and parse the request body, once per request.
+ *
+ * A URL-encoded body is parsed into an object of its fields, with a repeated
+ * field collected into an array. Anything else is parsed as JSON, and a body
+ * that is not valid JSON is a `400`. An empty body reads as `undefined`.
+ *
+ * The type parameter is an assertion: validate the result with a schema when
+ * it comes from a client.
+ *
+ * @since 5.0.0
+ */
+export async function readBody<T = unknown> (event: RequestEvent): Promise<T> {
+  const request = web(event).req
+  const contentType = request.headers.get('content-type') || ''
+  const text = await request.text()
+
+  if (!text) {
+    return undefined as T
+  }
+
+  if (contentType.startsWith('application/x-www-form-urlencoded')) {
+    return collectEntries(new URLSearchParams(text).entries()) as T
+  }
+
+  try {
+    return JSON.parse(text) as T
+  } catch {
+    throw createError({ status: 400, statusText: 'Bad Request', message: 'Invalid JSON body' })
+  }
+}
+
+/** Collect repeated keys into an array, as a form body's fields are read. */
+function collectEntries (entries: Iterable<[string, string]>): Record<string, string | string[]> {
+  const parsed: Record<string, string | string[]> = Object.create(null)
+  for (const [key, value] of entries) {
+    const existing = parsed[key]
+    if (existing === undefined) {
+      parsed[key] = value
+    } else if (Array.isArray(existing)) {
+      existing.push(value)
+    } else {
+      parsed[key] = [existing, value]
+    }
+  }
+  return parsed
+}
+
+/**
+ * Read one cookie sent with the request, or `undefined` when it was not sent.
+ *
+ * @since 5.0.0
+ */
+export function getCookie (event: RequestEvent, name: string): string | undefined {
+  const header = web(event).req.headers.get('cookie')
+  return header ? parse(header)[name] : undefined
+}
+
+/**
+ * Set a cookie on the response. Each call appends its own `Set-Cookie`
+ * header, so several cookies may be set for one response.
+ *
+ * @since 5.0.0
+ */
+export function setCookie (event: RequestEvent, name: string, value: string, options?: CookieSerializeOptions): void {
+  web(event).res.headers.append('set-cookie', serialize(name, value, { path: '/', ...options }))
+}
+
+/**
+ * Expire a cookie on the response. The `path` and `domain` must match those
+ * it was set with, or the original cookie survives alongside the expired one.
+ *
+ * @since 5.0.0
+ */
+export function deleteCookie (event: RequestEvent, name: string, options?: CookieSerializeOptions): void {
+  setCookie(event, name, '', { ...options, maxAge: 0 })
+}
+
+/**
+ * Redirect the request, returning the body to respond with: a
+ * `<meta http-equiv="refresh">`, so a client that ignores the status still
+ * follows the redirect.
+ *
+ * @example
+ * ```ts
+ * export default defineEventHandler(event => sendRedirect(event, '/login', 302))
+ * ```
+ *
+ * @since 5.0.0
+ */
+export function sendRedirect (event: RequestEvent, location: string, status = 302): string {
+  setResponseStatus(event, status)
+  setResponseHeader(event, 'location', location)
+  setResponseHeader(event, 'content-type', 'text/html')
+  const encoded = location.replace(REDIRECT_UNSAFE_RE, char => REDIRECT_ESCAPES[char]!)
+  return `<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=${encoded}"></head></html>`
+}
+
+const REDIRECT_ESCAPES: Record<string, string> = { '"': '%22', '\'': '%27', '<': '%3C', '>': '%3E', '&': '%26' }
+const REDIRECT_UNSAFE_RE = /["'<>&]/g
+
+/**
+ * The route rules matched for the request. A server builder without a
+ * route-rule matcher resolves none, so treat every rule as optional.
+ *
+ * @since 5.0.0
+ */
+export function getRouteRules (_event: RequestEvent): AppRouteRules {
+  return {}
+}
+
+/**
+ * The runtime configuration, including the keys only the server can read.
+ *
+ * @since 5.0.0
+ */
+export function useRuntimeConfig (): RuntimeConfig {
+  return _useRuntimeConfig() as RuntimeConfig
+}

--- a/packages/nuxt/src/server/index.ts
+++ b/packages/nuxt/src/server/index.ts
@@ -96,13 +96,11 @@ export type NuxtErrorLike<DataT = unknown> = Error
  * @since 5.0.0
  */
 export function isNuxtError<DataT = unknown> (error: unknown): error is NuxtErrorLike<DataT> {
-  if (!error || typeof error !== 'object') {
+  const candidate = error as { status?: unknown, [NUXT_ERROR_SIGNATURE]?: unknown } | null | undefined
+  if (!(error instanceof Error) || typeof candidate?.status !== 'number') {
     return false
   }
-  if (NUXT_ERROR_SIGNATURE in error) {
-    return true
-  }
-  return error instanceof Error && error.name === 'HTTPError' && typeof (error as { status?: unknown }).status === 'number'
+  return candidate[NUXT_ERROR_SIGNATURE] === true || error.name === 'HTTPError'
 }
 
 /**

--- a/packages/nuxt/test/import-protection.test.ts
+++ b/packages/nuxt/test/import-protection.test.ts
@@ -34,6 +34,8 @@ const testsToTriggerOn = [
   ['nitro/types', 'components/Component.vue', false],
   ['nitro', 'components/Component.vue', false],
   ['node_modules/some-pkg/server/api/helper.ts', 'components/Component.vue', false],
+  ['nuxt/server', 'components/Component.vue', true],
+  ['nuxt/app', 'components/Component.vue', false],
 ] as const
 
 describe('import protection', () => {
@@ -46,9 +48,19 @@ describe('import protection', () => {
       expect(result).toContain('impound:proxy')
     }
   })
+
+  it('should deny `nuxt/server` in app and shared code, and allow it on the server', async () => {
+    for (const context of ['nuxt-app', 'shared'] as const) {
+      const errors: string[] = []
+      await transformWithImportProtection('nuxt/server', 'components/Component.vue', context, errors)
+      expect(errors.join('\n'), context).toContain('`nuxt/server` cannot be imported in')
+    }
+
+    expect(await transformWithImportProtection('nuxt/server', 'server/api/hello.ts', 'nitro-app')).toBeFalsy()
+  })
 })
 
-const transformWithImportProtection = (id: string, importer: string, context: 'nitro-app' | 'nuxt-app' | 'shared') => {
+const transformWithImportProtection = (id: string, importer: string, context: 'nitro-app' | 'nuxt-app' | 'shared', errors: string[] = []) => {
   const plugin = ImpoundPlugin.rollup({
     cwd: '/root',
     patterns: createImportProtectionPatterns({
@@ -64,5 +76,5 @@ const transformWithImportProtection = (id: string, importer: string, context: 'n
     }, { context }),
   })
 
-  return (plugin as any).resolveId.call({ error: () => {} }, id, importer)
+  return (plugin as any).resolveId.call({ error: (error: unknown) => { errors.push(String((error as { message?: string })?.message ?? error)) } }, id, importer)
 }

--- a/packages/nuxt/test/modules-fixture/modules/runtime/handler.ts
+++ b/packages/nuxt/test/modules-fixture/modules/runtime/handler.ts
@@ -1,3 +1,3 @@
-import { defineEventHandler } from 'h3'
+import { defineEventHandler } from 'nuxt/server'
 
 export default defineEventHandler(() => 'handler added by auto-registered module')

--- a/packages/nuxt/test/modules-fixture/modules/runtime/late-handler.ts
+++ b/packages/nuxt/test/modules-fixture/modules/runtime/late-handler.ts
@@ -1,3 +1,3 @@
-import { defineEventHandler } from 'h3'
+import { defineEventHandler } from 'nuxt/server'
 
 export default defineEventHandler(() => 'handler added from nitro:config hook')

--- a/packages/nuxt/test/server-surface.test.ts
+++ b/packages/nuxt/test/server-surface.test.ts
@@ -191,11 +191,18 @@ describe('errors', () => {
     expect(isNuxtError(new HTTPError('teapot'))).toBe(true)
   })
 
-  it('rejects anything that is not an HTTP error', () => {
+  it('rejects anything that does not carry the shape it narrows to', () => {
     expect(isNuxtError(new Error('oops'))).toBe(false)
-    expect(isNuxtError({ status: 404 })).toBe(false)
     expect(isNuxtError(undefined)).toBe(false)
     expect(isNuxtError('oops')).toBe(false)
+    // marked, but not an `Error`, so `message` and `stack` are not there to read
+    expect(isNuxtError({ __nuxt_error: true, status: 404 })).toBe(false)
+    expect(isNuxtError({ status: 404 })).toBe(false)
+    // marked, but with no status to branch on
+    expect(isNuxtError(Object.assign(new Error('oops'), { __nuxt_error: true }))).toBe(false)
+    expect(isNuxtError(Object.assign(new Error('oops'), { __nuxt_error: true, status: '404' }))).toBe(false)
+    // the marker is only a marker when it is set
+    expect(isNuxtError(Object.assign(new Error('oops'), { __nuxt_error: false, status: 404 }))).toBe(false)
   })
 
   it('narrows to the shape both its own and the runtime\'s errors have', () => {

--- a/packages/nuxt/test/server-surface.test.ts
+++ b/packages/nuxt/test/server-surface.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import type { RequestEventFallback } from 'nuxt/schema'
+
+import {
+  createError,
+  defineEventHandler,
+  deleteCookie,
+  getCookie,
+  getQuery,
+  getRequestHeader,
+  getRequestHeaders,
+  getRequestURL,
+  isNuxtError,
+  readBody,
+  sendRedirect,
+  setCookie,
+  setResponseHeader,
+  setResponseHeaders,
+  setResponseStatus,
+} from '../src/server/index'
+import type { NuxtErrorLike, RequestEvent } from '../src/server/index'
+
+function event (request: Request): RequestEvent {
+  return {
+    req: request,
+    url: new URL(request.url),
+    res: { headers: new Headers() },
+    context: {},
+  } as unknown as RequestEvent
+}
+
+function response (event: RequestEvent) {
+  return (event as unknown as RequestEventFallback).res
+}
+
+describe('`defineEventHandler`', () => {
+  it('preserves the return type, which the generated route typings read', () => {
+    const handler = defineEventHandler(() => ({ hello: 'world' }))
+    expectTypeOf(handler).returns.toEqualTypeOf<{ hello: string }>()
+  })
+
+  it('contextually types the event it hands the handler', () => {
+    defineEventHandler((event) => {
+      expectTypeOf(event).toEqualTypeOf<RequestEvent>()
+      return null
+    })
+  })
+})
+
+describe('request', () => {
+  it('reads the request URL', () => {
+    expect(getRequestURL(event(new Request('https://nuxt.com/api/hello?a=1'))).pathname).toBe('/api/hello')
+  })
+
+  it('reads a request header case-insensitively, or `undefined`', () => {
+    const e = event(new Request('https://nuxt.com/', { headers: { 'X-Custom': 'value' } }))
+    expect(getRequestHeader(e, 'x-custom')).toBe('value')
+    expect(getRequestHeader(e, 'X-Custom')).toBe('value')
+    expect(getRequestHeader(e, 'x-missing')).toBeUndefined()
+  })
+
+  it('reads every request header, keyed by lowercased name', () => {
+    const e = event(new Request('https://nuxt.com/', { headers: { 'X-Custom': 'value' } }))
+    expect(getRequestHeaders(e)).toMatchObject({ 'x-custom': 'value' })
+  })
+
+  it('parses the query, resolving a repeated parameter to an array', () => {
+    const e = event(new Request('https://nuxt.com/?name=nuxt&tag=a&tag=b'))
+    expect(getQuery(e)).toEqual({ name: 'nuxt', tag: ['a', 'b'] })
+  })
+})
+
+describe('`readBody`', () => {
+  function post (body: BodyInit, contentType?: string) {
+    return event(new Request('https://nuxt.com/', {
+      method: 'POST',
+      body,
+      headers: contentType ? { 'content-type': contentType } : undefined,
+    }))
+  }
+
+  it.for([
+    ['application/json'],
+    ['application/json; charset=utf-8'],
+    ['application/merge-patch+json'],
+    ['application/problem+json; charset=utf-8'],
+    // h3 parses an unrecognised type as JSON rather than sniffing it
+    ['text/plain'],
+    ['application/jsonp'],
+    [undefined],
+  ] as const)('parses a JSON body sent as %s', async ([contentType]) => {
+    await expect(readBody(post(JSON.stringify({ name: 'nuxt' }), contentType))).resolves.toEqual({ name: 'nuxt' })
+  })
+
+  it('parses a URL-encoded body into its fields, collecting a repeated field', async () => {
+    const body = 'name=nuxt&tag=a&tag=b'
+    await expect(readBody(post(body, 'application/x-www-form-urlencoded'))).resolves.toEqual({ name: 'nuxt', tag: ['a', 'b'] })
+    await expect(readBody(post(body, 'application/x-www-form-urlencoded; charset=utf-8'))).resolves.toEqual({ name: 'nuxt', tag: ['a', 'b'] })
+  })
+
+  it('reads an empty body as undefined', async () => {
+    await expect(readBody(post('', 'application/json'))).resolves.toBeUndefined()
+  })
+
+  it('rejects a body that is not valid JSON with a 400', async () => {
+    await expect(readBody(post('not json', 'text/plain'))).rejects.toMatchObject({ status: 400, statusText: 'Bad Request' })
+  })
+})
+
+describe('response', () => {
+  it('sets the status and reason phrase', () => {
+    const e = event(new Request('https://nuxt.com/'))
+    setResponseStatus(e, 201)
+    expect(response(e).status).toBe(201)
+    expect(response(e).statusText).toBeUndefined()
+
+    setResponseStatus(e, 418, 'Teapot')
+    expect(response(e)).toMatchObject({ status: 418, statusText: 'Teapot' })
+  })
+
+  it('replaces a header already set', () => {
+    const e = event(new Request('https://nuxt.com/'))
+    setResponseHeader(e, 'x-custom', 'first')
+    setResponseHeader(e, 'x-custom', 'second')
+    setResponseHeaders(e, { 'x-other': 'value' })
+    expect(response(e).headers.get('x-custom')).toBe('second')
+    expect(response(e).headers.get('x-other')).toBe('value')
+  })
+})
+
+describe('cookies', () => {
+  it('reads a cookie sent with the request, or `undefined`', () => {
+    const e = event(new Request('https://nuxt.com/', { headers: { cookie: 'a=1; b=2' } }))
+    expect(getCookie(e, 'b')).toBe('2')
+    expect(getCookie(e, 'c')).toBeUndefined()
+  })
+
+  it('reads no cookie from a request that sent none', () => {
+    expect(getCookie(event(new Request('https://nuxt.com/')), 'a')).toBeUndefined()
+  })
+
+  it('sets several cookies on one response', () => {
+    const e = event(new Request('https://nuxt.com/'))
+    setCookie(e, 'a', '1')
+    setCookie(e, 'b', '2', { httpOnly: true })
+    expect(response(e).headers.getSetCookie()).toEqual(['a=1; Path=/', 'b=2; Path=/; HttpOnly'])
+  })
+
+  it('expires a cookie for the path and domain it was set with', () => {
+    const e = event(new Request('https://nuxt.com/'))
+    deleteCookie(e, 'a', { path: '/admin' })
+    expect(response(e).headers.getSetCookie()).toEqual(['a=; Max-Age=0; Path=/admin'])
+  })
+})
+
+describe('`sendRedirect`', () => {
+  it('sets the status and location, and returns a body that follows it', () => {
+    const e = event(new Request('https://nuxt.com/'))
+    expect(sendRedirect(e, '/login')).toContain('url=/login')
+    expect(response(e).status).toBe(302)
+    expect(response(e).headers.get('location')).toBe('/login')
+
+    sendRedirect(e, '/login', 301)
+    expect(response(e).status).toBe(301)
+  })
+
+  it('encodes a location that would otherwise break out of the meta tag', () => {
+    const e = event(new Request('https://nuxt.com/'))
+    const body = sendRedirect(e, '/login?next="><script>alert(1)</script>')
+    expect(body).not.toContain('<script>')
+    expect(response(e).headers.get('location')).toBe('/login?next="><script>alert(1)</script>')
+  })
+})
+
+describe('errors', () => {
+  it('constructs an error the server runtime recognises by name', () => {
+    const error = createError({ status: 404, statusText: 'Not Found' })
+    expect(error.name).toBe('HTTPError')
+    expect(error).toMatchObject({ status: 404, statusText: 'Not Found' })
+  })
+
+  it('recognises its own error', () => {
+    expect(isNuxtError(createError('oops'))).toBe(true)
+  })
+
+  it('recognises an error thrown by the server runtime, which carries no Nuxt signature', () => {
+    class HTTPError extends Error {
+      override get name () { return 'HTTPError' }
+      status = 418
+    }
+    expect(isNuxtError(new HTTPError('teapot'))).toBe(true)
+  })
+
+  it('rejects anything that is not an HTTP error', () => {
+    expect(isNuxtError(new Error('oops'))).toBe(false)
+    expect(isNuxtError({ status: 404 })).toBe(false)
+    expect(isNuxtError(undefined)).toBe(false)
+    expect(isNuxtError('oops')).toBe(false)
+  })
+
+  it('narrows to the shape both its own and the runtime\'s errors have', () => {
+    const error: unknown = createError('oops')
+    if (isNuxtError<{ id: string }>(error)) {
+      expectTypeOf(error).toExtend<NuxtErrorLike<{ id: string }>>()
+      expectTypeOf(error.status).toEqualTypeOf<number>()
+      expectTypeOf(error.data).toEqualTypeOf<{ id: string } | undefined>()
+    }
+  })
+})
+
+describe('the event the surface is typed against', () => {
+  it('is the event the configured server builder contributes, never a particular runtime\'s', () => {
+    expectTypeOf<Parameters<typeof getRequestURL>[0]>().toEqualTypeOf<RequestEvent>()
+    expectTypeOf<Parameters<typeof getCookie>[0]>().toEqualTypeOf<RequestEvent>()
+    expectTypeOf<Parameters<typeof readBody>[0]>().toEqualTypeOf<RequestEvent>()
+  })
+})

--- a/packages/nuxt/tsconfig.build.json
+++ b/packages/nuxt/tsconfig.build.json
@@ -7,6 +7,8 @@
       "#unhead/composables": ["./src/head/runtime/composables"],
       "nuxt/app": ["./src/app/index"],
       "nuxt/app/*": ["./src/app/*"],
+      "nuxt/server": ["./src/server/index"],
+      "nuxt/internal/*": ["./src/runtime/server/*"],
       "#build/nuxt.config.mjs": ["./src/build-stub-nuxt-config.d.ts"],
       "#build/pages": ["./src/build-stub-pages.d.ts"],
       "#build/fetch": ["./src/build-stub-fetch.d.ts"],

--- a/packages/nuxt/tsdown.config.ts
+++ b/packages/nuxt/tsdown.config.ts
@@ -17,6 +17,7 @@ const RUNTIME_TREES = [
   'src/pages/runtime',
   'src/compiler/runtime',
   'src/runtime/server',
+  'src/server',
 ]
 const RUNTIME_ENTRY_GLOBS = RUNTIME_TREES.flatMap(tree => [
   `${tree}/**/*.ts`,

--- a/packages/schema/src/types/nuxt.ts
+++ b/packages/schema/src/types/nuxt.ts
@@ -217,6 +217,22 @@ export interface NuxtServerBuildRuntime {
   fetch?: string
   /** Exports `useRuntimeConfig`. */
   runtimeConfig: string
+  /**
+   * Exports the implementations backing `nuxt/server`, which the server build resolves that
+   * subpath to. Omitted by a runtime with nothing to add to the web-standard implementations
+   * Nuxt ships, which the subpath resolves to otherwise.
+   *
+   * Every value `nuxt/server` exports must be exported here too: the types come from the
+   * `nuxt` package either way, so a missing export is a runtime error, not a type error.
+   */
+  server?: string
+  /**
+   * Exports `fetch`, a web-standard handler serving the built application, for a deploy
+   * target that runs the build in a worker or on a platform that hands it a `Request`. Only
+   * resolvable once the build producing it has run, and omitted by a runtime whose output is
+   * not importable as a module.
+   */
+  handler?: string
 }
 
 /**

--- a/packages/vite-server/src/index.ts
+++ b/packages/vite-server/src/index.ts
@@ -44,6 +44,8 @@ export function bundle (nuxt: Nuxt): Promise<void> {
     runtime: {
       fetch: resolve(distDir, 'runtime/fetch'),
       runtimeConfig: resolve(nuxt.options.buildDir, 'vite-server/runtime-config.mjs'),
+      // the emitted entry, which only exists once a build has run
+      handler: ssr && !nuxt.options.dev ? resolve(outputDir, 'server/index.mjs') : undefined,
     },
     preview: ssr
       ? { command: () => 'node ./server/index.mjs' }

--- a/packages/vite-server/src/runtime/renderer.ts
+++ b/packages/vite-server/src/runtime/renderer.ts
@@ -1,6 +1,7 @@
 import { withQuery } from 'ufo'
 import { createHooks } from 'hookable'
 import { SSR_ERROR_PARAM, encodeSSRError } from 'nuxt/internal/renderer/error'
+import { createError } from 'nuxt/server'
 import type { NuxtRendererOptions, RendererHooks } from 'nuxt/internal/renderer/runtime'
 import { buildAssetsURL, publicAssetsURL } from '#internal/nuxt/paths'
 
@@ -16,23 +17,6 @@ export interface NuxtRenderer {
  * for a module to register one at build time, so a custom server is the one that hooks in.
  */
 export const serverHooks: RendererHooks = createHooks() as unknown as RendererHooks
-
-/** An error carrying the HTTP status the renderer refused a request with. */
-export class NuxtServerError extends Error {
-  status: number
-  statusText: string
-  data: unknown
-  headers?: Record<string, string>
-
-  constructor (init: { status: number, statusText?: string, data?: unknown, headers?: Record<string, string> }) {
-    super(init.statusText || `Request failed with status ${init.status}`)
-    this.name = 'NuxtServerError'
-    this.status = init.status
-    this.statusText = init.statusText || ''
-    this.data = init.data
-    this.headers = init.headers
-  }
-}
 
 /**
  * The capabilities `@nuxt/vite-server` provides to the renderer. Everything comes from the
@@ -54,7 +38,7 @@ export function createRendererOptions (runtimeConfig: NuxtRendererOptions['runti
     getRouteRules: () => ({ ssr: true }),
     hooks: () => serverHooks,
     createResponse: (body, init) => new Response(body, init),
-    createError: init => new NuxtServerError(init),
+    createError: init => createError(init),
   }
 }
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -54,6 +54,34 @@ describe.skipIf(!runsOnceInMatrix)('server api', () => {
     expect(await $fetch('/api/counter')).toEqual({ count: 3 })
   })
 
+  it('should serve a handler written against `nuxt/server`', async () => {
+    const response = await fetch('/api/portable', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'nuxt' }),
+      headers: { 'content-type': 'application/json', 'cookie': 'incoming=here' },
+    })
+
+    expect(response.status).toBe(201)
+    expect(response.headers.get('x-portable')).toBe('yes')
+    expect(response.headers.getSetCookie()).toEqual([
+      'portable=set; Path=/',
+      'stale=; Max-Age=0; Path=/',
+    ])
+    expect(await response.json()).toMatchObject({
+      name: 'nuxt',
+      path: '/api/portable',
+      incoming: 'here',
+      publicKey: 123,
+    })
+  })
+
+  it('should map an error created with `nuxt/server` to its status', async () => {
+    const response = await fetch('/api/portable?fail=yes', { method: 'POST', body: '{}', headers: { 'content-type': 'application/json' } })
+
+    expect(response.status).toBe(418)
+    expect(await response.json()).toMatchObject({ status: 418, statusText: 'Teapot', data: { fail: 'yes' } })
+  })
+
   it('should auto-import', async () => {
     const res = await $fetch('/api/auto-imports')
     expect(res).toMatchInlineSnapshot(`

--- a/test/fixtures/basic-types/app/app-types.ts
+++ b/test/fixtures/basic-types/app/app-types.ts
@@ -88,6 +88,10 @@ describe('API routes', () => {
     expectTypeOf($fetch('/api/hello')).toEqualTypeOf<Promise<string>>()
   })
 
+  it('types the response of a handler written against `nuxt/server`', () => {
+    expectTypeOf($fetch('/api/portable')).toEqualTypeOf<Promise<{ greeting: string }>>()
+  })
+
   it('types responses of routes contributed by augmentation', () => {
     expectTypeOf($fetch('/api/augmented')).toEqualTypeOf<Promise<{ augmented: true }>>()
     expectTypeOf($fetch('/api/augmented', { method: 'GET' })).toEqualTypeOf<Promise<{ augmented: true }>>()

--- a/test/fixtures/basic-types/server/api/portable.ts
+++ b/test/fixtures/basic-types/server/api/portable.ts
@@ -1,0 +1,6 @@
+import { defineEventHandler, getQuery } from 'nuxt/server'
+
+export default defineEventHandler((event) => {
+  const { name } = getQuery<{ name?: string }>(event)
+  return { greeting: `Hello, ${name ?? 'world'}!` }
+})

--- a/test/fixtures/basic-types/server/type-context.ts
+++ b/test/fixtures/basic-types/server/type-context.ts
@@ -1,4 +1,7 @@
 import { expectTypeOf } from 'vitest'
+import type { H3Event } from 'nitro/h3'
+import type { RequestEvent } from 'nuxt/server'
+import { defineEventHandler, getRequestURL, getRouteRules } from 'nuxt/server'
 
 // @ts-expect-error Fromage is 'cheese'
 const _fake: Fromage = 'babybel'
@@ -9,3 +12,15 @@ const appConfig = useAppConfig()
 expectTypeOf(appConfig.fromNuxtConfig).toEqualTypeOf<boolean>()
 expectTypeOf(appConfig.userConfig).toEqualTypeOf<123 | 456 | undefined>()
 expectTypeOf(appConfig.fromLayer).toEqualTypeOf<unknown>()
+
+expectTypeOf<RequestEvent>().toEqualTypeOf<H3Event>()
+
+const portableHandler = defineEventHandler((event) => {
+  expectTypeOf(event).toEqualTypeOf<H3Event>()
+  expectTypeOf(getRequestURL(event)).toEqualTypeOf<URL>()
+  expectTypeOf(getRouteRules(event)).toExtend<{ ssr?: boolean }>()
+
+  return { greeting: 'hello' }
+})
+
+expectTypeOf(portableHandler).returns.toEqualTypeOf<{ greeting: string }>()

--- a/test/fixtures/basic/modules/auto-registered/runtime/handler.ts
+++ b/test/fixtures/basic/modules/auto-registered/runtime/handler.ts
@@ -1,3 +1,3 @@
-import { defineEventHandler } from 'nitro/h3'
+import { defineEventHandler } from 'nuxt/server'
 
 export default defineEventHandler(() => 'handler added by auto-registered module')

--- a/test/fixtures/basic/modules/auto-registered/runtime/late-handler.ts
+++ b/test/fixtures/basic/modules/auto-registered/runtime/late-handler.ts
@@ -1,3 +1,3 @@
-import { defineEventHandler } from 'nitro/h3'
+import { defineEventHandler } from 'nuxt/server'
 
 export default defineEventHandler(() => 'handler added from nitro:config hook')

--- a/test/fixtures/basic/server/api/error.ts
+++ b/test/fixtures/basic/server/api/error.ts
@@ -1,5 +1,5 @@
-import { HTTPError, defineEventHandler } from 'nitro/h3'
+import { createError } from 'nuxt/server'
 
 export default defineEventHandler(() => {
-  throw new HTTPError({ status: 400 })
+  throw createError({ status: 400 })
 })

--- a/test/fixtures/basic/server/api/portable.post.ts
+++ b/test/fixtures/basic/server/api/portable.post.ts
@@ -1,0 +1,23 @@
+import { createError, deleteCookie, getCookie, getQuery, getRequestHeader, getRequestURL, readBody, setCookie, setResponseHeader, setResponseStatus, useRuntimeConfig } from 'nuxt/server'
+
+export default defineEventHandler(async (event) => {
+  const { fail } = getQuery<{ fail?: string }>(event)
+  if (fail) {
+    throw createError({ status: 418, statusText: 'Teapot', data: { fail } })
+  }
+
+  const body = await readBody<{ name?: string }>(event)
+
+  setResponseStatus(event, 201)
+  setResponseHeader(event, 'x-portable', 'yes')
+  setCookie(event, 'portable', 'set')
+  deleteCookie(event, 'stale')
+
+  return {
+    name: body.name ?? null,
+    path: getRequestURL(event).pathname,
+    accept: getRequestHeader(event, 'accept') ?? null,
+    incoming: getCookie(event, 'incoming') ?? null,
+    publicKey: useRuntimeConfig().public.testConfig,
+  }
+})


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

at last!

it was rumoured for years, but now `nuxt/server` exists. the aim is to provide a complement to `nuxt/app`, so users can import server utilities from one, vue/nuxt app utilities from the other

using nitro, these utilities are re-exports of nitro core utils (but in a way that enables us to absorb breaking changes, such as between nitropack v2 -> v3)

there are also some nice side-effects, such as better typing support - we don't have to hoist nitro or h3 types to expose these to users, and we avoid conflicts that might otherwise occur

all these utilies use web apis, and if a user _isn't_ using nitro, they degrade gracefully in a way that's still compatible with vite SSR