### PR TITLE
fix(vite): resolve bare ssr externals from their importer

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -43,6 +43,21 @@
         "#shared/*": ["./shared/*"]
       }
     },
+    "test/fixtures/basic": {
+      "entry": [
+        "**/*.{js,ts,tsx,mjs,mts,vue}!"
+      ],
+      "paths": {
+        "~~/*": ["./*"],
+        "~/*": ["./*"],
+        "#shared/*": ["./shared/*"]
+      },
+      "ignoreDependencies": [
+        "@babel/plugin-proposal-decorators",
+        "@babel/plugin-syntax-jsx",
+        "nested-dep"
+      ]
+    },
     "packages/nitro-server": {
       "entry": [
         "src/runtime/**/*.{js,ts,mjs}!"

--- a/packages/vite/src/plugins/resolved-externals.ts
+++ b/packages/vite/src/plugins/resolved-externals.ts
@@ -1,48 +1,61 @@
+import { isBuiltin } from 'node:module'
 import type { Plugin } from 'vite'
 import type { Nuxt } from '@nuxt/schema'
 import { resolveModulePath } from 'exsolve'
+import { dirname, relative } from 'pathe'
 import escapeStringRegexp from 'escape-string-regexp'
-import { useServerBuild } from '@nuxt/kit/internal'
+import { parseNodeModulePath } from '@nuxt/kit/internal'
+
+const BARE_ID_RE = /^(?!\.{0,2}[/\\]|[A-Z]:[/\\]|[\0#~]|virtual:)/i
 
 export function ResolveExternalsPlugin (nuxt: Nuxt): Plugin {
-  let external: Set<string> = new Set()
   return {
     name: 'nuxt:resolve-externals',
     enforce: 'pre',
     config () {
-      external = new Set(nuxt['~runtimeDependencies'])
-
       return {
         optimizeDeps: {
-          exclude: Array.from(external),
+          exclude: nuxt['~runtimeDependencies'],
         },
       }
     },
     applyToEnvironment (environment) {
-      if (nuxt.options.dev || environment.name !== 'ssr' || !useServerBuild(nuxt).buildsSeparately) {
+      // a build that inlines everything has no externals to correct and is the deployable
+      if (nuxt.options.dev || environment.name !== 'ssr' || environment.config.resolve.noExternal === true) {
         return false
       }
+
+      // an importer inside the project (and outside node_modules) resolves a bare id to the
+      // same package the build directory does, so there is nothing to correct for it
+      const { rootDir, buildDir } = nuxt.options
+      const localImporterRE = relative(rootDir, buildDir).startsWith('..')
+        ? undefined
+        : new RegExp('^' + escapeStringRegexp(rootDir.replace(/\/$/, '') + '/') + '(?!.*node_modules)')
+
+      const conditions = [...new Set([...environment.config.resolve.conditions, 'import', 'default'])]
+        .map(c => c === 'development|production' ? 'production' : c)
+
       return {
         name: 'nuxt:resolve-externals:external',
         resolveId: {
           filter: {
-            id: [...external].map(dep => new RegExp('^' + escapeStringRegexp(dep) + '$')),
+            id: BARE_ID_RE,
           },
           async handler (id, importer) {
+            if (!importer || isBuiltin(id) || localImporterRE?.test(importer)) { return }
             const res = await this.resolve?.(id, importer, { skipSelf: true })
-            if (res !== undefined && res !== null) {
-              if (res.id === id) {
-                res.id = resolveModulePath(res.id, {
-                  try: true,
-                  from: importer,
-                  extensions: nuxt.options.extensions,
-                }) || res.id
-              }
-              return {
-                ...res,
-                external: 'absolute',
-              }
-            }
+            if (!res || res.external !== true || res.id !== id) { return res }
+            // every file in a package resolves a bare id the same way, so resolving from the
+            // package directory lets exsolve's cache absorb the other import sites
+            const { dir, name } = parseNodeModulePath(importer)
+            const path = resolveModulePath(id, {
+              try: true,
+              from: dir && name ? `${dir}${name}/` : `${dirname(importer)}/`,
+              conditions,
+              extensions: nuxt.options.extensions,
+            })
+            if (!path) { return res }
+            return { ...res, id: path, external: 'absolute' }
           },
         },
       }

--- a/packages/vite/test/resolved-externals.test.ts
+++ b/packages/vite/test/resolved-externals.test.ts
@@ -1,0 +1,127 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { ResolveExternalsPlugin } from '../src/plugins/resolved-externals.ts'
+
+const root = join(tmpdir(), 'nuxt-resolved-externals-test')
+
+function createNuxt (options: Record<string, unknown> = {}) {
+  return {
+    'options': {
+      dev: false,
+      rootDir: '/project',
+      buildDir: '/project/.nuxt',
+      extensions: ['.js', '.ts', '.mjs'],
+      ...options,
+    },
+    '~runtimeDependencies': [],
+  } as any
+}
+
+function createEnvironment (name = 'ssr', resolve: Record<string, unknown> = {}) {
+  return { name, config: { resolve: { conditions: ['module', 'node', 'development|production'], ...resolve } } } as any
+}
+
+function environmentPlugin (nuxt = createNuxt(), environment = createEnvironment()) {
+  const plugin = ResolveExternalsPlugin(nuxt) as any
+  return plugin.applyToEnvironment(environment)
+}
+
+function resolveId (plugin: any, context: any, id: string, importer?: string) {
+  return plugin.resolveId.handler.call(context, id, importer)
+}
+
+function writePackage (dir: string, value: string) {
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'dep', type: 'module', exports: './index.js' }))
+  writeFileSync(join(dir, 'index.js'), `export default ${JSON.stringify(value)}`)
+}
+
+describe('ResolveExternalsPlugin', () => {
+  const rootDep = join(root, 'node_modules/dep')
+  const nestedDep = join(root, 'node_modules/mod/node_modules/dep')
+  const importer = join(root, 'node_modules/mod/dist/deep/plugin.js')
+  const layerImporter = join(root, 'layer/plugins/plugin.js')
+
+  beforeAll(() => {
+    writePackage(rootDep, 'root')
+    writePackage(nestedDep, 'nested')
+    mkdirSync(join(root, 'node_modules/mod/dist/deep'), { recursive: true })
+    mkdirSync(join(root, 'layer/plugins'), { recursive: true })
+    writeFileSync(importer, 'import dep from "dep"')
+    writeFileSync(layerImporter, 'import dep from "dep"')
+  })
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it('does not apply in dev, outside the ssr environment, or to a build that inlines everything', () => {
+    expect(environmentPlugin(createNuxt({ dev: true }))).toBe(false)
+    expect(environmentPlugin(createNuxt(), createEnvironment('client'))).toBe(false)
+    expect(environmentPlugin(createNuxt(), createEnvironment('ssr', { noExternal: true }))).toBe(false)
+    expect(environmentPlugin(createNuxt(), createEnvironment('ssr', { noExternal: [/foo/] }))).not.toBe(false)
+  })
+
+  // https://github.com/nuxt/nuxt/issues/22077
+  it('resolves bare externals from the importing package', async () => {
+    const plugin = environmentPlugin()
+    const context = { resolve: vi.fn().mockResolvedValue({ id: 'dep', external: true }) }
+
+    await expect(resolveId(plugin, context, 'dep', importer)).resolves.toStrictEqual({ id: join(nestedDep, 'index.js'), external: 'absolute' })
+    expect(context.resolve).toHaveBeenCalledWith('dep', importer, { skipSelf: true })
+
+    await expect(resolveId(plugin, context, 'dep', layerImporter)).resolves.toStrictEqual({ id: join(rootDep, 'index.js'), external: 'absolute' })
+  })
+
+  it('does not resolve for importers inside the project', async () => {
+    const context = { resolve: vi.fn() }
+
+    await expect(resolveId(environmentPlugin(), context, 'dep', '/project/app/plugins/plugin.js')).resolves.toBeUndefined()
+    expect(context.resolve).not.toHaveBeenCalled()
+
+    for (const importer of ['/project/node_modules/mod/plugin.js', '/other/layer/plugins/plugin.js']) {
+      await resolveId(environmentPlugin(), context, 'dep', importer)
+      expect(context.resolve).toHaveBeenCalledWith('dep', importer, { skipSelf: true })
+    }
+
+    await resolveId(environmentPlugin(createNuxt({ buildDir: '/elsewhere/.nuxt' })), context, 'dep', '/project/app/plugins/plugin.js')
+    expect(context.resolve).toHaveBeenCalledWith('dep', '/project/app/plugins/plugin.js', { skipSelf: true })
+  })
+
+  it('leaves inlined and unresolvable modules alone', async () => {
+    const plugin = environmentPlugin()
+
+    const inlined = { id: join(nestedDep, 'index.js'), external: false }
+    await expect(resolveId(plugin, { resolve: vi.fn().mockResolvedValue(inlined) }, 'dep', importer)).resolves.toBe(inlined)
+
+    const unresolvable = { id: 'does-not-exist', external: true }
+    await expect(resolveId(plugin, { resolve: vi.fn().mockResolvedValue(unresolvable) }, 'does-not-exist', importer)).resolves.toBe(unresolvable)
+  })
+
+  it('skips node builtins and ids without an importer', async () => {
+    const plugin = environmentPlugin()
+    const context = { resolve: vi.fn() }
+
+    await expect(resolveId(plugin, context, 'node:fs', importer)).resolves.toBeUndefined()
+    await expect(resolveId(plugin, context, 'fs', importer)).resolves.toBeUndefined()
+    await expect(resolveId(plugin, context, 'dep')).resolves.toBeUndefined()
+    expect(context.resolve).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['./relative.js', false],
+    ['/abs/path.js', false],
+    ['C:\\abs\\path.js', false],
+    ['\0virtual:nuxt', false],
+    ['virtual:nuxt', false],
+    ['#app', false],
+    ['~/foo', false],
+    ['dep', true],
+    ['@scope/dep/deep', true],
+  ])('filters %s', (id, matches) => {
+    const plugin = environmentPlugin()
+    expect(plugin.resolveId.filter.id.test(id)).toBe(matches)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2027,12 +2027,21 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/nuxt
     devDependencies:
+      '@babel/plugin-proposal-decorators':
+        specifier: catalog:dev
+        version: 8.0.2(@babel/core@8.0.1)
+      '@babel/plugin-syntax-jsx':
+        specifier: catalog:dev
+        version: 8.0.1(@babel/core@8.0.1)
       '@vue/devtools-api':
         specifier: catalog:dev
         version: 8.2.1
       defu:
         specifier: catalog:build
         version: 6.1.7
+      nested-dep:
+        specifier: file:./deps/nested-dep
+        version: file:test/fixtures/basic/deps/nested-dep
       postcss:
         specifier: catalog:build
         version: 8.5.28
@@ -9474,6 +9483,9 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  nested-dep@file:test/fixtures/basic/deps/nested-dep:
+    resolution: {directory: test/fixtures/basic/deps/nested-dep, type: directory}
 
   netlify-redirector@0.5.0:
     resolution: {integrity: sha512-4zdzIP+6muqPCuE8avnrgDJ6KW/2+UpHTRcTbMXCIRxiRmyrX+IZ4WSJGZdHPWF3WmQpXpy603XxecZ9iygN7w==}
@@ -20255,6 +20267,8 @@ snapshots:
   natural-orderby@5.0.0: {}
 
   neo-async@2.6.2: {}
+
+  nested-dep@file:test/fixtures/basic/deps/nested-dep: {}
 
   netlify-redirector@0.5.0: {}
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1709,6 +1709,14 @@ describe('server tree shaking', () => {
   })
 })
 
+describe('dependencies of code in node_modules', () => {
+  // https://github.com/nuxt/nuxt/issues/22077
+  it('resolves them from the importing package rather than the project', async () => {
+    const html = await $fetch<string>('/foo')
+    expect(html).toContain('Plugin | nested dependency: nested dependency of foo')
+  })
+})
+
 describe.skipIf(!runsOnceInMatrix)('extends support', () => {
   it('renders layer layout, page, component, middleware, composable and plugin together', async () => {
     const html = await $fetch<string>('/foo')

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -100,13 +100,12 @@ describe.skipIf(process.env.SKIP_BUNDLE_SIZE === 'true' || process.env.ECOSYSTEM
     const serverDir = join(pagesRootDir, '.output/server')
 
     const serverStats = await analyzeSizes(['**/*.mjs'], serverDir, pagesRootDir)
-    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"318k"`)
+    expect.soft(roundToKilobytes(serverStats.totalBytes)).toMatchInlineSnapshot(`"317k"`)
 
     const packages = getVendorPackages(await glob(['_libs/**/*'], { cwd: serverDir }))
     expect(packages).toMatchInlineSnapshot(`
       [
         "_vue/server-renderer+[...]",
-        "defu",
         "devalue",
         "h3+rou3+srvx",
         "hookable",

--- a/test/fixtures/basic/.gitignore
+++ b/test/fixtures/basic/.gitignore
@@ -1,1 +1,2 @@
 !extends/node_modules
+!extends/node_modules/foo/node_modules

--- a/test/fixtures/basic/deps/nested-dep/index.mjs
+++ b/test/fixtures/basic/deps/nested-dep/index.mjs
@@ -1,0 +1,1 @@
+export default 'nested dependency from the project'

--- a/test/fixtures/basic/deps/nested-dep/package.json
+++ b/test/fixtures/basic/deps/nested-dep/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "nested-dep",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "exports": "./index.mjs"
+}

--- a/test/fixtures/basic/extends/node_modules/foo/node_modules/nested-dep/index.mjs
+++ b/test/fixtures/basic/extends/node_modules/foo/node_modules/nested-dep/index.mjs
@@ -1,0 +1,1 @@
+export default 'nested dependency of foo'

--- a/test/fixtures/basic/extends/node_modules/foo/node_modules/nested-dep/package.json
+++ b/test/fixtures/basic/extends/node_modules/foo/node_modules/nested-dep/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "nested-dep",
+  "version": "2.0.0",
+  "type": "module",
+  "exports": "./index.mjs"
+}

--- a/test/fixtures/basic/extends/node_modules/foo/pages/foo.vue
+++ b/test/fixtures/basic/extends/node_modules/foo/pages/foo.vue
@@ -14,6 +14,7 @@ const foo = useExtendsFoo()
     <div>Middleware | foo: {{ $route.meta.foo }}</div>
     <div>Composable | useExtendsFoo: {{ foo }}</div>
     <div>Plugin | foo: {{ $foo() }}</div>
+    <div>Plugin | nested dependency: {{ $fooNestedDep() }}</div>
     <ExtendsFoo />
   </div>
 </template>

--- a/test/fixtures/basic/extends/node_modules/foo/plugins/foo.ts
+++ b/test/fixtures/basic/extends/node_modules/foo/plugins/foo.ts
@@ -1,7 +1,10 @@
+import nestedDep from 'nested-dep'
+
 export default defineNuxtPlugin(() => {
   return {
     provide: {
-      foo: () => 'String generated from foo plugin!'
+      foo: () => 'String generated from foo plugin!',
+      fooNestedDep: () => nestedDep,
     }
   }
 })

--- a/test/fixtures/basic/package.json
+++ b/test/fixtures/basic/package.json
@@ -11,8 +11,11 @@
     "nuxt": "workspace:*"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-decorators": "catalog:dev",
+    "@babel/plugin-syntax-jsx": "catalog:dev",
     "@vue/devtools-api": "catalog:dev",
     "defu": "catalog:build",
+    "nested-dep": "file:./deps/nested-dep",
     "postcss": "catalog:build",
     "ufo": "catalog:build",
     "unplugin": "catalog:build",


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/22077

### 📚 Description

this resolves bare externals from the location of their importer rather than from the project directory, meaning we resolve the right version of that dependency