### PR TITLE
refactor(nuxt,nitro,schema): collect prerender hints in nuxt context

### DIFF
--- a/packages/nitro-server/src/augments.ts
+++ b/packages/nitro-server/src/augments.ts
@@ -4,7 +4,7 @@ import type { ServerImportsOptions } from './auto-imports.ts'
 import type { EventHandler, H3Event } from 'nitro/h3'
 import type { LogObject } from 'consola'
 import type { NuxtIslandContext, NuxtIslandResponse, NuxtRenderChunkContext, NuxtRenderCloseContext, NuxtRenderHTMLContext, NuxtRenderRouteContext } from '#app/types'
-import type { HookResult, RuntimeConfig, SharedAppConfig, TSReference } from 'nuxt/schema'
+import type { HookResult, NuxtRequestContext, RuntimeConfig, TSReference } from 'nuxt/schema'
 
 /**
  * Per-channel toggles for `tracingChannel`. Extends Nitro's own
@@ -325,22 +325,7 @@ declare module 'nuxt/schema' {
   }
 }
 
-export interface NuxtRequestContext {
-  'appConfig'?: SharedAppConfig
-  'noSSR'?: boolean
-  /** @internal */
-  '~internal'?: boolean
-  /** @internal */
-  '~rendering-error'?: boolean
-  /**
-   * Dev-only: CSS module URLs the builder has loaded for this request, provided
-   * by a dev integration so the SSR renderer can emit the right stylesheet
-   * links / inline styles. @internal
-   */
-  '~devClientCss'?: string[]
-  /** @internal */
-  '~error-cause'?: unknown
-}
+export type { NuxtRequestContext } from 'nuxt/schema'
 
 declare module 'srvx' {
   interface ServerRequestContext {

--- a/packages/nitro-server/src/runtime/handlers/error.ts
+++ b/packages/nitro-server/src/runtime/handlers/error.ts
@@ -7,6 +7,7 @@ import { serverFetch } from 'nitro'
 import type { SSRErrorInput } from '../utils/error'
 import { SSR_ERROR_PARAM, encodeSSRError, isJsonRequest } from '../utils/error'
 import { withBaseURL } from '../utils/base'
+import { applyPrerenderHints } from '../utils/prerender'
 import { generateErrorOverlayHTML } from '../utils/dev'
 
 export default <NitroErrorHandler> async function errorhandler (error, event, { defaultHandler }) {
@@ -17,6 +18,9 @@ export default <NitroErrorHandler> async function errorhandler (error, event, { 
   const status = error.status || 500
   const headers = new Headers(error.headers)
   appendVary(headers, 'accept, sec-fetch-mode')
+  if (import.meta.prerender && 'context' in event) {
+    applyPrerenderHints(event as H3Event, headers)
+  }
   if (isJsonRequest(event) || (status === 404 && defaultRes.status === 302)) {
     const setCookies = new Set(headers.getSetCookie())
     const headerEntries = [

--- a/packages/nitro-server/src/runtime/handlers/island.ts
+++ b/packages/nitro-server/src/runtime/handlers/island.ts
@@ -20,6 +20,7 @@ import { getClientIslandResponse, getServerComponentHTML, getSlotIslandResponse 
 import { isStyleOfModule, patchDevClientCss } from 'nuxt/internal/renderer/dev-css'
 import { urlHash } from 'nuxt/internal/renderer/url'
 import { createEvent } from '../utils/base'
+import { applyIslandPrerenderHints } from '../utils/prerender'
 import { recordDevClientCss } from '../utils/renderer/dev-client-css'
 
 import { rendererInstance } from '../utils/renderer/options'
@@ -81,12 +82,18 @@ export default {
 
       return toResponse(event, await prerenderIsland(event, islandPath))
     } catch (error) {
+      if (import.meta.prerender) {
+        applyIslandPrerenderHints(event)
+      }
       rethrowWithResponseHeaders(event, error)
     }
   },
 }
 
 function toResponse (event: H3Event, result: IslandRenderResult): Response {
+  if (import.meta.prerender) {
+    applyIslandPrerenderHints(event)
+  }
   return 'raw' in result
     ? returnRenderResponse(rendererInstance.options, event, result.raw)
     : new FastResponse(JSON.stringify(result), event.res)

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -4,6 +4,7 @@ import { createNuxtRenderer } from 'nuxt/internal/renderer'
 
 import { NUXT_ASYNC_CONTEXT } from '#internal/nuxt/nitro-config.mjs'
 import { createEvent } from '../utils/base'
+import { applyPrerenderHints } from '../utils/prerender'
 import { rendererInstance } from '../utils/renderer/options'
 
 // Polyfill for unctx (https://github.com/unjs/unctx#native-async-context)
@@ -14,7 +15,12 @@ if (NUXT_ASYNC_CONTEXT && !('AsyncLocalStorage' in globalThis)) {
 const renderer = createNuxtRenderer(rendererInstance)
 
 export default {
-  fetch (request: ServerRequest): Promise<Response> {
-    return renderer.fetch(createEvent(request))
+  async fetch (request: ServerRequest): Promise<Response> {
+    const event = createEvent(request)
+    const response = await renderer.fetch(event)
+    if (import.meta.prerender) {
+      applyPrerenderHints(event, response.headers)
+    }
+    return response
   },
 }

--- a/packages/nitro-server/src/runtime/utils/prerender.ts
+++ b/packages/nitro-server/src/runtime/utils/prerender.ts
@@ -1,0 +1,36 @@
+import type { H3Event } from 'nitro/h3'
+
+/** The header Nitro's prerenderer reads additional routes to crawl from. */
+const NITRO_PRERENDER_HEADER = 'x-nitro-prerender'
+
+/** The header a Nuxt island response carries its own hints on, read by `<NuxtIsland>`. */
+const NUXT_PRERENDER_HEADER = 'x-nuxt-prerender'
+
+function encodeHints (paths: string[]): string {
+  return paths.map(path => encodeURIComponent(path)).join(', ')
+}
+
+/**
+ * Translate the routes collected on the event's Nuxt context into the header Nitro's
+ * prerenderer reads, so that `prerenderRoutes()` and the renderer's own hints reach the
+ * crawler without either of them naming a Nitro header.
+ */
+export function applyPrerenderHints (event: H3Event, headers: Headers = event.res.headers): void {
+  const paths = event.context.nuxt?.prerenderRoutes
+  if (!paths?.length) { return }
+
+  headers.append(NITRO_PRERENDER_HEADER, encodeHints(paths))
+}
+
+/**
+ * Emit the hints collected while rendering an island on the island response, which crosses
+ * HTTP back to the page that embedded it. Nitro only crawls the header of HTML routes, so the
+ * page forwards these onto its own context once it has read them.
+ */
+export function applyIslandPrerenderHints (event: H3Event): void {
+  const paths = event.context.nuxt?.prerenderRoutes
+  if (!paths?.length) { return }
+
+  event.res.headers.append(NUXT_PRERENDER_HEADER, encodeHints(paths))
+  event.res.headers.append(NITRO_PRERENDER_HEADER, encodeHints(paths))
+}

--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -8,7 +8,7 @@ import { joinURL } from 'ufo'
 import type { NuxtAppLiterals, NuxtIslandResponse } from '../types'
 import { useNuxtApp } from '../nuxt'
 import { createError } from '../composables/error'
-import { prerenderRoutes, useRequestEvent, useRequestFetch } from '../composables/ssr'
+import { prerenderRoutes, useRequestFetch } from '../composables/ssr'
 import { injectHead } from '../composables/head'
 import { getFragmentHTML, isEndFragment, isStartFragment } from './utils'
 import { getIslandHash, serializeIslandProps } from '../island-hash'
@@ -108,7 +108,6 @@ const NuxtIsland = defineComponent({
     const serializedProps = computed(() => serializeIslandProps(props.props))
     const hashId = computed(() => getIslandHash({ name: props.name, props: serializedProps.value, context: props.context, source: props.source }))
     const instance = getCurrentInstance()!
-    const event = useRequestEvent()
     const islandFetch = import.meta.server ? useRequestFetch() : $fetch
 
     let activeHead: ActiveHeadEntry<SerializableHead>
@@ -219,7 +218,6 @@ const NuxtIsland = defineComponent({
 
       const url = remoteComponentIslands && props.source ? joinURL(props.source, `/__nuxt_island/${key}.json`) : `/__nuxt_island/${key}.json`
       if (import.meta.server && import.meta.prerender) {
-        // Hint to Nitro to prerender the island component
         nuxtApp.runWithContext(() => prerenderRoutes(url))
       }
       // TODO: Validate response
@@ -241,9 +239,11 @@ const NuxtIsland = defineComponent({
         const result = r._data!
         // TODO: support passing on more headers
         if (import.meta.server && import.meta.prerender) {
-          const hints = r.headers.get('x-nitro-prerender')
+          // the island render is a separate request, so its hints only reach the page that
+          // embedded it over the wire
+          const hints = r.headers.get('x-nuxt-prerender')
           if (hints) {
-            event!.res.headers.append('x-nitro-prerender', hints)
+            nuxtApp.runWithContext(() => prerenderRoutes(hints.split(',').map(hint => decodeURIComponent(hint.trim()))))
           }
         }
         setPayload(key, result)

--- a/packages/nuxt/src/app/components/nuxt-island.ts
+++ b/packages/nuxt/src/app/components/nuxt-island.ts
@@ -232,20 +232,20 @@ const NuxtIsland = defineComponent({
         responseType: 'json',
         ignoreResponseError: true,
       })
+      // the island render is a separate request, so its hints only reach the page that
+      // embedded it over the wire, including when the render failed part-way
+      // TODO: support passing on more headers
+      if (import.meta.server && import.meta.prerender) {
+        const hints = r.headers.get('x-nuxt-prerender')
+        if (hints) {
+          nuxtApp.runWithContext(() => prerenderRoutes(hints.split(',').map(hint => decodeURIComponent(hint.trim()))))
+        }
+      }
       if (!r.ok) {
         throw createError({ status: r.status, statusText: r.statusText })
       }
       try {
         const result = r._data!
-        // TODO: support passing on more headers
-        if (import.meta.server && import.meta.prerender) {
-          // the island render is a separate request, so its hints only reach the page that
-          // embedded it over the wire
-          const hints = r.headers.get('x-nuxt-prerender')
-          if (hints) {
-            nuxtApp.runWithContext(() => prerenderRoutes(hints.split(',').map(hint => decodeURIComponent(hint.trim()))))
-          }
-        }
         setPayload(key, result)
         return result
       } catch (e: any) {

--- a/packages/nuxt/src/app/composables/payload.ts
+++ b/packages/nuxt/src/app/composables/payload.ts
@@ -136,7 +136,6 @@ export function isCachedPayloadRoute (url: string): boolean {
 }
 
 async function _isPrerenderedInManifest (url: string) {
-  // Note: Alternative for server is checking x-nitro-prerender header
   if (!appManifest) {
     return false
   }

--- a/packages/nuxt/src/app/composables/ssr.ts
+++ b/packages/nuxt/src/app/composables/ssr.ts
@@ -158,8 +158,12 @@ export function useResponseHeader (header: string): import('vue').WritableComput
 export function prerenderRoutes (path: string | string[]): void {
   if (!import.meta.server || !import.meta.prerender) { return }
 
-  const paths = toArray(path)
-  useRequestEvent()?.res.headers.append('x-nitro-prerender', paths.map(p => encodeURIComponent(p)).join(', '))
+  const context = useRequestEvent()?.context
+  if (!context) { return }
+
+  const nuxt = context.nuxt ||= {}
+  nuxt.prerenderRoutes ||= []
+  nuxt.prerenderRoutes.push(...toArray(path))
 }
 
 const PREHYDRATE_ATTR_KEY = 'data-prehydrate-id'

--- a/packages/nuxt/src/app/types/augments.ts
+++ b/packages/nuxt/src/app/types/augments.ts
@@ -1,4 +1,5 @@
 /// <reference path="./build-only.d.ts" />
+/// <reference path="../../build-only-server-augments.d.ts" />
 
 import type { UseHeadInput } from '@unhead/vue/types'
 import type { NuxtApp, useNuxtApp } from '../nuxt'

--- a/packages/nuxt/src/app/types/build-only.d.ts
+++ b/packages/nuxt/src/app/types/build-only.d.ts
@@ -1,5 +1,4 @@
 /// <reference path="../../pages/build.d.ts" />
-/// <reference path="../../../../nitro-server/src/augments.ts" />
 
 declare global {
   interface ImportMeta {

--- a/packages/nuxt/src/build-only-server-augments.d.ts
+++ b/packages/nuxt/src/build-only-server-augments.d.ts
@@ -1,0 +1,13 @@
+/**
+ * The declarations of the default server builder, pulled in when this package's own
+ * declarations are emitted: the virtual modules the server runtime generates
+ * (`#internal/nuxt/paths`, ...) and the config keys it contributes to `@nuxt/schema` are
+ * declared there, and Nuxt's sources are compiled against them.
+ *
+ * This is a build-time resolution crutch only: nothing in `src/app` depends on the shapes it
+ * declares, and a project configured with another `server.builder` resolves that builder's
+ * declarations instead.
+ */
+/// <reference path="../../nitro-server/src/augments.ts" />
+
+export {}

--- a/packages/nuxt/src/runtime/server/renderer/index.ts
+++ b/packages/nuxt/src/runtime/server/renderer/index.ts
@@ -27,7 +27,7 @@ import { renderStreamedIslandTeleports, replaceIslandTeleports } from './islands
 import { rendererDiagnostics } from './diagnostics'
 import { warnNoScriptsClientReliance } from './no-scripts'
 import { extractCspNonce } from './csp-nonce'
-import { getRequestState } from './runtime'
+import { addPrerenderRoutes, getRequestState } from './runtime'
 import { createRendererInstance } from './instance'
 import type { NuxtRendererInstance } from './instance'
 import type { NuxtRendererOptions, RendererRouteRules } from './runtime'
@@ -288,8 +288,8 @@ async function renderRoute (instance: NuxtRendererInstance, event: RequestEvent,
   }
 
   if (_PAYLOAD_EXTRACTION && import.meta.prerender) {
-    // Hint nitro to prerender payload for this route
-    event.res.headers.append('x-nitro-prerender', joinURL(ssrContext.url.replace(/\?.*$/, ''), PAYLOAD_FILENAME))
+    // the payload for this route is prerendered alongside it
+    addPrerenderRoutes(event, joinURL(ssrContext.url.replace(/\?.*$/, ''), PAYLOAD_FILENAME))
     // Use same ssr context to generate payload for this route
     await runtime.prerender!.payloadCache.setItem((ssrContext.url === '/' ? '/' : ssrContext.url.replace(/\/$/, '')) + '.json', renderPayloadResponse(ssrContext))
   }

--- a/packages/nuxt/src/runtime/server/renderer/runtime.ts
+++ b/packages/nuxt/src/runtime/server/renderer/runtime.ts
@@ -73,6 +73,8 @@ export interface NuxtRendererOptions {
 /** Per-request Nuxt state the renderer reads from the request event, populated by the server runtime. */
 export interface NuxtRequestState {
   'noSSR'?: boolean
+  /** Routes the render asked the server runtime to prerender as well, as raw paths. */
+  'prerenderRoutes'?: string[]
   /** Set when the runtime re-enters the renderer to render an error page. */
   '~rendering-error'?: boolean
   /** Dev-only: CSS module URLs the builder has loaded for this request. */
@@ -83,4 +85,15 @@ export interface NuxtRequestState {
 
 export function getRequestState (event: RequestEvent): NuxtRequestState | undefined {
   return (event.context as { nuxt?: NuxtRequestState }).nuxt
+}
+
+/**
+ * Ask the server runtime to prerender `paths` alongside the route being rendered. What the
+ * runtime does with them is its own concern; a runtime that does not prerender ignores them.
+ */
+export function addPrerenderRoutes (event: RequestEvent, ...paths: string[]): void {
+  const context = event.context as { nuxt?: NuxtRequestState }
+  const state = context.nuxt ||= {}
+  state.prerenderRoutes ||= []
+  state.prerenderRoutes.push(...paths)
 }

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -16,7 +16,7 @@ export type { ModuleDefinition, ModuleDependencies, ModuleDependencyMeta, Module
 export type { Nuxt, NuxtApp, NuxtBuildOutputs, NuxtPlugin, NuxtPluginTemplate, NuxtTemplate, NuxtTemplateChange, NuxtTemplateDependency, NuxtTypeTemplate, NuxtServerTemplate, ResolvedNuxtTemplate } from './types/nuxt.ts'
 export type { RouterConfig, RouterConfigSerializable, RouterOptions } from './types/router.ts'
 export type { NitroInstance, NitroInstanceFallback, NitroInstanceOptions, NitroInstanceOptionsFallback, NitroTypes } from './types/nitro.ts'
-export type { AppRouteRules, AppRouteRulesBase, AppRouteRulesExtensions, RequestEvent, RequestEventFallback, ServerRequestTypes, ServerRouteHandler, ServerRoutes, ServerRouteSegment, ServerTypes } from './types/server.ts'
+export type { AppRouteRules, AppRouteRulesBase, AppRouteRulesExtensions, NuxtRequestContext, RequestEvent, RequestEventContext, RequestEventFallback, ServerRequestTypes, ServerRouteHandler, ServerRoutes, ServerRouteSegment, ServerTypes } from './types/server.ts'
 export type { ConfigSchema } from './types/schema.ts'
 export type { NuxtDebugContext, NuxtDebugOptions, NuxtDebugModuleMutationRecord } from './types/debug.ts'
 

--- a/packages/schema/src/types/server.ts
+++ b/packages/schema/src/types/server.ts
@@ -1,3 +1,5 @@
+import type { SharedAppConfig } from './config.ts'
+
 /**
  * Extension point through which the configured `server.builder` contributes the type of the
  * request event its runtime hands to the app layer.
@@ -93,6 +95,41 @@ export interface ServerRouteHandler {
 }
 
 /**
+ * Nuxt-owned per-request state, carried on the request event's context under `nuxt`.
+ *
+ * This is the channel the app layer and the SSR renderer use to communicate with the
+ * configured `server.builder`, which is free to translate it into whatever its own runtime
+ * understands (Nitro turns {@link NuxtRequestContext.prerenderRoutes} into the response header
+ * its crawler reads).
+ */
+export interface NuxtRequestContext {
+  'appConfig'?: SharedAppConfig
+  'noSSR'?: boolean
+  /**
+   * Routes to additionally prerender, as raw paths, collected from `prerenderRoutes()` and from
+   * the renderer's own hints while a route is prerendered.
+   */
+  'prerenderRoutes'?: string[]
+  /** @internal */
+  '~internal'?: boolean
+  /** @internal */
+  '~rendering-error'?: boolean
+  /**
+   * Dev-only: CSS module URLs the builder has loaded for this request, provided
+   * by a dev integration so the SSR renderer can emit the right stylesheet
+   * links / inline styles. @internal
+   */
+  '~devClientCss'?: string[]
+  /** @internal */
+  '~error-cause'?: unknown
+}
+
+/** The context of a {@link RequestEventFallback}, which carries Nuxt's own per-request state. */
+export interface RequestEventContext extends Record<string, unknown> {
+  nuxt?: NuxtRequestContext
+}
+
+/**
  * Fallback request event shape, described in web standards only. Used when no server builder
  * has contributed an event type.
  */
@@ -104,7 +141,7 @@ export interface RequestEventFallback {
     statusText?: string
     readonly headers: Headers
   }
-  readonly context: Record<string, unknown>
+  readonly context: RequestEventContext
 }
 
 /**


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this moves us away from the magical `x-nitro-prerender` header, and instead records routes on an array, which we subsequently expose to nitro after already rendering the response