### PR TITLE
fix(nitro): prefer project server utils over extended layers

### DIFF
--- a/packages/nitro-server/src/auto-imports.ts
+++ b/packages/nitro-server/src/auto-imports.ts
@@ -38,6 +38,12 @@ export function createServerAutoImports (nuxt: Nuxt, options: ServerImportsOptio
   const isIgnored = createIsIgnored(nuxt)
   const scanDirs = options.dirs ?? []
 
+  // the project comes first in `_layers`, so it gets the highest priority; the floor of 1 is
+  // unimport's default, so a scanned util still takes precedence over a preset of the same name
+  const layerPriorities = nuxt.options._layers
+    .map((layer, i) => [layer.config.rootDir, nuxt.options._layers.length - i] as const)
+    .sort(([a], [b]) => b.length - a.length)
+
   let initialised: Promise<void> | undefined
   function init () {
     initialised ??= (async () => {
@@ -53,6 +59,9 @@ export function createServerAutoImports (nuxt: Nuxt, options: ServerImportsOptio
       const scanned = await scanDirExports(scanDirs, {
         fileFilter: file => !isIgnored(file),
       })
+      for (const i of scanned) {
+        i.priority ??= layerPriorities.find(([dir]) => i.from === dir || i.from.startsWith(dir + '/'))?.[1]
+      }
       imports.push(...scanned)
       return imports
     })

--- a/packages/nitro-server/test/auto-imports.test.ts
+++ b/packages/nitro-server/test/auto-imports.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { describe, expect, it } from 'vitest'
 import { dirname, isAbsolute, join, resolve } from 'pathe'
@@ -118,6 +118,28 @@ describe('createServerAutoImports', () => {
       const result = await autoImports.injectImports(code, '/app/server/utils/shadow.ts')
       expect(result?.s.hasChanged()).toBe(false)
     }
+  })
+
+  it('prefers a project server util over one from an extended layer', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'server-auto-imports-layers-'))
+    const layerDir = join(rootDir, 'layer')
+    for (const [dir, value] of [[rootDir, 'root'], [layerDir, 'layer']] as const) {
+      mkdirSync(join(dir, 'server/utils'), { recursive: true })
+      writeFileSync(join(dir, 'server/utils/useMyServerUtil.ts'), `export const useMyServerUtil = () => '${value}'\n`)
+    }
+    const nuxt = mockNuxt()
+    nuxt.options.rootDir = rootDir
+    nuxt.options.srcDir = rootDir
+    nuxt.options._layers = [{ cwd: rootDir, config: { rootDir } }, { cwd: layerDir, config: { rootDir: layerDir } }] as unknown as Nuxt['options']['_layers']
+
+    const autoImports = createServerAutoImports(
+      nuxt,
+      { autoImport: true, dirs: [join(rootDir, 'server/utils'), join(layerDir, 'server/utils')] },
+      mkdtempSync(join(tmpdir(), 'server-auto-imports-')),
+    )
+
+    const imports = await autoImports.getImports()
+    expect(imports.filter(i => i.name === 'useMyServerUtil').map(i => i.from)).toEqual([join(rootDir, 'server/utils/useMyServerUtil.ts')])
   })
 
   it('resolves `#imports` to a path inside the types directory', () => {


### PR DESCRIPTION
### 🔗 Linked issue

resolves #28006

### 📚 Description

now that we own the unimport presets for nitro v3, we can prioritise scanned utils based on layer priority