### PR TITLE
fix(nuxt): skip scanning page meta if the scanner cannot parse

### DIFF
--- a/packages/nuxt/src/pages/plugins/page-meta.ts
+++ b/packages/nuxt/src/pages/plugins/page-meta.ts
@@ -9,7 +9,7 @@ import { parseModuleId } from '../../core/utils/plugins.ts'
 import { parseModule } from '../../core/utils/parse.ts'
 import { getStaticImports } from '../../core/utils/static-imports.ts'
 import type { ParsedStaticImport } from '../../core/utils/static-imports.ts'
-import { classifyPageMetaProperty } from '../utils.ts'
+import { classifyPageMetaProperty, isScannablePageFile } from '../utils.ts'
 import { linkToAlias } from '../../utils.ts'
 import type { ESTree, ParserOptions } from 'rolldown/utils'
 
@@ -50,6 +50,8 @@ if (import.meta.webpackHot) {
 export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnplugin(() => {
   const extractedKeys = new Set(options.extractedKeys)
   const classifyOptions = { extractSerializable: options.extractSerializable }
+  const noExtractedKeys = new Set<string>()
+  const noExtraction = { extractSerializable: false }
 
   return {
     name: 'nuxt:pages-macros-transform',
@@ -79,6 +81,10 @@ export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnp
         }
 
         const hasMacro = HAS_MACRO_RE.test(code)
+
+        const scanned = isScannablePageFile(id)
+        const fileExtractedKeys = scanned ? extractedKeys : noExtractedKeys
+        const fileClassifyOptions = scanned ? classifyOptions : noExtraction
 
         const parsed = parseModule(code, id, { lang: query.lang ?? 'ts' })
         const imports = getStaticImports(code, parsed.module.staticImports)
@@ -266,7 +272,7 @@ export const PageMetaPlugin = (options: PageMetaPluginOptions = {}) => createUnp
 
               for (let i = 0; i < meta.properties.length; i++) {
                 const prop = meta.properties[i]!
-                const classification = classifyPageMetaProperty(prop, extractedKeys, classifyOptions)
+                const classification = classifyPageMetaProperty(prop, fileExtractedKeys, fileClassifyOptions)
 
                 // The route record now carries the value, so drop it here to keep the two in step.
                 if (classification.kind === 'extract' || (classification.kind === 'reshape' && classification.value)) {

--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 
-import { normalize, relative } from 'pathe'
+import { extname, normalize, relative } from 'pathe'
 import { joinURL } from 'ufo'
 import { getLayerDirectories, resolveFiles, resolvePath, tryUseNuxt, useNuxt } from '@nuxt/kit'
 import { pageDiagnostics } from '@nuxt/kit/internal'
@@ -14,7 +14,7 @@ import type { ESTree } from 'rolldown/utils'
 import { addFile, buildTree, compileParsePath, removeFile, toVueRouter4, vueRouterToRou3 } from 'unrouting'
 import type { BuildTreeOptions, InputFile, RouteTree, VueRouterEmitOptions } from 'unrouting'
 
-import { getLoader } from '../core/utils/index.ts'
+import { getLoader, parseModuleId } from '../core/utils/index.ts'
 import { linkToAlias, logger, offsetToPosition, toArray } from '../utils.ts'
 import type { Nuxt, NuxtPage } from 'nuxt/schema'
 
@@ -466,6 +466,17 @@ export function getDynamicMetaKeys (absolutePath: string, extraExtractionKeys: S
   return dynamicMetaCache.get(absolutePath)?.get(getExtractVariant(extraExtractionKeys, options)) ?? EMPTY_DYNAMIC_META
 }
 
+/**
+ * Whether build-time scanning can see a page file's `definePageMeta` call. A file in a format the
+ * scanner cannot parse (e.g. `.md` compiled to a component by a build plugin) may still call the
+ * macro once transformed, so all of its metadata has to be left to the runtime macro module.
+ * Extensionless entries have no module to transform and so nothing to fall back to.
+ */
+export function isScannablePageFile (path: string) {
+  const { pathname } = parseModuleId(path)
+  return !!getLoader(pathname) || !extname(pathname)
+}
+
 export function getRouteMeta (contents: string, absolutePath: string, extraExtractionKeys: Set<string> = new Set(), options: ClassifyPageMetaOptions = {}): Partial<Record<keyof NuxtPage, any>> {
   const variant = getExtractVariant(extraExtractionKeys, options)
 
@@ -481,17 +492,22 @@ export function getRouteMeta (contents: string, absolutePath: string, extraExtra
     return klona(cached)
   }
 
+  const extractionKeys = resolvePageMetaExtractionKeys(extraExtractionKeys)
+
   const loader = getLoader(absolutePath)
-  const scriptBlocks = !loader ? null : loader === 'vue' ? extractScriptContent(contents) : [{ code: contents, loader, offset: 0 }]
-  if (!scriptBlocks) {
+  if (!loader) {
+    if (!isScannablePageFile(absolutePath)) {
+      cacheVariant(dynamicMetaCache, absolutePath).set(variant, new Set<string>([...extractionKeys, 'meta']))
+    }
     cacheVariant(extractCache, absolutePath).set(variant, {})
     return {}
   }
 
+  const scriptBlocks = loader === 'vue' ? extractScriptContent(contents) : [{ code: contents, loader, offset: 0 }]
+
   const extractedData: Partial<Record<keyof NuxtPage, any>> = {}
   const fileAt = (offset: number) => linkToAlias(absolutePath, undefined, offsetToPosition(contents, offset))
 
-  const extractionKeys = resolvePageMetaExtractionKeys(extraExtractionKeys)
   // Widened for lookups by a property name that may not be a route field at all.
   const routeFieldKeys: ReadonlySet<string> = extractionKeys
   const dynamicProperties = new Set<keyof NuxtPage>()

--- a/packages/nuxt/test/page-metadata.test.ts
+++ b/packages/nuxt/test/page-metadata.test.ts
@@ -738,6 +738,32 @@ describe('normalizeRoutes', () => {
     expect(imports).toEqual(new Set())
   })
 
+  it('should import the macro module for pages the scanner cannot parse', async () => {
+    const mdPath = '/app/pages/about.md'
+    const page: NuxtPage = { path: '/about', name: 'about', file: mdPath }
+    await augmentForNuxt([page], { [mdPath]: '---\nmeta:\n  layout: dark\n---\n# About' }, { fullyResolvedPaths: new Set([mdPath]) })
+
+    const { routes, imports } = normalizeRoutes([page], new Set(), {
+      clientComponentRuntime: '<client-component-runtime>',
+      serverComponentRuntime: '<server-component-runtime>',
+      overrideMeta: true,
+    })
+    expect(imports.size).toBe(1)
+    expect(routes).toMatchInlineSnapshot(`
+      "[
+        {
+          name: aboutovScknMoPDsfPpjLmpwuiAjQpDUQXp2Mg32kpF79y6IMeta?.name ?? "about",
+          path: aboutovScknMoPDsfPpjLmpwuiAjQpDUQXp2Mg32kpF79y6IMeta?.path ?? "/about",
+          props: aboutovScknMoPDsfPpjLmpwuiAjQpDUQXp2Mg32kpF79y6IMeta?.props ?? false,
+          meta: aboutovScknMoPDsfPpjLmpwuiAjQpDUQXp2Mg32kpF79y6IMeta || {},
+          alias: aboutovScknMoPDsfPpjLmpwuiAjQpDUQXp2Mg32kpF79y6IMeta?.alias || [],
+          redirect: aboutovScknMoPDsfPpjLmpwuiAjQpDUQXp2Mg32kpF79y6IMeta?.redirect,
+          component: () => import("/app/pages/about.md")
+        }
+      ]"
+    `)
+  })
+
   it('should import the macro module for a route whose name was stripped as a duplicate', async () => {
     const vfs = { [filePath]: `<script setup>definePageMeta({ name: 'from-macro', alias: ['/some-alias'] })</script>` }
     const pages: NuxtPage[] = [
@@ -1653,6 +1679,27 @@ definePageMeta({ title: 'hello', order: -2, tags: ['a', 'b'], nested: { deep: tr
       const macro = macroModule(sfc)
       expect(macro).not.toContain('hello')
       expect(macro).toContain('const __nuxt_page_meta = {')
+    })
+
+    it('should keep all metadata in the macro module for files the scanner cannot parse', () => {
+      const code = `
+import { definePageMeta } from '#app/composables/pages'
+export const meta = { redirect: '/about' }
+const _sfc_main = {
+  setup() {
+    definePageMeta({ redirect: '/about', layout: 'dark' })
+    return () => null
+  }
+}
+export default _sfc_main
+      `
+      expect(getRouteMeta(code, '/app/pages/redirect.md', new Set(), options)).toEqual({
+        dynamic: new Set([...defaultExtractionKeys, 'meta']),
+      })
+      const plugin = PageMetaPlugin({ extractedKeys: [...defaultExtractionKeys], extractSerializable: true }).raw({}, {} as any) as { transform: { handler: (code: string, id: string) => { code: string } | null } }
+      const macro = plugin.transform.handler(code, '/app/pages/redirect.md?macro=true')?.code
+      expect(macro).toContain(`redirect: '/about'`)
+      expect(macro).toContain(`layout: 'dark'`)
     })
 
     it('should fall back to the macro module for an unlisted key that is not serializable', () => {


### PR DESCRIPTION
### 🔗 Linked issue

resolves #29269

### 📚 Description

some files can't be parsed, and in this case we fall back to in-build extraction