### PR TITLE
fix(kit): do not exclude module directories with a dot in their name from app tsconfig

### DIFF
--- a/packages/kit/src/template.ts
+++ b/packages/kit/src/template.ts
@@ -10,6 +10,7 @@ import { readPackageJSON } from './internal/package-json.ts'
 import { resolveModulePath } from 'exsolve'
 import { captureStackTrace } from 'errx'
 
+import { DEFAULT_JS_FILE_EXTENSIONS } from './constants.ts'
 import { distDirURL, filterInPlace } from './utils.ts'
 import { directoryToURL } from './internal/esm.ts'
 import { resolveDeclarationPath } from './types.ts'
@@ -186,7 +187,11 @@ interface LayerPaths {
   globalDeclarations: string[]
 }
 
-export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: string): LayerPaths {
+function moduleFileGlobs (dir: string, extensions: string[]): string[] {
+  return extensions.map(ext => join(dir, `*${ext}`))
+}
+
+export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: string, extensions: string[] = DEFAULT_JS_FILE_EXTENSIONS): LayerPaths {
   const relativeRootDir = relativeWithDot(projectBuildDir, dirs.root)
   const relativeSrcDir = relativeWithDot(projectBuildDir, dirs.app)
   const relativeModulesDir = relativeWithDot(projectBuildDir, dirs.modules)
@@ -208,13 +213,13 @@ export function resolveLayerPaths (dirs: LayerDirectories, projectBuildDir: stri
       join(relativeRootDir, `layers/*/modules/*/runtime/server/**/*`),
     ],
     node: [
-      join(relativeModulesDir, `*.*`),
+      ...moduleFileGlobs(relativeModulesDir, extensions),
       join(relativeRootDir, `nuxt.config.*`),
       join(relativeRootDir, `.config/nuxt.*`),
       join(relativeRootDir, `layers/*/nuxt.config.*`),
       join(relativeRootDir, `layers/*/.config/nuxt.*`),
-      join(relativeRootDir, `layers/*/modules/*.*`),
-      join(relativeRootDir, `layers/*/modules/*/*.*`),
+      ...moduleFileGlobs(join(relativeRootDir, 'layers/*/modules'), extensions),
+      ...moduleFileGlobs(join(relativeRootDir, 'layers/*/modules/*'), extensions),
     ],
     shared: [
       join(relativeSharedDir, `**/*`),
@@ -344,7 +349,7 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
   for (const dirs of layerDirs) {
     if (!dirs.app.startsWith(rootDirWithSlash) || dirs.root === rootDirWithSlash || dirs.app.includes('node_modules')) {
       const rootGlob = join(relativeWithDot(typesDir, dirs.root), '**/*')
-      const paths = resolveLayerPaths(dirs, typesDir)
+      const paths = resolveLayerPaths(dirs, typesDir, nuxt.options.extensions)
       for (const path of paths.nuxt) {
         include.add(path)
         legacyInclude.add(path)
@@ -405,10 +410,16 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
 
   for (const path of modulePaths) {
     const relative = relativeWithDot(typesDir, path)
+    const entryGlobs = [
+      ...moduleFileGlobs(relative, nuxt.options.extensions),
+      ...moduleFileGlobs(join(relative, 'dist'), nuxt.options.extensions),
+    ]
     if (!path.includes('node_modules') && path.startsWith(rootDirWithSlash)) {
       include.add(join(relative, 'runtime'))
       include.add(join(relative, 'dist/runtime'))
-      nodeInclude.add(join(relative, '*.*'))
+      for (const glob of moduleFileGlobs(relative, nuxt.options.extensions)) {
+        nodeInclude.add(glob)
+      }
     }
 
     legacyInclude.add(join(relative, 'runtime'))
@@ -420,13 +431,15 @@ export async function _generateTypes (nuxt: Nuxt): Promise<GenerateTypesReturn> 
     serverInclude.add(join(relative, 'runtime/server'))
     serverInclude.add(join(relative, 'dist/runtime/server'))
 
-    serverExclude.add(join(relative, '*.*'))
-    serverExclude.add(join(relative, 'dist/*.*'))
+    for (const glob of entryGlobs) {
+      serverExclude.add(glob)
+    }
 
     exclude.add(join(relative, 'runtime/server'))
     exclude.add(join(relative, 'dist/runtime/server'))
-    exclude.add(join(relative, '*.*'))
-    exclude.add(join(relative, 'dist/*.*'))
+    for (const glob of entryGlobs) {
+      exclude.add(glob)
+    }
     legacyExclude.add(join(relative, 'runtime/server'))
     legacyExclude.add(join(relative, 'dist/runtime/server'))
   }

--- a/packages/kit/test/generate-types.spec.ts
+++ b/packages/kit/test/generate-types.spec.ts
@@ -99,15 +99,50 @@ describe('tsConfig generation', () => {
         "../modules/*/runtime/server/**/*",
         "../layers/*/server/**/*",
         "../layers/*/modules/*/runtime/server/**/*",
-        "../modules/*.*",
+        "../modules/*.mjs",
+        "../modules/*.js",
+        "../modules/*.cjs",
+        "../modules/*.mts",
+        "../modules/*.ts",
+        "../modules/*.cts",
+        "../modules/*.tsx",
+        "../modules/*.jsx",
         "../nuxt.config.*",
         "../.config/nuxt.*",
         "../layers/*/nuxt.config.*",
         "../layers/*/.config/nuxt.*",
-        "../layers/*/modules/*.*",
-        "../layers/*/modules/*/*.*",
+        "../layers/*/modules/*.mjs",
+        "../layers/*/modules/*.js",
+        "../layers/*/modules/*.cjs",
+        "../layers/*/modules/*.mts",
+        "../layers/*/modules/*.ts",
+        "../layers/*/modules/*.cts",
+        "../layers/*/modules/*.tsx",
+        "../layers/*/modules/*.jsx",
+        "../layers/*/modules/*/*.mjs",
+        "../layers/*/modules/*/*.js",
+        "../layers/*/modules/*/*.cjs",
+        "../layers/*/modules/*/*.mts",
+        "../layers/*/modules/*/*.ts",
+        "../layers/*/modules/*/*.cts",
+        "../layers/*/modules/*/*.tsx",
+        "../layers/*/modules/*/*.jsx",
       ]
     `)
+  })
+
+  it('should not exclude module directories with a dot in their name', async () => {
+    // TypeScript applies `exclude` globs to directories too, so a bare `modules/*.*` would also
+    // match a module directory such as `modules/1.dotted/` and drop its runtime files
+    const { tsConfig, nodeTsConfig } = await _generateTypes(mockNuxtWithOptions({
+      _installedModules: [{ meta: { name: 'dotted-module', rawPath: '/my-app/modules/1.dotted/index.ts' }, entryPath: '/my-app/modules/1.dotted/index.ts', timings: {} }],
+    }))
+
+    expect(tsConfig.include).toContain('../modules/1.dotted/runtime')
+    expect(tsConfig.exclude).not.toEqual(expect.arrayContaining([expect.stringMatching(/\*\.\*$/)]))
+    expect(tsConfig.exclude).toEqual(expect.arrayContaining(['../modules/*.ts', '../modules/1.dotted/*.ts']))
+    expect(nodeTsConfig.include).toEqual(expect.arrayContaining(['../modules/*.ts', '../modules/1.dotted/*.ts']))
+    expect(nodeTsConfig.include).not.toEqual(expect.arrayContaining([expect.stringMatching(/\*\.\*$/)]))
   })
 
   it('should not exclude layer module runtime files from app tsconfig', async () => {
@@ -393,13 +428,34 @@ describe('resolveLayerPaths', async () => {
           "../layers/*/*.d.ts",
         ],
         "node": [
-          "../custom-modules/*.*",
+          "../custom-modules/*.mjs",
+          "../custom-modules/*.js",
+          "../custom-modules/*.cjs",
+          "../custom-modules/*.mts",
+          "../custom-modules/*.ts",
+          "../custom-modules/*.cts",
+          "../custom-modules/*.tsx",
+          "../custom-modules/*.jsx",
           "../nuxt.config.*",
           "../.config/nuxt.*",
           "../layers/*/nuxt.config.*",
           "../layers/*/.config/nuxt.*",
-          "../layers/*/modules/*.*",
-          "../layers/*/modules/*/*.*",
+          "../layers/*/modules/*.mjs",
+          "../layers/*/modules/*.js",
+          "../layers/*/modules/*.cjs",
+          "../layers/*/modules/*.mts",
+          "../layers/*/modules/*.ts",
+          "../layers/*/modules/*.cts",
+          "../layers/*/modules/*.tsx",
+          "../layers/*/modules/*.jsx",
+          "../layers/*/modules/*/*.mjs",
+          "../layers/*/modules/*/*.js",
+          "../layers/*/modules/*/*.cjs",
+          "../layers/*/modules/*/*.mts",
+          "../layers/*/modules/*/*.ts",
+          "../layers/*/modules/*/*.cts",
+          "../layers/*/modules/*/*.tsx",
+          "../layers/*/modules/*/*.jsx",
         ],
         "nuxt": [
           "../app/**/*",


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/nuxt/issues/36330

### 📚 Description

This replaces the bare `*.*` globs with one glob per extension from `nuxt.options.extensions`. The same change applies to the `layers/*/modules` globs and the per-module excludes in the app, node and server tsconfigs.

Example for a project with `modules/1.first/` and `modules/plain/`, extensions trimmed for brevity.

**Before**, `.nuxt/tsconfig.app.json`:

```json
"exclude": [
  "../modules/*.*",
  "../modules/1.first/*.*",
  "../modules/plain/*.*"
]
```

**After**:

```json
"exclude": [
  "../modules/*.mjs",
  "../modules/*.js",
  "../modules/*.ts",
  "../modules/*.vue",
  "../modules/1.first/*.mjs",
  "../modules/1.first/*.js",
  "../modules/1.first/*.ts",
  "../modules/1.first/*.vue",
  "../modules/plain/*.mjs",
  "../modules/plain/*.js",
  "../modules/plain/*.ts",
  "../modules/plain/*.vue"
]
```

P.S. Maybe it is a good idea to also add a fixture with a dotted module directory?