### PR TITLE
fix(kit): register the base path of a wildcard route on nitro v2

### DIFF
--- a/docs/4.api/5.kit/12.nitro.md
+++ b/docs/4.api/5.kit/12.nitro.md
@@ -34,7 +34,7 @@ export default defineNuxtModule({
 ### Type
 
 ```ts
-function addServerHandler (handler: NitroEventHandler): void
+function addServerHandler (handler: ServerHandlerInput): void
 ```
 
 ### Parameters
@@ -43,11 +43,17 @@ function addServerHandler (handler: NitroEventHandler): void
 
 | Property     | Type      | Required | Description                                                                                                                                   |
 |--------------|-----------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------|
-| `handler`    | `string`  | `true`   | Path to event handler.                                                                                                                        |
-| `route`      | `string`  | `false`  | Path prefix or route. If an empty string used, will be used as a middleware.                                                                  |
+| `handler`    | `string \| { nuxt?: string, nitro2?: string, nitro3?: string }`  | `true`   | Path to the event handler, or one path per server API. Nuxt registers the implementation the application's server can run.                     |
+| `route`      | `string`  | `false`  | The route to match, exactly. End it in `/**` to match the paths below it as well. If an empty string is used, the handler is registered as middleware. |
 | `middleware` | `boolean` | `false`  | Specifies this is a middleware handler. Middleware are called on every route and should normally return nothing to pass to the next handlers. |
 | `lazy`       | `boolean` | `false`  | Use lazy loading to import the handler. This is useful when you only want to load the handler on demand.                                      |
 | `method`     | `string`  | `false`  | Router method matcher. If handler name contains method name, it will be used as a default value.                                              |
+
+A route ending in `/**` matches its base path too, so `route: '/_fonts/**'` serves `/_fonts` and everything below it. On a Nitro 2 host, whose router matches only the paths below the base, Nuxt registers the base path as a second route so that one registration behaves the same on both.
+
+::read-more{to="/docs/4.x/guide/modules/server-compatibility"}
+Learn when to register one path per server API, and which key to write your handler against.
+::
 
 ### Example
 
@@ -117,11 +123,8 @@ export default defineNuxtModule({
 
 ### Type
 
-```ts twoslash
-// @errors: 2391
-import type { NitroDevEventHandler } from 'nitro/types'
-// ---cut---
-function addDevServerHandler (handler: NitroDevEventHandler): void
+```ts
+function addDevServerHandler (handler: DevServerHandlerInput): void
 ```
 
 ### Parameters

--- a/packages/kit/src/nitro.ts
+++ b/packages/kit/src/nitro.ts
@@ -97,6 +97,31 @@ function withVariantMeta<T extends object, V> (entry: T, resolved: ResolvedVaria
 }
 
 const HANDLER_METHOD_RE = /\.(get|head|patch|post|put|delete|connect|options|trace|query)(\.\w+)*$/
+const WILDCARD_SUFFIX_RE = /\/\*\*(?::\w+)?$/
+
+/**
+ * h3 v1 routes with radix3, where `/fonts/**` matches every path below `/fonts` but not
+ * `/fonts` itself; h3 v2 routes with rou3, where it matches both. A second registration on
+ * the base path gives one wildcard route the same reach on either, and rou3 prefers the
+ * static route, so the pair is unambiguous where both are registered.
+ *
+ * Not applied to middleware, which nitro v2 mounts with `app.use()` and so already runs on
+ * the base path, nor to `/**`, whose base would shadow the renderer on `/`.
+ */
+function addLegacyBaseRoute (nuxt: Nuxt, entry: ServerHandler, resolved: ResolvedVariant<string>): void {
+  const route = entry.route
+  if (!route || entry.middleware || getNitroVersion(nuxt) !== 2) {
+    return
+  }
+  const base = route.replace(WILDCARD_SUFFIX_RE, '')
+  if (base === route || !base || base === '/') {
+    return
+  }
+  const duplicate = nuxt.options.serverHandlers.some(handler => handler.route === base && handler.handler === entry.handler && handler.method === entry.method)
+  if (!duplicate) {
+    nuxt.options.serverHandlers.push(withVariantMeta({ ...entry, route: base }, resolved))
+  }
+}
 
 /**
  * Adds a server handler.
@@ -124,11 +149,13 @@ export function addServerHandler (handler: ServerHandlerInput): void {
   }
   // retrieve method from handler file name
   const [, method = undefined] = resolved.value.match(HANDLER_METHOD_RE) || []
-  nuxt.options.serverHandlers.push(withVariantMeta({
+  const entry: ServerHandler = {
     method: method?.toUpperCase() as ServerHandler['method'],
     ...handler,
     handler: resolved.value,
-  }, resolved))
+  }
+  nuxt.options.serverHandlers.push(withVariantMeta(entry, resolved))
+  addLegacyBaseRoute(nuxt, entry, resolved)
 }
 
 /**

--- a/packages/kit/src/nitro.ts
+++ b/packages/kit/src/nitro.ts
@@ -105,6 +105,8 @@ const WILDCARD_SUFFIX_RE = /\/\*\*(?::\w+)?$/
  * the base path gives one wildcard route the same reach on either, and rou3 prefers the
  * static route, so the pair is unambiguous where both are registered.
  *
+ * A handler already registered on the base path keeps it.
+ *
  * Not applied to middleware, which nitro v2 mounts with `app.use()` and so already runs on
  * the base path, nor to `/**`, whose base would shadow the renderer on `/`.
  */
@@ -117,8 +119,8 @@ function addLegacyBaseRoute (nuxt: Nuxt, entry: ServerHandler, resolved: Resolve
   if (base === route || !base || base === '/') {
     return
   }
-  const duplicate = nuxt.options.serverHandlers.some(handler => handler.route === base && handler.handler === entry.handler && handler.method === entry.method)
-  if (!duplicate) {
+  const occupied = nuxt.options.serverHandlers.some(handler => handler.route === base && (!handler.method || !entry.method || handler.method === entry.method))
+  if (!occupied) {
     nuxt.options.serverHandlers.push(withVariantMeta({ ...entry, route: base }, resolved))
   }
 }

--- a/packages/kit/test/nitro.test.ts
+++ b/packages/kit/test/nitro.test.ts
@@ -257,8 +257,24 @@ describe('addServerHandler', () => {
       // and the author may have registered the pair themselves
       addServerHandler({ route: '/_icons', handler: '/handlers/icons.ts' })
       addServerHandler({ route: '/_icons/**', handler: '/handlers/icons.ts' })
+      // or given the base path to a different handler entirely, which keeps the route
+      addServerHandler({ route: '/_img', handler: '/handlers/img-meta.ts' })
+      addServerHandler({ route: '/_img/**', handler: '/handlers/img.ts' })
     })
-    expect(nuxt.options.serverHandlers.map(handler => handler.route)).toEqual(['/**', '/_mw/**', '/_icons', '/_icons/**'])
+    expect(nuxt.options.serverHandlers.map(handler => handler.route)).toEqual(['/**', '/_mw/**', '/_icons', '/_icons/**', '/_img', '/_img/**'])
+  })
+
+  it('adds a base route where an existing handler on it takes another method', () => {
+    const nuxt = createMockNuxt('2.11.0')
+    runWithNuxtContext(nuxt, () => {
+      addServerHandler({ route: '/_icons', method: 'post', handler: '/handlers/icons-upload.ts' })
+      addServerHandler({ route: '/_icons/**', method: 'get', handler: '/handlers/icons.ts' })
+    })
+    expect(nuxt.options.serverHandlers).toMatchObject([
+      { route: '/_icons', method: 'post' },
+      { route: '/_icons/**', method: 'get' },
+      { route: '/_icons', method: 'get', handler: '/handlers/icons.ts' },
+    ])
   })
 
   it('takes the filename convention from the implementation it registered', () => {

--- a/packages/kit/test/nitro.test.ts
+++ b/packages/kit/test/nitro.test.ts
@@ -229,6 +229,38 @@ describe('addServerHandler', () => {
     report.mockRestore()
   })
 
+  it('registers the base path of a wildcard route on a nitro v2 host', () => {
+    // h3 v1 routes with radix3, where `/_fonts/**` does not match `/_fonts` itself
+    const nuxt = createMockNuxt('2.11.0')
+    runWithNuxtContext(nuxt, () => addServerHandler({ route: '/_fonts/**', handler: { nitro2: '/handlers/fonts.v2.ts', nuxt: '/handlers/fonts.ts' } }))
+    expect(nuxt.options.serverHandlers).toMatchObject([
+      { route: '/_fonts/**', handler: '/handlers/fonts.v2.ts' },
+      { route: '/_fonts', handler: '/handlers/fonts.v2.ts' },
+    ])
+    expect(serverApiOf(nuxt.options.serverHandlers[1]!)).toBe('nitro2')
+    expect(unusedVariantsOf(nuxt.options.serverHandlers[1]!)).toEqual(['/handlers/fonts.ts'])
+  })
+
+  it('leaves a wildcard route alone where the host router matches the base path', () => {
+    const nuxt = createMockNuxt('3.0.1')
+    runWithNuxtContext(nuxt, () => addServerHandler({ route: '/_fonts/**', handler: '/handlers/fonts.ts' }))
+    expect(nuxt.options.serverHandlers.map(handler => handler.route)).toEqual(['/_fonts/**'])
+  })
+
+  it('does not add a base route that would shadow another handler', () => {
+    const nuxt = createMockNuxt('2.11.0')
+    runWithNuxtContext(nuxt, () => {
+      // `/**` would give the renderer's own route to the module
+      addServerHandler({ route: '/**', handler: '/handlers/catch-all.ts' })
+      // middleware is mounted with `app.use()` in nitro v2, so it runs on the base already
+      addServerHandler({ route: '/_mw/**', middleware: true, handler: '/handlers/mw.ts' })
+      // and the author may have registered the pair themselves
+      addServerHandler({ route: '/_icons', handler: '/handlers/icons.ts' })
+      addServerHandler({ route: '/_icons/**', handler: '/handlers/icons.ts' })
+    })
+    expect(nuxt.options.serverHandlers.map(handler => handler.route)).toEqual(['/**', '/_mw/**', '/_icons', '/_icons/**'])
+  })
+
   it('takes the filename convention from the implementation it registered', () => {
     const nuxt = createMockNuxt('3.0.1')
     runWithNuxtContext(nuxt, () => addServerHandler({ handler: { nitro2: '/handlers/test.post.ts' } }))


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this adds handling to match the behaviour of routes in radix3 (where a prefix also served subpaths, and where a wildcard did _not_ include the base)