### PR TITLE
feat: add Server-Timing for Nuxt plugins and middleware

### DIFF
--- a/packages/nitro-server/src/augments.ts
+++ b/packages/nitro-server/src/augments.ts
@@ -8,14 +8,15 @@ import type { HookResult, RuntimeConfig, SharedAppConfig, TSReference } from 'nu
 /**
  * Per-channel toggles for `tracingChannel`. Extends Nitro's own
  * {@link TracingOptions} with a `nuxt` key for Nuxt-owned channels
- * (`nuxt.render`, `nuxt.island`, `nuxt.data`, `nuxt.plugin`). Channel names
+ * (`nuxt.render`, `nuxt.island`, `nuxt.data`, `nuxt.plugin`,
+ * `nuxt.middleware`). Channel names
  * follow the [untracing](https://github.com/unjs/untracing) naming convention
  * (`{namespace}.{operation}`).
  *
  * @experimental Channel names, payload shapes, and option keys may change.
  */
 export interface NuxtTracingChannelOptions extends TracingOptions {
-  /** Enable Nuxt-owned channels (`nuxt.render`, `nuxt.island`, `nuxt.data`, `nuxt.plugin`). */
+  /** Enable Nuxt-owned channels (`nuxt.render`, `nuxt.island`, `nuxt.data`, `nuxt.plugin`, `nuxt.middleware`). */
   nuxt?: boolean
 }
 

--- a/packages/nitro-server/src/runtime/handlers/renderer.ts
+++ b/packages/nitro-server/src/runtime/handlers/renderer.ts
@@ -19,7 +19,7 @@ import { relative } from 'pathe'
 import '../context'
 
 import type { NuxtPayload, NuxtRenderHTMLContext, NuxtSSRContext, SerializedErrorCause } from '#app/types'
-import { traceAsync } from '#app/internal/tracing'
+import { appendServerTimingHeader, traceAsync } from '#app/internal/tracing'
 
 import { APP_ROOT_CLOSE_TAG, APP_ROOT_OPEN_TAG, getRenderer, getServerApp } from '../utils/renderer/build-files'
 import { payloadCache, prerenderRenderingURLs } from '../utils/cache'
@@ -151,6 +151,12 @@ async function renderRoute (event: H3Event, ssrError?: (NuxtPayload['error'] & {
   // Initialize ssr context
   const ssrContext: NuxtSSRContext = createSSRContext(event)
 
+  const applyServerTiming = () => {
+    if (tracingChannelNuxt) {
+      appendServerTimingHeader(event.res.headers, ssrContext)
+    }
+  }
+
   ssrContext.head.push(appHead)
 
   if (ssrError) {
@@ -196,6 +202,7 @@ async function renderRoute (event: H3Event, ssrError?: (NuxtPayload['error'] & {
     ssrContext.url = url + payloadURL.search
 
     if (import.meta.prerender && await payloadCache!.hasItem(ssrContext.url + '.json')) {
+      applyServerTiming()
       event.res.headers.set('content-type', 'application/json')
       const response = await payloadCache!.getItem(ssrContext.url + '.json') || undefined
       return new FastResponse(response?.body, response)
@@ -288,6 +295,7 @@ async function renderRoute (event: H3Event, ssrError?: (NuxtPayload['error'] & {
   if (appRenderedResult instanceof Promise) { await appRenderedResult }
 
   if (ssrContext['~renderResponse']) {
+    applyServerTiming()
     return returnRenderResponse(event, ssrContext['~renderResponse'])
   }
 
@@ -303,6 +311,7 @@ async function renderRoute (event: H3Event, ssrError?: (NuxtPayload['error'] & {
       await payloadCache!.setItem(ssrContext.url + '.json', response)
     }
 
+    applyServerTiming()
     return new FastResponse(response.body, response)
   }
 
@@ -473,6 +482,7 @@ async function renderRoute (event: H3Event, ssrError?: (NuxtPayload['error'] & {
 
   event.res.headers.set('content-type', 'text/html;charset=utf-8')
   event.res.headers.set('x-powered-by', 'Nuxt')
+  applyServerTiming()
 
   return new FastResponse(renderHTMLDocument(htmlContext), event.res)
 }
@@ -488,6 +498,11 @@ async function renderStreamedResponse (ctx: {
   payloadURL: string | undefined
 }): Promise<ReadableStream<Uint8Array> | Response> {
   const { event, ssrContext, renderer, routeOptions, ssrError, _PAYLOAD_EXTRACTION, _PAYLOAD_INLINE, payloadURL } = ctx
+  const applyServerTiming = () => {
+    if (tracingChannelNuxt) {
+      appendServerTimingHeader(event.res.headers, ssrContext)
+    }
+  }
   const NO_SCRIPTS = NUXT_NO_SCRIPTS || !!routeOptions?.noScripts
 
   pushNoScriptsHints(ssrContext, NO_SCRIPTS)
@@ -595,6 +610,7 @@ async function renderStreamedResponse (ctx: {
       // Drop any preload `Link` header that targeted the streamed entry - the
       // redirect/response we are about to send does not need them.
       event.res.headers.delete('link')
+      applyServerTiming()
       return returnRenderResponse(event, ssrContext['~renderResponse'])
     }
     const r = ssrContext.nuxt?.hooks.callHook('app:error', error)
@@ -603,6 +619,7 @@ async function renderStreamedResponse (ctx: {
   }
   if (ssrContext['~renderResponse']) {
     event.res.headers.delete('link')
+    applyServerTiming()
     return returnRenderResponse(event, ssrContext['~renderResponse'])
   }
 
@@ -916,6 +933,7 @@ async function renderStreamedResponse (ctx: {
 
   event.res.headers.set('content-type', 'text/html;charset=utf-8')
   event.res.headers.set('x-powered-by', 'Nuxt')
+  applyServerTiming()
 
   return new FastResponse(outputStream, event.res)
 }

--- a/packages/nuxt/src/app/internal/tracing.ts
+++ b/packages/nuxt/src/app/internal/tracing.ts
@@ -7,6 +7,7 @@
  * - `nuxt.island` (per-island `renderToString`)
  * - `nuxt.data` (`useAsyncData` / `useFetch` handler executions)
  * - `nuxt.plugin` (Nuxt app plugin invocations)
+ * - `nuxt.middleware` (Nuxt route middleware invocations during SSR)
  *
  * Channel names follow the [untracing](https://github.com/unjs/untracing)
  * `{namespace}.{operation}` convention.
@@ -23,6 +24,18 @@ type TracingChannel<C> = {
   tracePromise<T> (fn: (...args: any[]) => Promise<T> | T, context: C, ...args: unknown[]): Promise<T>
 }
 
+type ServerTimingMetric = {
+  name: string
+  duration: number
+  description?: string
+}
+
+type ServerTimingCarrier = {
+  ['~serverTiming']?: ServerTimingMetric[]
+}
+
+const TOKEN_RE = /[^\w!#$%&'*+.^`|~-]/g
+
 let _channels: Record<string, TracingChannel<any> | null> | undefined
 
 function getChannel<C> (name: string): TracingChannel<C> | null {
@@ -37,6 +50,33 @@ function getChannel<C> (name: string): TracingChannel<C> | null {
   const channel = dc?.tracingChannel ? (dc.tracingChannel(name) as TracingChannel<C>) : null
   _channels[name] = channel
   return channel
+}
+
+function formatDuration (duration: number) {
+  const value = Math.max(0, duration)
+  const rounded = Math.round(value * 1000) / 1000
+  return Number.isInteger(rounded) ? String(rounded) : String(rounded)
+}
+
+function sanitizeToken (name: string) {
+  const token = name.replace(TOKEN_RE, '-')
+  return token || 'nuxt'
+}
+
+function escapeDescription (description: string) {
+  return description.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+}
+
+function formatMetric (metric: ServerTimingMetric) {
+  if (!Number.isFinite(metric.duration)) {
+    return ''
+  }
+  const name = sanitizeToken(metric.name)
+  const dur = `dur=${formatDuration(metric.duration)}`
+  if (!metric.description) {
+    return `${name};${dur}`
+  }
+  return `${name};${dur};desc="${escapeDescription(metric.description)}"`
 }
 
 /**
@@ -63,4 +103,25 @@ export function traceAsync<T, C> (name: string, context: C, fn: () => Promise<T>
     return fn()
   }
   return channel.tracePromise(fn, context)
+}
+
+export function addServerTimingMetric (carrier: ServerTimingCarrier | undefined, metric: ServerTimingMetric): void {
+  if (!carrier || !Number.isFinite(metric.duration)) {
+    return
+  }
+  ;(carrier['~serverTiming'] ||= []).push(metric)
+}
+
+export function appendServerTimingHeader (headers: Headers, carrier: ServerTimingCarrier | undefined): void {
+  if (!carrier?.['~serverTiming']?.length) {
+    return
+  }
+
+  const serialized = carrier['~serverTiming'].map(formatMetric).filter(Boolean).join(', ')
+  if (!serialized) {
+    return
+  }
+
+  const existing = headers.get('server-timing')
+  headers.set('server-timing', existing ? `${existing}, ${serialized}` : serialized)
 }

--- a/packages/nuxt/src/app/nuxt.ts
+++ b/packages/nuxt/src/app/nuxt.ts
@@ -13,7 +13,7 @@ import type { NuxtPayload, NuxtSSRContext, NuxtServerRuntimeHooks, PluginMeta } 
 import type { RouteMiddleware } from './composables/router'
 import type { AsyncDataExecuteOptions, AsyncDataRequestStatus } from './composables/asyncData'
 import type { NuxtAppManifestMeta } from './composables/manifest'
-import { traceAsync } from './internal/tracing'
+import { addServerTimingMetric, traceAsync } from './internal/tracing'
 import type { LoadingIndicator } from './composables/loading-indicator'
 import type { RouteAnnouncer } from './composables/route-announcer'
 import type { NuxtAnnouncer } from './composables/announcer'
@@ -394,15 +394,31 @@ export function registerPluginHooks (nuxtApp: NuxtApp, plugin: Plugin & ObjectPl
 /** @since 3.0.0 */
 export async function applyPlugin (nuxtApp: NuxtApp, plugin: Plugin & ObjectPlugin<any>): Promise<void> {
   if (typeof plugin === 'function') {
+    const pluginName = plugin._name || plugin.name || 'anonymous'
     const run = () => nuxtApp.runWithContext(() => plugin(nuxtApp))
-    const { provide } = await (import.meta.server && tracingChannelNuxt
-      ? traceAsync(
-          'nuxt.plugin',
-          { plugin: { name: plugin._name, parallel: plugin.parallel, dependsOn: plugin.dependsOn } },
-          run,
-        )
-      : run()
-    ) || {}
+    const start = import.meta.server && tracingChannelNuxt ? globalThis.performance.now() : 0
+
+    let pluginResult: Awaited<ReturnType<typeof run>> | undefined
+    try {
+      pluginResult = await (import.meta.server && tracingChannelNuxt
+        ? traceAsync(
+            'nuxt.plugin',
+            { plugin: { name: plugin._name, parallel: plugin.parallel, dependsOn: plugin.dependsOn } },
+            run,
+          )
+        : run()
+      ) || {}
+    } finally {
+      if (import.meta.server && tracingChannelNuxt) {
+        addServerTimingMetric(nuxtApp.ssrContext, {
+          name: `nuxt.plugin.${pluginName}`,
+          duration: globalThis.performance.now() - start,
+          description: `plugin:${pluginName}`,
+        })
+      }
+    }
+
+    const { provide } = pluginResult || {}
     if (provide && typeof provide === 'object') {
       for (const key in provide) {
         nuxtApp.provide(key, provide[key])

--- a/packages/nuxt/src/app/types.ts
+++ b/packages/nuxt/src/app/types.ts
@@ -198,6 +198,8 @@ export interface NuxtSSRContext extends SSRContext {
   ['~lazyHydratedModules']?: Set<string>
   /** @internal */
   ['~neverHydratedModules']?: Set<string>
+  /** @internal */
+  ['~serverTiming']?: Array<{ name: string, duration: number, description?: string }>
 }
 
 export interface NuxtIslandSlotResponse {

--- a/packages/nuxt/src/pages/runtime/plugins/router.ts
+++ b/packages/nuxt/src/pages/runtime/plugins/router.ts
@@ -12,6 +12,7 @@ import { generateRouteKey, toArray } from '../utils'
 import { getRouteRules } from '#app/composables/manifest'
 import { defineNuxtPlugin, useRuntimeConfig } from '#app/nuxt'
 import { _showErrorUnlessCrawler, clearError, createError, isNuxtError, showError, useError } from '#app/composables/error'
+import { addServerTimingMetric, traceAsync } from '#app/internal/tracing'
 import { navigateTo } from '#app/composables/router'
 import { navigationDiagnostics } from '../../../app/diagnostics/navigation'
 
@@ -19,6 +20,8 @@ import _routes, { handleHotUpdate } from '#build/routes'
 import _routeRulesMatcher from '#build/route-rules.mjs'
 import routerOptions, { hashMode } from '#build/router.options.mjs'
 import { globalMiddleware, namedMiddleware } from '#build/middleware'
+// @ts-expect-error virtual file
+import { tracingChannelNuxt } from '#build/nuxt.config.mjs'
 import { pageIslandRoutes } from '#build/components.islands.mjs'
 
 // matches a trailing slash on the path only, leaving query and hash significant
@@ -272,6 +275,7 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
 
         for (const entry of middlewareEntries) {
           const middleware: RouteMiddleware = typeof entry === 'string' ? nuxtApp._middleware.named[entry] || await namedMiddleware[entry]?.().then((r: any) => r.default || r) : entry
+          const middlewareName = typeof entry === 'string' ? entry : middleware?.name || 'anonymous'
 
           if (!middleware) {
             throw navigationDiagnostics.NUXT_E2004({
@@ -280,11 +284,20 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
             })
           }
 
+          const start = import.meta.server && tracingChannelNuxt ? globalThis.performance.now() : 0
           try {
             if (import.meta.dev) {
               nuxtApp._processingMiddleware = (middleware as any)._path || (typeof entry === 'string' ? entry : true)
             }
-            const result = await nuxtApp.runWithContext(() => middleware(to, from))
+            const runMiddleware = () => nuxtApp.runWithContext(() => middleware(to, from))
+            const result = await (import.meta.server && tracingChannelNuxt
+              ? traceAsync(
+                  'nuxt.middleware',
+                  { middleware: { name: middlewareName }, route: { to: to.path, from: from.path } },
+                  () => Promise.resolve(runMiddleware()),
+                )
+              : runMiddleware()
+            )
             if (import.meta.server || (!nuxtApp.payload.serverRendered && nuxtApp.isHydrating)) {
               if (result === false || result instanceof Error) {
                 const error = result || createError({
@@ -314,6 +327,14 @@ const plugin: Plugin<{ router: Router }> = defineNuxtPlugin({
               pushErroredRoute(to)
             }
             return error
+          } finally {
+            if (import.meta.server && tracingChannelNuxt) {
+              addServerTimingMetric(nuxtApp.ssrContext, {
+                name: `nuxt.middleware.${middlewareName}`,
+                duration: globalThis.performance.now() - start,
+                description: `middleware:${middlewareName}`,
+              })
+            }
           }
         }
       }

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -18,6 +18,7 @@ await setup({
   browser: true,
   setupTimeout: (isWindows ? 360 : 120) * 1000,
   nuxtConfig: {
+    tracingChannel: true,
     hooks: {
       'modules:done' () {
         // TODO: investigate whether to upstream a fix to vite-plugin-vue or nuxt/test-utils
@@ -136,6 +137,14 @@ describe('route rules', () => {
 })
 
 describe('pages', () => {
+  it('emits Server-Timing entries for plugin and route middleware tracing', async () => {
+    const res = await fetch('/server-timing')
+    expect(res.status).toEqual(200)
+    const serverTiming = res.headers.get('server-timing') || ''
+    expect(serverTiming).toContain('nuxt.plugin.server-timing-test-plugin')
+    expect(serverTiming).toContain('nuxt.middleware.server-timing-test')
+  })
+
   it('exposes the current env name at runtime', async () => {
     const expectedEnvName = isDev ? 'development' : 'production'
     const { page } = await renderPage('/env-name')

--- a/test/fixtures/basic/app/middleware/server-timing-test.ts
+++ b/test/fixtures/basic/app/middleware/server-timing-test.ts
@@ -1,0 +1,3 @@
+export default defineNuxtRouteMiddleware(async () => {
+  await new Promise(resolve => setTimeout(resolve, 15))
+})

--- a/test/fixtures/basic/app/pages/server-timing.vue
+++ b/test/fixtures/basic/app/pages/server-timing.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+definePageMeta({
+  middleware: ['server-timing-test'],
+})
+</script>
+
+<template>
+  <div>server timing test</div>
+</template>

--- a/test/fixtures/basic/app/plugins/server-timing-test.server.ts
+++ b/test/fixtures/basic/app/plugins/server-timing-test.server.ts
@@ -1,0 +1,6 @@
+export default defineNuxtPlugin({
+  name: 'server-timing-test-plugin',
+  async setup () {
+    await new Promise(resolve => setTimeout(resolve, 25))
+  },
+})

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -8,6 +8,7 @@ import { isNuxtPrepare, projectSuffix, withMatrix } from '../../matrix.ts'
 export default withMatrix({
   ...(isNuxtPrepare ? {} : { buildDir: `.nuxt-${projectSuffix}` }),
   appId: 'nuxt-app-basic',
+  tracingChannel: true,
   extends: [
     './extends/node_modules/foo',
   ],


### PR DESCRIPTION
### 🔗 Linked issue
Issue #35287 

### 📚 Description
Nuxt wasn't previously recording time spent in app plugins and route middleware, meaning slow SSR paths were invisible in the response's metadata. This adds a small server-timing collection layer where each plugin and route middleware will get a timing metric, stored in the SSR context, which is added to the `Server-Timing` header.