### PR TITLE
fix(nuxt): keep page transition mounted for nested route with no children

### DIFF
--- a/packages/nuxt/src/pages/runtime/page.ts
+++ b/packages/nuxt/src/pages/runtime/page.ts
@@ -129,7 +129,9 @@ export default defineComponent({
                   return vnode
                 }
                 done()
-                return
+                const hasTransition = !!(props.transition ?? routeProps.route.meta.pageTransition ?? defaultPageTransition)
+                if (!hasTransition) { return }
+                return _wrapInTransition(_mergeTransitionProps([props.transition, routeProps.route.meta.pageTransition, defaultPageTransition]), null).default()
               }
 
               // Return old vnode if we are rendering _new_ page suspense fork in _old_ layout suspense fork

--- a/test/nuxt/nuxt-page.test.ts
+++ b/test/nuxt/nuxt-page.test.ts
@@ -1126,3 +1126,70 @@ describe('NuxtPage with page keys', () => {
     el.unmount()
   })
 })
+
+describe('NuxtPage transitions on nested child routes (#12361)', () => {
+  let router: ReturnType<typeof useRouter>
+  const hooks: string[] = []
+
+  beforeEach(() => {
+    router = useRouter()
+    hooks.length = 0
+
+    router.addRoute({
+      name: 'parent-12361',
+      path: '/parent-12361',
+      component: defineComponent({
+        name: 'parent-12361',
+        render: () => h('div', { 'data-testid': 'parent-12361' }, [
+          h('span', 'Parent'),
+          h(NuxtPage, {
+            transition: {
+              css: false,
+              onEnter: (_el: Element, done: () => void) => { hooks.push('enter'); done() },
+              onLeave: (_el: Element, done: () => void) => { hooks.push('leave'); done() },
+            },
+          }),
+        ]),
+      }),
+      children: [
+        {
+          name: 'child-12361',
+          path: 'child',
+          component: defineComponent({
+            name: 'child-12361',
+            render: () => h('div', { 'data-testid': 'child-12361' }, 'Child'),
+          }),
+        },
+      ],
+    })
+  })
+
+  afterEach(async () => {
+    await navigateTo('/')
+    await flushPromises()
+    router.removeRoute('parent-12361')
+  })
+
+  it('runs enter and leave transitions when a child route is added or removed', async () => {
+    const el = await mountSuspended({
+      setup: () => () => h(NuxtLayout, {}, { default: () => h(NuxtPage) }),
+    }, { global: { stubs: { transition: false } } })
+
+    await navigateTo('/parent-12361')
+    await flushPromises()
+    expect(el.html()).toContain('Parent')
+    expect(el.html()).not.toContain('Child')
+
+    await navigateTo('/parent-12361/child')
+    await flushPromises()
+    expect(el.html()).toContain('Child')
+    expect(hooks).toEqual(['enter'])
+
+    await navigateTo('/parent-12361')
+    await flushPromises()
+    expect(el.html()).not.toContain('Child')
+    expect(hooks).toEqual(['enter', 'leave'])
+
+    el.unmount()
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

resolves #12361

### 📚 Description

this addresses a failure to return an (empty) transition when navigating around a nested route with no children