### PR TITLE
fix(kit,nuxt): fail the build when a template never finishes compiling

### DIFF
--- a/packages/kit/src/diagnostics/build.ts
+++ b/packages/kit/src/diagnostics/build.ts
@@ -116,5 +116,10 @@ export const buildDiagnostics = /* #__PURE__ */ defineDiagnostics({
       fix: 'If you are a module author, ensure the `export` you register for a component is a valid identifier. Otherwise, please report this issue.',
       docs: false,
     },
+    NUXT_B1022: {
+      why: (p: { count: number, templates: string }) => `The build stopped with ${p.count} template${p.count === 1 ? '' : 's'} still compiling:\n  - ${p.templates}`,
+      fix: 'A `getContents` function returned a promise that never settles. Resolve it during the build (from `nitro:init` at the latest), rather than waiting on something that happens after it.',
+      docs: false,
+    },
   },
 })

--- a/packages/kit/src/internal/index.ts
+++ b/packages/kit/src/internal/index.ts
@@ -19,6 +19,8 @@ export { configDiagnostics } from '../diagnostics/config.ts'
 export { headDiagnostics } from '../diagnostics/head.ts'
 export { bundlerDiagnostics } from '../diagnostics/bundler.ts'
 
+export { reportPendingTemplates, trackPendingTemplate } from './pending-templates.ts'
+
 export { loadJiti } from './jiti.ts'
 
 export { parseNodeModulePath } from './node-module.ts'

--- a/packages/kit/src/internal/pending-templates.ts
+++ b/packages/kit/src/internal/pending-templates.ts
@@ -1,0 +1,37 @@
+import process from 'node:process'
+
+import { buildDiagnostics } from '../diagnostics/build.ts'
+
+const pending = new Map<symbol, string>()
+
+/** @internal */
+export function reportPendingTemplates (): boolean {
+  if (pending.size === 0) {
+    return false
+  }
+  const filenames = [...new Set(pending.values())]
+  buildDiagnostics.NUXT_B1022({
+    count: filenames.length,
+    templates: filenames.map(filename => `\`${filename}\``).join('\n  - '),
+  }, { method: 'error' })
+  process.exitCode ||= 1
+  return true
+}
+
+process.on('beforeExit', reportPendingTemplates)
+
+/**
+ * Nothing else keeps the event loop alive during a build, so a template whose contents never
+ * resolve would otherwise let the process drain and exit 0 with no output.
+ *
+ * @internal
+ */
+export async function trackPendingTemplate<T> (filename: string, getContents: () => T | Promise<T>): Promise<T> {
+  const token = Symbol(filename)
+  pending.set(token, filename)
+  try {
+    return await getContents()
+  } finally {
+    pending.delete(token)
+  }
+}

--- a/packages/kit/test/pending-templates.test.ts
+++ b/packages/kit/test/pending-templates.test.ts
@@ -1,0 +1,49 @@
+import process from 'node:process'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { buildDiagnostics } from '../src/diagnostics/build.ts'
+import { reportPendingTemplates, trackPendingTemplate } from '../src/internal/pending-templates.ts'
+
+describe('trackPendingTemplate', () => {
+  const exitCode = process.exitCode
+  const settle: Array<() => void> = []
+
+  afterEach(async () => {
+    while (settle.length) { settle.pop()!() }
+    await Promise.resolve()
+    process.exitCode = exitCode
+    vi.restoreAllMocks()
+  })
+
+  /** A template left pending for the duration of a single test. */
+  function hang (filename: string) {
+    void trackPendingTemplate(filename, () => new Promise<string>(resolve => settle.push(() => resolve(''))))
+  }
+
+  it('reports nothing once every template has settled', async () => {
+    expect(await trackPendingTemplate('settles.mjs', () => 'contents')).toBe('contents')
+    await expect(trackPendingTemplate('rejects.mjs', () => Promise.reject(new Error('nope')))).rejects.toThrow('nope')
+
+    expect(reportPendingTemplates()).toBe(false)
+    expect(process.exitCode).toBe(exitCode)
+  })
+
+  it('fails the process for a template whose contents never settle', () => {
+    const report = vi.spyOn(buildDiagnostics, 'NUXT_B1022').mockImplementation(() => ({}) as any)
+    hang('never-settles.mjs')
+
+    expect(reportPendingTemplates()).toBe(true)
+    expect(report.mock.calls[0]![0]).toMatchObject({ count: 1, templates: '`never-settles.mjs`' })
+    expect(process.exitCode).toBe(1)
+  })
+
+  it('tracks templates sharing a filename independently', async () => {
+    const report = vi.spyOn(buildDiagnostics, 'NUXT_B1022').mockImplementation(() => ({}) as any)
+    hang('dup.mjs')
+    expect(await trackPendingTemplate('dup.mjs', () => 'contents')).toBe('contents')
+
+    expect(reportPendingTemplates()).toBe(true)
+    expect(report.mock.calls[0]![0]).toMatchObject({ count: 1, templates: '`dup.mjs`' })
+    expect(process.exitCode).toBe(1)
+  })
+})

--- a/packages/nuxt/src/core/app.ts
+++ b/packages/nuxt/src/core/app.ts
@@ -5,7 +5,7 @@ import { dirname, join, resolve } from 'pathe'
 import { defu } from 'defu'
 import { Diagnostic } from 'nostics'
 import { findPath, getLayerDirectories, normalizePlugin, normalizeTemplate, resolveFiles, resolvePath } from '@nuxt/kit'
-import { buildDiagnostics, pageDiagnostics, pluginDiagnostics } from '@nuxt/kit/internal'
+import { buildDiagnostics, pageDiagnostics, pluginDiagnostics, trackPendingTemplate } from '@nuxt/kit/internal'
 
 import { linkToAlias, logger } from '../utils.ts'
 import * as defaultTemplates from './templates.ts'
@@ -90,7 +90,7 @@ export async function generateApp (nuxt: Nuxt, app: NuxtApp, options: { filter?:
     const fullPath = template.dst || resolve(nuxt.options.buildDir, template.filename!)
     const start = performance.now()
     const oldContents = nuxt.vfs[fullPath]
-    const contents = await compileTemplate(template, templateContext).catch((e) => {
+    const contents = await trackPendingTemplate(template.filename!, () => compileTemplate(template, templateContext)).catch((e) => {
       // already-coded template failures (e.g. B1002/B1003) were reported in `compileTemplate`
       if (!(e instanceof Diagnostic)) {
         buildDiagnostics.NUXT_B1001({ filename: template.filename!, src: template.src, cause: e })

--- a/test/hung-template.test.ts
+++ b/test/hung-template.test.ts
@@ -1,0 +1,34 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { afterAll, describe, expect, it } from 'vitest'
+import { exec } from 'tinyexec'
+import { join } from 'pathe'
+import { projectSuffix, runsOnceInMatrix } from './matrix'
+
+describe.skipIf(!runsOnceInMatrix)('a template whose contents never resolve', () => {
+  const rootDir = fileURLToPath(new URL(`./fixtures/.hung-template-${projectSuffix}`, import.meta.url))
+
+  afterAll(() => {
+    rmSync(rootDir, { recursive: true, force: true })
+  })
+
+  it('fails the build and names the template', async () => {
+    mkdirSync(rootDir, { recursive: true })
+    writeFileSync(join(rootDir, 'package.json'), JSON.stringify({ private: true, type: 'module', name: 'fixture-hung-template' }))
+    writeFileSync(join(rootDir, 'app.vue'), `<template><div>hung</div></template>`)
+    writeFileSync(join(rootDir, 'nuxt.config.mjs'), [
+      `export default {`,
+      `  modules: [(_options, nuxt) => {`,
+      `    nuxt.options.build.templates.push({ filename: 'never-settles.mjs', getContents: () => new Promise(() => {}) })`,
+      `  }],`,
+      `}`,
+    ].join('\n'))
+
+    const result = await exec('pnpm', ['nuxt', 'build', rootDir], { throwOnError: false })
+    const output = result.stdout + result.stderr
+
+    expect(result.exitCode).not.toBe(0)
+    expect(output).toContain('NUXT_B1022')
+    expect(output).toContain('never-settles.mjs')
+  }, 120 * 1000)
+})


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

spotted this when looking at https://github.com/nuxt/nuxt/pull/36318 - it was possible to get a _success_ exit code if a template failed to compile