### PR TITLE
fix(nitro): pass glob patterns to devStorage fs watch ignore

### DIFF
--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -10,7 +10,7 @@ import { joinURL, withTrailingSlash, withoutTrailingSlash } from 'ufo'
 import nuxtPkg from 'nuxt/package.json' with { type: 'json' }
 import { createNitro } from 'nitro/builder'
 import type { Nitro, NitroConfig } from 'nitro/types'
-import { addPlugin, addTemplate, addVitePlugin, createIsIgnored, ensureDependencyInstalled, findPath, getAddDependencyCommand, getLayerDirectories, resolveAlias, resolveIgnorePatterns } from '@nuxt/kit'
+import { addPlugin, addTemplate, addVitePlugin, ensureDependencyInstalled, findPath, getAddDependencyCommand, getLayerDirectories, resolveAlias, resolveIgnorePatterns } from '@nuxt/kit'
 import { bundlerDiagnostics, getServerRuntime, setServerBuild } from '@nuxt/kit/internal'
 import escapeRE from 'escape-string-regexp'
 import { defu } from 'defu'
@@ -22,7 +22,7 @@ import { resolveModulePath } from 'exsolve'
 import { runtimeDependencies } from 'nitro/meta'
 
 import nitroBuilder from '../package.json' with { type: 'json' }
-import { PATHS_SPECIFIER, distDir, getLayerNodeModulesExcludePattern, getServerReplacements, getSsrResolveConditions, toArray } from './utils.ts'
+import { PATHS_SPECIFIER, distDir, getLayerNodeModulesExcludePattern, getServerReplacements, getSsrResolveConditions, toArray, toFsDriverIgnorePatterns } from './utils.ts'
 import { setupNitroViteEnvironment } from './vite.ts'
 import { setupLegacyDevAndBuild } from './legacy.ts'
 import { LOOPBACK_HOSTS, isLocalDevRequest, isLoopbackPeer } from './dev-request.ts'
@@ -614,26 +614,24 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     }
   }
 
-  // Apply Nuxt's ignore configuration to the root and src unstorage mounts
-  // created by Nitro. This ensures that the unstorage watcher will use the
-  // same ignore list as Nuxt's watcher and can reduce unnecessary file handles.
-  const isIgnored = createIsIgnored(nuxt)
+  // Nitro serialises mount options with `JSON.stringify`, so the patterns have to go
+  // through the fs driver's `ignore` option rather than a `watchOptions.ignored` matcher.
+  const devStorageIgnore = (base?: string) => toFsDriverIgnorePatterns([
+    '**/node_modules',
+    ...resolveIgnorePatterns(base),
+  ])
   nitroConfig.devStorage ??= {}
   nitroConfig.devStorage.root ??= {
     driver: 'fs',
     readOnly: true,
     base: nitroConfig.rootDir,
-    watchOptions: {
-      ignored: [isIgnored],
-    },
+    ignore: devStorageIgnore(),
   }
   nitroConfig.devStorage.src ??= {
     driver: 'fs',
     readOnly: true,
     base: nitroConfig.serverDir,
-    watchOptions: {
-      ignored: [isIgnored],
-    },
+    ignore: devStorageIgnore(nuxt.options.serverDir),
   }
 
   const cacheDriverPath = join(distDir, 'runtime/utils/cache-driver.mjs')

--- a/packages/nitro-server/src/utils.ts
+++ b/packages/nitro-server/src/utils.ts
@@ -1,4 +1,5 @@
 import { fileURLToPath } from 'node:url'
+import { matchesGlob } from 'node:path'
 import { dirname } from 'pathe'
 import escapeRE from 'escape-string-regexp'
 import type { Nuxt } from '@nuxt/schema'
@@ -53,6 +54,42 @@ export function getLayerNodeModulesExcludePattern (layerRoots: Iterable<string>)
   return excludePaths.length
     ? new RegExp(`node_modules\\/(?!${excludePaths.join('|')})`)
     : /node_modules/
+}
+
+/**
+ * Convert Nuxt's gitignore-style ignore patterns into globs for the unstorage `fs`
+ * driver, which matches them with `node:path` `matchesGlob` relative to the mount base.
+ *
+ * 1. A gitignore pattern without a slash matches at any depth, so it is prefixed with `**\/`
+ * 2. A trailing slash (directory-only) and a leading slash (anchored) have no meaning.
+ * 3. Re-inclusion cannot be expressed in a flat list of globs at all, we drop whatever
+ *    a negated pattern would 'undo'.
+ */
+export function toFsDriverIgnorePatterns (patterns: string[]): string[] {
+  const globs = new Set<string>()
+  const rescued = new Set<string>()
+  for (const pattern of patterns) {
+    const negated = pattern[0] === '!'
+    const glob = toFsDriverGlob(negated ? pattern.slice(1) : pattern)
+    if (glob) {
+      (negated ? rescued : globs).add(glob)
+    }
+  }
+  if (!rescued.size) {
+    return [...globs]
+  }
+  return [...globs].filter(glob => ![...rescued].some(path => matchesGlob(path, glob)))
+}
+
+function toFsDriverGlob (pattern: string): string | undefined {
+  const trimmed = pattern.replace(/\/+$/, '')
+  const anchored = trimmed.includes('/')
+  const glob = trimmed.replace(/^\//, '')
+  // patterns resolved outside the mount base can never match a key within it
+  if (!glob || glob.startsWith('../')) {
+    return
+  }
+  return anchored ? glob : `**/${glob}`
 }
 
 /**

--- a/packages/nitro-server/src/utils.ts
+++ b/packages/nitro-server/src/utils.ts
@@ -64,21 +64,32 @@ export function getLayerNodeModulesExcludePattern (layerRoots: Iterable<string>)
  * 2. A trailing slash (directory-only) and a leading slash (anchored) have no meaning.
  * 3. Re-inclusion cannot be expressed in a flat list of globs at all, we drop whatever
  *    a negated pattern would 'undo'.
+ *
+ * Rules are order-sensitive (the last one to match a path wins), so a negated pattern
+ * only drops the patterns declared before it.
  */
 export function toFsDriverIgnorePatterns (patterns: string[]): string[] {
-  const globs = new Set<string>()
-  const rescued = new Set<string>()
+  const globs: string[] = []
   for (const pattern of patterns) {
     const negated = pattern[0] === '!'
     const glob = toFsDriverGlob(negated ? pattern.slice(1) : pattern)
-    if (glob) {
-      (negated ? rescued : globs).add(glob)
+    if (!glob) {
+      continue
+    }
+    if (!negated) {
+      if (!globs.includes(glob)) {
+        globs.push(glob)
+      }
+      continue
+    }
+    for (let i = globs.length - 1; i >= 0; i--) {
+      const ignored = globs[i]!
+      if (matchesGlob(glob, ignored) || matchesGlob(ignored, glob)) {
+        globs.splice(i, 1)
+      }
     }
   }
-  if (!rescued.size) {
-    return [...globs]
-  }
-  return [...globs].filter(glob => ![...rescued].some(path => matchesGlob(path, glob)))
+  return globs
 }
 
 function toFsDriverGlob (pattern: string): string | undefined {

--- a/packages/nitro-server/test/utils.test.ts
+++ b/packages/nitro-server/test/utils.test.ts
@@ -90,4 +90,14 @@ describe('toFsDriverIgnorePatterns', () => {
     expect(toFsDriverIgnorePatterns(['*.log', '!important.log'])).toEqual([])
     expect(toFsDriverIgnorePatterns(['*.log', '**/.output', '!important.log'])).toEqual(['**/.output'])
   })
+
+  it('drops a pattern re-included by a more general negated pattern', () => {
+    expect(toFsDriverIgnorePatterns(['app/middleware/foo/bar.js', '!app/middleware/foo/*.js'])).toEqual([])
+    expect(toFsDriverIgnorePatterns(['app/middleware/foo/bar.js', '!**/*.js'])).toEqual([])
+  })
+
+  it('keeps a pattern declared after the negated pattern it overlaps', () => {
+    expect(toFsDriverIgnorePatterns(['!important.log', '*.log'])).toEqual(['**/*.log'])
+    expect(toFsDriverIgnorePatterns(['*.log', '!important.log', '**/*.log'])).toEqual(['**/*.log'])
+  })
 })

--- a/packages/nitro-server/test/utils.test.ts
+++ b/packages/nitro-server/test/utils.test.ts
@@ -1,5 +1,6 @@
+import { matchesGlob } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { getLayerNodeModulesExcludePattern } from '../src/utils.ts'
+import { getLayerNodeModulesExcludePattern, toFsDriverIgnorePatterns } from '../src/utils.ts'
 
 describe('getLayerNodeModulesExcludePattern', () => {
   it('falls back to a bare node_modules pattern when no layers live in node_modules', () => {
@@ -61,5 +62,32 @@ describe('getLayerNodeModulesExcludePattern', () => {
     const withSlash = getLayerNodeModulesExcludePattern(['/proj/node_modules/foo/'])
     const withoutSlash = getLayerNodeModulesExcludePattern(['/proj/node_modules/foo'])
     expect(withSlash.source).toBe(withoutSlash.source)
+  })
+})
+
+describe('toFsDriverIgnorePatterns', () => {
+  it('matches slashless patterns at any depth', () => {
+    expect(toFsDriverIgnorePatterns(['*.log', 'node_modules'])).toEqual(['**/*.log', '**/node_modules'])
+    expect(matchesGlob('nested/file.log', '**/*.log')).toBe(true)
+  })
+
+  it('keeps patterns containing a slash anchored to the mount base', () => {
+    expect(toFsDriverIgnorePatterns(['app/middleware/*.js', '**/*.spec.ts'])).toEqual(['app/middleware/*.js', '**/*.spec.ts'])
+    expect(matchesGlob('nested/app/middleware/x.js', 'app/middleware/*.js')).toBe(false)
+  })
+
+  it('strips the leading and trailing slashes of anchored and directory-only patterns', () => {
+    expect(toFsDriverIgnorePatterns(['/vendor', 'build/', '/packages/a/'])).toEqual(['vendor', '**/build', 'packages/a'])
+    expect(matchesGlob('nested/vendor', 'vendor')).toBe(false)
+  })
+
+  it('drops patterns resolved outside the mount base', () => {
+    expect(toFsDriverIgnorePatterns(['../.nuxt', '.nuxt'])).toEqual(['**/.nuxt'])
+  })
+
+  it('drops patterns a negated pattern would re-include', () => {
+    expect(toFsDriverIgnorePatterns(['app/middleware/foo/*.js', '!app/middleware/foo/bar.js'])).toEqual([])
+    expect(toFsDriverIgnorePatterns(['*.log', '!important.log'])).toEqual([])
+    expect(toFsDriverIgnorePatterns(['*.log', '**/.output', '!important.log'])).toEqual(['**/.output'])
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

previously we passed a function which was serialised to null after passing through `JSON.stringify`, which meant we over-watched in development - our ignore matcher never reached the watcher

so here we pass glob patterns instead