### PR TITLE
fix(nitro): drain oversized island body before rejecting it

### DIFF
--- a/packages/nitro-server/src/runtime/handlers/island.ts
+++ b/packages/nitro-server/src/runtime/handlers/island.ts
@@ -9,7 +9,7 @@ import { getQuery as getURLQuery } from 'ufo'
 import { FastResponse } from 'srvx'
 import { filterIslandProps, getIslandHash } from '#app/island-hash'
 import { findUnsafeIslandPropKey } from '#app/island-props'
-import { MAX_ISLAND_BODY_BYTES, exceedsMaxBytes, exceedsMaxDepth } from '../utils/island-props'
+import { MAX_ISLAND_BODY_BYTES, MAX_ISLAND_DRAIN_BYTES, exceedsMaxBytes, exceedsMaxDepth } from '../utils/island-props'
 import type { NuxtIslandContext, NuxtIslandResponse } from '#app/types'
 import { traceAsync } from '#app/internal/tracing'
 import { runtimeCompiler, tracingChannelNuxt } from '#internal/nuxt.config.mjs'
@@ -222,11 +222,27 @@ async function renderIsland (event: H3Event): Promise<IslandRenderResult> {
 
 const VALID_COMPONENT_NAME_RE = /^[a-z][\w.-]*$/i
 
+async function drainBody (event: H3Event) {
+  if (!event.req.body) { return }
+  const reader = event.req.body.getReader()
+  try {
+    for (;;) {
+      const { done } = await reader.read()
+      if (done) { break }
+    }
+  } finally {
+    reader.releaseLock()
+  }
+}
+
 // Read a non-GET island body, refusing oversized or deeply nested input before the JSON
 // parse and hash run on it.
 async function readGuardedIslandBody (event: H3Event): Promise<NuxtIslandContext> {
   const contentLength = Number(event.req.headers.get('content-length'))
   if (contentLength > MAX_ISLAND_BODY_BYTES) {
+    if (contentLength <= MAX_ISLAND_DRAIN_BYTES) {
+      await drainBody(event)
+    }
     throw new HTTPError({ status: 413, statusText: 'Island request body too large' })
   }
 

--- a/packages/nitro-server/src/runtime/utils/island-props.ts
+++ b/packages/nitro-server/src/runtime/utils/island-props.ts
@@ -9,6 +9,17 @@ export const MAX_ISLAND_BODY_BYTES = 64 * 1024
 export const MAX_ISLAND_PROP_DEPTH = 64
 
 /**
+ * Upper bound on an oversized body that is still read to completion before the 413 is sent.
+ * Replying while the upload is still in flight leaves the client (or a proxy in front of the
+ * server) with an unfinished request on the wire, which can stall and take down the keep-alive
+ * connection along with whatever is queued behind it. Above this size the body is refused
+ * without reading it.
+ *
+ * @internal
+ */
+export const MAX_ISLAND_DRAIN_BYTES = 4 * 1024 * 1024
+
+/**
  * Whether the bracket nesting of a JSON-ish string exceeds `maxDepth`, in a single linear
  * pass. Brackets inside string values are ignored.
  *

--- a/test/server-components.test.ts
+++ b/test/server-components.test.ts
@@ -1,13 +1,14 @@
+import { connect } from 'node:net'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { withQuery } from 'ufo'
 import { isWindows } from 'std-env'
 import { normalize } from 'pathe'
-import { $fetch, fetch, setup, startServer } from '@nuxt/test-utils/e2e'
+import { $fetch, fetch, setup, startServer, url } from '@nuxt/test-utils/e2e'
 import type { NuxtIslandResponse } from 'nuxt/app'
 import { getIslandHash, serializeIslandProps } from '../packages/nuxt/src/app/island-hash'
 import { MAX_VFOR_LENGTH } from '../packages/nuxt/src/app/components/vfor'
-import { MAX_ISLAND_BODY_BYTES } from '../packages/nitro-server/src/runtime/utils/island-props'
+import { MAX_ISLAND_BODY_BYTES, MAX_ISLAND_DRAIN_BYTES } from '../packages/nitro-server/src/runtime/utils/island-props'
 
 import { isDev, isWebpack } from './matrix'
 import { renderPage } from './utils'
@@ -674,6 +675,41 @@ describe('denial-of-service protections', () => {
       body: JSON.stringify({ props }),
     })
     expect(res.status).toBe(413)
+  })
+
+  it('keeps the connection usable after rejecting an oversized body', async () => {
+    const { hostname, port } = new URL(url('/'))
+    const oversized = 'x'.repeat(MAX_ISLAND_DRAIN_BYTES)
+    const nested = `{"props":${'['.repeat(500)}${']'.repeat(500)}}`
+    const request = (body: string) => [
+      'POST /__nuxt_island/PureComponent_deadbeef.json HTTP/1.1',
+      `Host: ${hostname}:${port}`,
+      'Content-Type: application/json',
+      `Content-Length: ${Buffer.byteLength(body)}`,
+      '',
+      body,
+    ].join('\r\n')
+
+    const statuses = await new Promise<string[]>((resolve, reject) => {
+      const socket = connect(Number(port), hostname)
+      let received = ''
+      socket.on('data', (chunk) => {
+        received += chunk.toString()
+        const statuses = [...received.matchAll(/^HTTP\/1\.1 (\d{3})/gm)].map(m => m[1]!)
+        if (statuses.length === 2) {
+          socket.end()
+          resolve(statuses)
+        }
+      })
+      socket.on('error', reject)
+      socket.on('close', () => reject(new Error(`connection closed after: ${received.split('\r\n')[0]}`)))
+      socket.on('connect', () => {
+        socket.write(request(oversized))
+        socket.write(request(nested))
+      })
+    })
+
+    expect(statuses).toEqual(['413', '400'])
   })
 
   it('rejects an oversized chunked island body without content-length', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

we've had a number of flaky tests (caught with [flakiness.io](https://flakiness.io/)) that seem to be related to undrained body, so this reads the rest of the body (but doesn't process it or hold it in memory).