### PR TITLE
fix(nuxt): resolve awaited lazy async data immediately

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -652,7 +652,7 @@ export const createUseAsyncData: CreateUseAsyncData = defineKeyedFunctionFactory
       }
 
       // Allow directly awaiting on asyncData
-      const asyncDataPromise = Promise.resolve(nuxtApp._asyncDataPromises[key.value]).then(() => asyncReturn) as AsyncData<ResT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>)>
+      const asyncDataPromise = Promise.resolve(import.meta.client && opts.lazy ? undefined : nuxtApp._asyncDataPromises[key.value]).then(() => asyncReturn) as AsyncData<ResT, (NuxtErrorDataT extends Error | NuxtError ? NuxtErrorDataT : NuxtError<NuxtErrorDataT>)>
       Object.assign(asyncDataPromise, asyncReturn)
       // Allow destructuring without losing promise methods
       Object.defineProperties(asyncDataPromise, {

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -1013,6 +1013,24 @@ describe('useAsyncData', () => {
     vi.useRealTimers()
   })
 
+  it('should resolve immediately when awaiting useLazyAsyncData outside of component setup', async () => {
+    vi.useFakeTimers()
+
+    const promiseFn = vi.fn(() => new Promise(resolve => setTimeout(() => resolve('test'), 10)))
+    const { data, status } = await useLazyAsyncData(uniqueKey, promiseFn)
+    expect(promiseFn).toHaveBeenCalledTimes(1)
+    expect(data.value).toBe(undefined)
+    expect(status.value).toBe('pending')
+
+    vi.advanceTimersByTime(10)
+    await flushPromises()
+
+    expect(data.value).toBe('test')
+    expect(status.value).toBe('success')
+
+    vi.useRealTimers()
+  })
+
   it('should not execute with immediate: false and be executable', async () => {
     const promiseFn = vi.fn(() => Promise.resolve('test'))
     const { data, status, execute } = useAsyncData(promiseFn, { immediate: false })


### PR DESCRIPTION
### 🔗 Linked issue

resolves #25033

### 📚 Description

`const { data } = await useLazyAsyncData()` was awaiting the promise on client, effectively making it non-lazy.

this PR changes it so the promise isn't awaited on the client, as expected.