### PR TITLE
fix(nuxt): strip hydrated `nuxt-client` markup from cached island html

### DIFF
--- a/packages/nuxt/src/app/components/utils.ts
+++ b/packages/nuxt/src/app/components/utils.ts
@@ -164,13 +164,15 @@ function getFragmentChildren (element: RendererNode | null, blocks: string[] = [
   return blocks
 }
 
+const ISLAND_TELEPORT_TARGET_SELECTOR = '[data-island-slot],[data-island-component]'
+
 function getElementHTML (element: RendererNode, withoutSlots: boolean) {
-  if (!withoutSlots || !element.querySelector?.('[data-island-slot]')) {
+  if (!withoutSlots || !element.querySelector?.(ISLAND_TELEPORT_TARGET_SELECTOR)) {
     return element.outerHTML
   }
   const template = element.ownerDocument.createElement('template')
   template.innerHTML = element.outerHTML
-  template.content.querySelectorAll('[data-island-slot]').forEach((n: Element) => { n.innerHTML = '' })
+  template.content.querySelectorAll(ISLAND_TELEPORT_TARGET_SELECTOR).forEach((n: Element) => { n.innerHTML = '' })
   return template.innerHTML
 }
 

--- a/test/nuxt/component-utils.test.ts
+++ b/test/nuxt/component-utils.test.ts
@@ -59,6 +59,20 @@ describe('getFragmentHTML', () => {
     ])
   })
 
+  // https://github.com/nuxt/nuxt/issues/33809
+  it('clears hydrated client component contents', () => {
+    const fragment = document.createDocumentFragment()
+    const start = document.createComment('[')
+    const element = document.createElement('div')
+
+    element.innerHTML = '<div data-island-uid="1" data-island-component="v-0-0-0"><!--teleport start anchor--><button>hydrated</button><!--teleport anchor--></div>'
+    fragment.append(start, element, document.createComment(']'))
+
+    expect(getFragmentHTML(start, true)).toEqual([
+      '<div><div data-island-uid="1" data-island-component="v-0-0-0"></div></div>',
+    ])
+  })
+
   // cloning a live `<img>` starts a second load of its `src`
   it('does not clone live nodes', () => {
     const cloneNode = vi.spyOn(Node.prototype, 'cloneNode')


### PR DESCRIPTION
### 🔗 Linked issue

resolves #33809
closes https://github.com/nuxt/nuxt/pull/34055

### 📚 Description

we need to clear hydrated client component contents