### PR TITLE
fix(nitro): allow importing from `#imports/server` when auto-imports are disabled

### DIFF
--- a/packages/nitro-server/src/auto-imports.ts
+++ b/packages/nitro-server/src/auto-imports.ts
@@ -104,13 +104,11 @@ export function createServerAutoImports (nuxt: Nuxt, options: ServerImportsOptio
     },
 
     async getImports () {
-      if (!enabled) { return [] }
       await init()
       return ctx.getImports()
     },
 
     async refresh () {
-      if (!enabled) { return }
       await init()
       resolvedTypePaths.clear()
       await ctx.modifyDynamicImports((imports) => {
@@ -123,27 +121,26 @@ export function createServerAutoImports (nuxt: Nuxt, options: ServerImportsOptio
     async writeTypes () {
       await mkdir(join(typesDir, 'types'), { recursive: true })
 
-      if (!enabled) {
-        await writeFile(importsModulePath + '.d.ts', 'export {}\n', 'utf8')
-        await writeFile(importsModulePath + '.mjs', 'export {}\n', 'utf8')
-        return
-      }
-
       await init()
       const imports = await ctx.getImports()
       resolveTypePaths(imports)
 
-      const declarations = await ctx.generateTypeDeclarations({
-        exportHelper: false,
-        resolvePath: i => resolvedTypePaths.get(i.typeFrom || i.from) ?? i.from,
-      })
+      // with `autoImport: false` nothing is injected, but the registered imports stay reachable
+      // through an explicit `import { x } from '#imports/server'`, so the module is still emitted;
+      // only the ambient global declarations are skipped
+      const declarations = enabled
+        ? await ctx.generateTypeDeclarations({
+            exportHelper: false,
+            resolvePath: i => resolvedTypePaths.get(i.typeFrom || i.from) ?? i.from,
+          })
+        : ''
 
       // the re-exports make this a module, so `import { x } from '#imports'` resolves as well as
       // the ambient `x` the declarations provide
       const reExports = toExports(imports, importsModuleDir, true)
 
       await Promise.all([
-        writeFile(importsModulePath + '.d.ts', [declarations.trim(), reExports.trim() || 'export {}', ''].join('\n'), 'utf8'),
+        writeFile(importsModulePath + '.d.ts', [declarations.trim(), reExports.trim() || 'export {}'].filter(Boolean).join('\n') + '\n', 'utf8'),
         writeFile(importsModulePath + '.mjs', (toExports(imports, importsModuleDir).trim() || 'export {}') + '\n', 'utf8'),
       ])
     },

--- a/packages/nitro-server/src/index.ts
+++ b/packages/nitro-server/src/index.ts
@@ -694,17 +694,18 @@ export async function bundle (nuxt: Nuxt & { _nitro?: Nitro }): Promise<void> {
         }))
       }
     }
-
-    // a file added to or removed from a scanned directory changes the auto-import set
-    const scannedDirs = (nitroConfig.imports as ServerImportsOptions).dirs ?? []
-    nuxt.hook('builder:watch', async (event, relativePath) => {
-      if (event !== 'add' && event !== 'unlink') { return }
-      const path = resolve(nuxt.options.srcDir, relativePath)
-      if (!scannedDirs.some(dir => path === dir || path.startsWith(dir + '/'))) { return }
-      await autoImports.refresh()
-      await autoImports.writeTypes()
-    })
   }
+
+  // a file added to or removed from a scanned directory changes the set of imports available
+  // through `#imports/server`, whether or not they are injected
+  const scannedDirs = (nitroConfig.imports as ServerImportsOptions).dirs ?? []
+  nuxt.hook('builder:watch', async (event, relativePath) => {
+    if (event !== 'add' && event !== 'unlink') { return }
+    const path = resolve(nuxt.options.srcDir, relativePath)
+    if (!scannedDirs.some(dir => path === dir || path.startsWith(dir + '/'))) { return }
+    await autoImports.refresh()
+    await autoImports.writeTypes()
+  })
 
   if (nitroConfig.static && nuxt.options.dev) {
     nitroConfig.routeRules ||= {}

--- a/packages/nitro-server/test/auto-imports.test.ts
+++ b/packages/nitro-server/test/auto-imports.test.ts
@@ -87,6 +87,26 @@ describe('createServerAutoImports', () => {
     expect(readFileSync(autoImports.importsModulePath + '.mjs', 'utf8')).toContain('export {}')
   })
 
+  it('still re-exports registered imports when auto-importing is disabled', async () => {
+    const typesDir = mkdtempSync(join(tmpdir(), 'server-auto-imports-'))
+    const autoImports = createServerAutoImports(
+      mockNuxt(),
+      { autoImport: false, imports: [{ name: 'withBaseURL', from: resolve(import.meta.dirname, '../src/runtime/utils/base.ts') }] },
+      typesDir,
+    )
+
+    await autoImports.writeTypes()
+
+    const module = readFileSync(autoImports.importsModulePath + '.mjs', 'utf8')
+    const declarations = readFileSync(autoImports.importsModulePath + '.d.ts', 'utf8')
+    expect(module).toContain('export { withBaseURL }')
+    expect(declarations).toContain('export { withBaseURL }')
+    expect(declarations).not.toContain('declare global')
+
+    const injected = await autoImports.injectImports('export default withBaseURL("/")', '/app/server/api/index.ts')
+    expect(injected).toBeUndefined()
+  })
+
   it('injects an import for an identifier used in a TypeScript-only expression', async () => {
     const typesDir = mkdtempSync(join(tmpdir(), 'server-auto-imports-'))
     const autoImports = createServerAutoImports(


### PR DESCRIPTION
### 🔗 Linked issue

resolves #36296

### 📚 Description

this fixes a regression in https://github.com/nuxt/nuxt/pull/36265 whereby we prevented `addServerImport` from registering imports _at all_ when auto-imports were disabled (when that option was only meant to stop the _injection_ from happening, and to continue to allow importing from `#imports` and `#imports/server`)