### PR TITLE
fix(kit): respect method when checking for existing handlers

### DIFF
--- a/packages/kit/src/nitro.ts
+++ b/packages/kit/src/nitro.ts
@@ -105,7 +105,8 @@ const WILDCARD_SUFFIX_RE = /\/\*\*(?::\w+)?$/
  * the base path gives one wildcard route the same reach on either, and rou3 prefers the
  * static route, so the pair is unambiguous where both are registered.
  *
- * A handler already registered on the base path keeps it.
+ * A handler already registered on the base path for the same method keeps it: a
+ * method-specific handler there does not answer the other methods the wildcard covers.
  *
  * Not applied to middleware, which nitro v2 mounts with `app.use()` and so already runs on
  * the base path, nor to `/**`, whose base would shadow the renderer on `/`.
@@ -119,7 +120,7 @@ function addLegacyBaseRoute (nuxt: Nuxt, entry: ServerHandler, resolved: Resolve
   if (base === route || !base || base === '/') {
     return
   }
-  const occupied = nuxt.options.serverHandlers.some(handler => handler.route === base && (!handler.method || !entry.method || handler.method === entry.method))
+  const occupied = nuxt.options.serverHandlers.some(handler => handler.route === base && (!handler.method || handler.method === entry.method))
   if (!occupied) {
     nuxt.options.serverHandlers.push(withVariantMeta({ ...entry, route: base }, resolved))
   }

--- a/packages/kit/test/nitro.test.ts
+++ b/packages/kit/test/nitro.test.ts
@@ -277,6 +277,19 @@ describe('addServerHandler', () => {
     ])
   })
 
+  it('adds a base route for a methodless wildcard where the handler on it takes one method', () => {
+    const nuxt = createMockNuxt('2.11.0')
+    runWithNuxtContext(nuxt, () => {
+      addServerHandler({ route: '/_icons', method: 'post', handler: '/handlers/icons-upload.ts' })
+      addServerHandler({ route: '/_icons/**', handler: '/handlers/icons.ts' })
+    })
+    expect(nuxt.options.serverHandlers).toMatchObject([
+      { route: '/_icons', method: 'post' },
+      { route: '/_icons/**', method: undefined },
+      { route: '/_icons', method: undefined, handler: '/handlers/icons.ts' },
+    ])
+  })
+
   it('takes the filename convention from the implementation it registered', () => {
     const nuxt = createMockNuxt('3.0.1')
     runWithNuxtContext(nuxt, () => addServerHandler({ handler: { nitro2: '/handlers/test.post.ts' } }))


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

follow up on https://github.com/nuxt/nuxt/pull/36325