### PR TITLE
fix(nitro): apply server replacements to prerenderer

### DIFF
--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -752,7 +752,7 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
   })
 
   if (nuxt.options.experimental.nitroViteEnvironment) {
-    // Nitro builds the prerenderer with its own bundler. The Vite `define` does not reach it.
+    // the vite `define` does not reach the prerenderer, which nitro bundles separately
     nitro.hooks.hook('prerender:config', (config) => {
       config.replace = { ...getServerReplacements(nuxt), ...config.replace }
     })

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -751,6 +751,13 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
     },
   })
 
+  if (nuxt.options.experimental.nitroViteEnvironment) {
+    // Nitro builds the prerenderer with its own bundler. The Vite `define` does not reach it.
+    nitro.hooks.hook('prerender:config', (config) => {
+      config.replace = { ...getServerReplacements(nuxt), ...config.replace }
+    })
+  }
+
   // Expose nitro to modules and kit
   nuxt._nitro = nitro
   setServerBuild({

--- a/packages/nitro-server/test/nitro-config.test.ts
+++ b/packages/nitro-server/test/nitro-config.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { resolve } from 'pathe'
+import { loadNuxt } from '@nuxt/kit'
+import type { NuxtConfig } from '@nuxt/schema'
+import type { Nitro, NitroConfig } from 'nitro/types'
+
+const fixtureDir = resolve(import.meta.dirname, '../../../test/fixtures/minimal')
+
+const serverReplacements = {
+  '__VUE_PROD_DEVTOOLS__': 'false',
+  'import.meta.test': 'false',
+}
+
+async function withNitro<T> (overrides: NuxtConfig, fn: (nitro: Nitro, nitroConfig: NitroConfig) => T | Promise<T>) {
+  let nitroConfig: NitroConfig | undefined
+  let nitro: Nitro | undefined
+  const nuxt = await loadNuxt({
+    cwd: fixtureDir,
+    ready: true,
+    overrides: {
+      ...overrides,
+      hooks: {
+        'nitro:config' (config) {
+          nitroConfig = config
+        },
+        'nitro:init' (_nitro) {
+          nitro = _nitro
+        },
+      },
+    },
+  })
+  try {
+    return await fn(nitro!, nitroConfig!)
+  } finally {
+    await nuxt.close()
+  }
+}
+
+describe('nitro config', () => {
+  it('passes the server replacements to nitro as `replace` without nitroViteEnvironment', async () => {
+    await withNitro({ experimental: { nitroViteEnvironment: false } }, (_nitro, nitroConfig) => {
+      expect(nitroConfig.replace).toMatchObject(serverReplacements)
+    })
+  })
+
+  it('leaves the server replacements to the vite `define` with nitroViteEnvironment', async () => {
+    await withNitro({ experimental: { nitroViteEnvironment: true } }, (_nitro, nitroConfig) => {
+      expect(nitroConfig.replace).not.toHaveProperty('__VUE_PROD_DEVTOOLS__')
+    })
+  })
+
+  it.for([true, false])('passes the server replacements to the prerenderer when nitroViteEnvironment is %s', async (nitroViteEnvironment) => {
+    await withNitro({ experimental: { nitroViteEnvironment } }, async (nitro) => {
+      // Nitro creates the prerenderer from a copy of this config after the hook.
+      const prerendererConfig: NitroConfig = { ...nitro.options._config }
+      await nitro.hooks.callHook('prerender:config', prerendererConfig)
+      expect(prerendererConfig.replace).toMatchObject(serverReplacements)
+    })
+  })
+})

--- a/packages/nitro-server/test/nitro-config.test.ts
+++ b/packages/nitro-server/test/nitro-config.test.ts
@@ -51,7 +51,7 @@ describe('nitro config', () => {
 
   it.for([true, false])('passes the server replacements to the prerenderer when nitroViteEnvironment is %s', async (nitroViteEnvironment) => {
     await withNitro({ experimental: { nitroViteEnvironment } }, async (nitro) => {
-      // Nitro creates the prerenderer from a copy of this config after the hook.
+      // nitro creates the prerenderer from a copy of this config
       const prerendererConfig: NitroConfig = { ...nitro.options._config }
       await nitro.hooks.callHook('prerender:config', prerendererConfig)
       expect(prerendererConfig.replace).toMatchObject(serverReplacements)

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -697,6 +697,11 @@ describe('pages', () => {
     expect(html).toContain('should be prerendered: true')
   })
 
+  it.skipIf(isDev)('substitutes the server compile-time constants in the prerenderer', async () => {
+    const html = await $fetch<string>('/prerender/import-meta-test')
+    expect(html).toContain('server test flag: true')
+  })
+
   it('renders pages with special characters in route', async () => {
     const html = await $fetch('/non-ascii/ç')
     // Verify page renders successfully with layout

--- a/test/fixtures/basic/app/pages/prerender/import-meta-test.vue
+++ b/test/fixtures/basic/app/pages/prerender/import-meta-test.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+const { data } = await useFetch('/api/import-meta-test')
+</script>
+
+<template>
+  <div>
+    server test flag: {{ String(data?.test) }}
+  </div>
+</template>

--- a/test/fixtures/basic/server/api/import-meta-test.ts
+++ b/test/fixtures/basic/server/api/import-meta-test.ts
@@ -1,0 +1,1 @@
+export default defineEventHandler(() => ({ test: import.meta.test }))

--- a/test/fixtures/nitro-vite-environment/app/app.vue
+++ b/test/fixtures/nitro-vite-environment/app/app.vue
@@ -1,3 +1,5 @@
 <template>
-  <div>nitro-vite-environment</div>
+  <div>
+    <NuxtPage />
+  </div>
 </template>

--- a/test/fixtures/nitro-vite-environment/app/pages/index.vue
+++ b/test/fixtures/nitro-vite-environment/app/pages/index.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>nitro-vite-environment</div>
+</template>

--- a/test/fixtures/nitro-vite-environment/server/api/string-literals.ts
+++ b/test/fixtures/nitro-vite-environment/server/api/string-literals.ts
@@ -1,0 +1,1 @@
+export default () => ({ vueFlag: 'flag __VUE_PROD_DEVTOOLS__ in a string' })

--- a/test/nitro-vite-environment.test.ts
+++ b/test/nitro-vite-environment.test.ts
@@ -1,12 +1,47 @@
 import http from 'node:http'
 import type { AddressInfo } from 'node:net'
+import { readFile } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { join } from 'pathe'
 import { buildNuxt, loadNuxt } from '@nuxt/kit'
 
 import { builder, isBuilt } from './matrix'
 
 const rootDir = fileURLToPath(new URL('./fixtures/nitro-vite-environment', import.meta.url))
+
+describe.skipIf(builder !== 'nitro-vite' || !isBuilt)('nitro/vite environment prerender', () => {
+  const outputDir = join(rootDir, 'node_modules/.cache/nuxt/.output-prerender')
+
+  beforeAll(async () => {
+    const nuxt = await loadNuxt({
+      cwd: rootDir,
+      ready: true,
+      overrides: {
+        buildDir: join(rootDir, 'node_modules/.cache/nuxt/.nuxt-prerender'),
+        nitro: {
+          output: { dir: outputDir },
+          prerender: { routes: ['/'] },
+          // Nitro bundles vue-router into the prerenderer. The bundle reads `__VUE_PROD_DEVTOOLS__`.
+          noExternals: ['vue-router'],
+        },
+      },
+    })
+    const nodeEnv = process.env.NODE_ENV
+    try {
+      // `nuxt build` sets this. The vue-router guard only reads the flag in production.
+      process.env.NODE_ENV = 'production'
+      await buildNuxt(nuxt)
+    } finally {
+      process.env.NODE_ENV = nodeEnv
+      await nuxt.close()
+    }
+  }, 240 * 1000)
+
+  it('prerenders a page that uses vue-router', async () => {
+    expect(await readFile(join(outputDir, 'public/index.html'), 'utf-8')).toContain('nitro-vite-environment')
+  })
+})
 
 describe.skipIf(builder !== 'nitro-vite' || isBuilt)('nitro/vite environment dev middleware', () => {
   let nuxt: Awaited<ReturnType<typeof import('@nuxt/kit').loadNuxt>>

--- a/test/nitro-vite-environment.test.ts
+++ b/test/nitro-vite-environment.test.ts
@@ -1,50 +1,12 @@
 import http from 'node:http'
 import type { AddressInfo } from 'node:net'
-import { existsSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
-import { join } from 'pathe'
 import { buildNuxt, loadNuxt } from '@nuxt/kit'
-import type { NitroConfig } from 'nitro/types'
 
 import { builder, isBuilt } from './matrix'
 
 const rootDir = fileURLToPath(new URL('./fixtures/nitro-vite-environment', import.meta.url))
-
-describe.skipIf(builder !== 'nitro-vite' || !isBuilt)('nitro/vite environment prerender', () => {
-  const outputDir = join(rootDir, 'node_modules/.cache/nuxt/.output-prerender')
-  let prerendererConfig: NitroConfig | undefined
-
-  beforeAll(async () => {
-    const nuxt = await loadNuxt({
-      cwd: rootDir,
-      ready: false,
-      overrides: {
-        buildDir: join(rootDir, 'node_modules/.cache/nuxt/.nuxt-prerender'),
-        nitro: { output: { dir: outputDir }, prerender: { routes: ['/'] } },
-      },
-    })
-    nuxt.hook('nitro:init', (nitro) => {
-      nitro.hooks.hook('prerender:config', (config) => { prerendererConfig = config })
-    })
-    try {
-      await nuxt.ready()
-      await buildNuxt(nuxt)
-    } finally {
-      await nuxt.close()
-    }
-  }, 240 * 1000)
-
-  it('passes the server replacements to the prerenderer', () => {
-    expect(prerendererConfig?.replace?.__VUE_PROD_DEVTOOLS__).toBe('false')
-    // vitest sets the `test` option. The value is not stable here.
-    expect(prerendererConfig?.replace?.['import.meta.test']).toMatch(/^(?:true|false)$/)
-  })
-
-  it('writes the prerendered route', () => {
-    expect(existsSync(join(outputDir, 'public/index.html'))).toBe(true)
-  })
-})
 
 describe.skipIf(builder !== 'nitro-vite' || isBuilt)('nitro/vite environment dev middleware', () => {
   let nuxt: Awaited<ReturnType<typeof import('@nuxt/kit').loadNuxt>>

--- a/test/nitro-vite-environment.test.ts
+++ b/test/nitro-vite-environment.test.ts
@@ -33,7 +33,11 @@ describe.skipIf(builder !== 'nitro-vite' || !isBuilt)('nitro/vite environment pr
       process.env.NODE_ENV = 'production'
       await buildNuxt(nuxt)
     } finally {
-      process.env.NODE_ENV = nodeEnv
+      if (nodeEnv === undefined) {
+        delete process.env.NODE_ENV
+      } else {
+        process.env.NODE_ENV = nodeEnv
+      }
       await nuxt.close()
     }
   }, 240 * 1000)

--- a/test/nitro-vite-environment.test.ts
+++ b/test/nitro-vite-environment.test.ts
@@ -22,14 +22,14 @@ describe.skipIf(builder !== 'nitro-vite' || !isBuilt)('nitro/vite environment pr
         nitro: {
           output: { dir: outputDir },
           prerender: { routes: ['/'] },
-          // Nitro bundles vue-router into the prerenderer. The bundle reads `__VUE_PROD_DEVTOOLS__`.
+          // inlining vue-router is what makes the prerenderer read `__VUE_PROD_DEVTOOLS__`
           noExternals: ['vue-router'],
         },
       },
     })
     const nodeEnv = process.env.NODE_ENV
     try {
-      // `nuxt build` sets this. The vue-router guard only reads the flag in production.
+      // vue-router only reads the flag in a production bundle
       process.env.NODE_ENV = 'production'
       await buildNuxt(nuxt)
     } finally {
@@ -82,5 +82,10 @@ describe.skipIf(builder !== 'nitro-vite' || isBuilt)('nitro/vite environment dev
     expect(res.headers.get('content-type')).toMatch(/(text|application)\/javascript/)
     // Drain so Vite doesn't hold the socket open and block server close.
     await res.arrayBuffer()
+  }, 120 * 1000)
+
+  it('does not substitute the server constants inside string literals', async () => {
+    const res = await fetch(`http://127.0.0.1:${port}/api/string-literals`)
+    await expect(res.json()).resolves.toEqual({ vueFlag: 'flag __VUE_PROD_DEVTOOLS__ in a string' })
   }, 120 * 1000)
 })

--- a/test/nitro-vite-environment.test.ts
+++ b/test/nitro-vite-environment.test.ts
@@ -1,12 +1,50 @@
 import http from 'node:http'
 import type { AddressInfo } from 'node:net'
+import { existsSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { join } from 'pathe'
 import { buildNuxt, loadNuxt } from '@nuxt/kit'
+import type { NitroConfig } from 'nitro/types'
 
 import { builder, isBuilt } from './matrix'
 
 const rootDir = fileURLToPath(new URL('./fixtures/nitro-vite-environment', import.meta.url))
+
+describe.skipIf(builder !== 'nitro-vite' || !isBuilt)('nitro/vite environment prerender', () => {
+  const outputDir = join(rootDir, 'node_modules/.cache/nuxt/.output-prerender')
+  let prerendererConfig: NitroConfig | undefined
+
+  beforeAll(async () => {
+    const nuxt = await loadNuxt({
+      cwd: rootDir,
+      ready: false,
+      overrides: {
+        buildDir: join(rootDir, 'node_modules/.cache/nuxt/.nuxt-prerender'),
+        nitro: { output: { dir: outputDir }, prerender: { routes: ['/'] } },
+      },
+    })
+    nuxt.hook('nitro:init', (nitro) => {
+      nitro.hooks.hook('prerender:config', (config) => { prerendererConfig = config })
+    })
+    try {
+      await nuxt.ready()
+      await buildNuxt(nuxt)
+    } finally {
+      await nuxt.close()
+    }
+  }, 240 * 1000)
+
+  it('passes the server replacements to the prerenderer', () => {
+    expect(prerendererConfig?.replace?.__VUE_PROD_DEVTOOLS__).toBe('false')
+    // vitest sets the `test` option. The value is not stable here.
+    expect(prerendererConfig?.replace?.['import.meta.test']).toMatch(/^(?:true|false)$/)
+  })
+
+  it('writes the prerendered route', () => {
+    expect(existsSync(join(outputDir, 'public/index.html'))).toBe(true)
+  })
+})
 
 describe.skipIf(builder !== 'nitro-vite' || isBuilt)('nitro/vite environment dev middleware', () => {
   let nuxt: Awaited<ReturnType<typeof import('@nuxt/kit').loadNuxt>>


### PR DESCRIPTION
### 🔗 Linked issue

resolves #36310

### 📚 Description

When `experimental.nitroViteEnvironment` is enabled, register a `prerender:config` hook that adds `getServerReplacements()` to the prerenderer's `replace` option.
