### PR TITLE
fix(nitro,vite-server): render `error.vue` 404 when accessing `/__nuxt_error`

### DIFF
--- a/packages/nitro-server/src/runtime/handlers/error.ts
+++ b/packages/nitro-server/src/runtime/handlers/error.ts
@@ -57,7 +57,7 @@ export default <NitroErrorHandler> async function errorhandler (error, event, { 
   mergeHeaders(headers, new Headers(defaultRes.headers), new Set(), IGNORED_ERROR_HEADERS)
 
   // Skip SSR error rendering if we're already inside one, to avoid recursion.
-  const isRenderingError = (event as H3Event).url?.pathname.startsWith('/__nuxt_error') || !!(event as H3Event).context.nuxt?.['~rendering-error']
+  const isRenderingError = !!(event as H3Event).context.nuxt?.['~rendering-error']
 
   if (!isRenderingError) {
     const eventContext = (event as H3Event).context

--- a/packages/vite-server/src/runtime/renderer.ts
+++ b/packages/vite-server/src/runtime/renderer.ts
@@ -83,36 +83,33 @@ async function renderError (renderer: NuxtRenderer, request: Request, error: unk
   const { status, statusText, message, headers } = describeError(error)
   const url = new URL(request.url)
 
-  // a render that failed while rendering the error page cannot be recovered by rendering it again
-  if (!url.pathname.startsWith('/__nuxt_error')) {
-    const errorEvent = createRequestEvent(new Request(withQuery(new URL('/__nuxt_error', url).href, {
-      [SSR_ERROR_PARAM]: encodeSSRError({
-        status,
-        statusText,
-        message,
-        fatal: false,
-        url: request.url,
-        data: (error as { data?: unknown })?.data,
-      }),
-    }), { headers: request.headers }))
-    // while prerendering the two renders share one state, so routes the error page asks
-    // for are reported alongside those the failed render collected before it threw
-    const state = (import.meta.prerender ? (event.context as { nuxt?: Record<string, unknown> }).nuxt : undefined) || {}
-    state['~rendering-error'] = true
-    ;(errorEvent.context as { nuxt?: Record<string, unknown> }).nuxt = state
-    if (import.meta.prerender) {
-      ;(event.context as { nuxt?: Record<string, unknown> }).nuxt = state
-    }
+  const errorEvent = createRequestEvent(new Request(withQuery(new URL('/__nuxt_error', url).href, {
+    [SSR_ERROR_PARAM]: encodeSSRError({
+      status,
+      statusText,
+      message,
+      fatal: false,
+      url: request.url,
+      data: (error as { data?: unknown })?.data,
+    }),
+  }), { headers: request.headers }))
+  // while prerendering the two renders share one state, so routes the error page asks
+  // for are reported alongside those the failed render collected before it threw
+  const state = (import.meta.prerender ? (event.context as { nuxt?: Record<string, unknown> }).nuxt : undefined) || {}
+  state['~rendering-error'] = true
+  ;(errorEvent.context as { nuxt?: Record<string, unknown> }).nuxt = state
+  if (import.meta.prerender) {
+    ;(event.context as { nuxt?: Record<string, unknown> }).nuxt = state
+  }
 
-    const rendered = await renderer.fetch(errorEvent).catch(() => null)
-    if (rendered) {
-      const responseHeaders = new Headers(rendered.headers)
-      for (const [name, value] of new Headers(headers)) {
-        responseHeaders.set(name, value)
-      }
-      responseHeaders.set('content-type', 'text/html;charset=utf-8')
-      return new Response(rendered.body, { status, statusText, headers: responseHeaders })
+  const rendered = await renderer.fetch(errorEvent).catch(() => null)
+  if (rendered) {
+    const responseHeaders = new Headers(rendered.headers)
+    for (const [name, value] of new Headers(headers)) {
+      responseHeaders.set(name, value)
     }
+    responseHeaders.set('content-type', 'text/html;charset=utf-8')
+    return new Response(rendered.body, { status, statusText, headers: responseHeaders })
   }
 
   return new Response(message, {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1409,6 +1409,18 @@ describe('errors', () => {
     expect(error).not.toHaveProperty('url')
   })
 
+  it('should render the app error page when accessing error route directly', async () => {
+    const res = await fetch('/__nuxt_error', {
+      headers: {
+        accept: 'text/html',
+      },
+    })
+    expect(res.status).toBe(404)
+    const html = await res.text()
+    expect(html).toContain('This is the error page 😱')
+    expect(html).toContain('Page Not Found: /__nuxt_error')
+  })
+
   it('should not recursively throw an error when there is an error rendering the error page', async () => {
     const res = await $fetch<string>('/', {
       headers: {


### PR DESCRIPTION

### 🔗 Linked issue

resolves #20623

### 📚 Description

this removes the special-casing of accessing `/__nuxt_error`; the sole way we distinguish error page rendering is an internal context value which can't be set by an external request