### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/docs/4.api/6.nuxt-config.md
+++ b/docs/4.api/6.nuxt-config.md
@@ -161,6 +161,27 @@ This can be set to a different value at runtime by setting the `NUXT_APP_CDN_URL
 NUXT_APP_CDN_URL=https://mycdn.org/ node .output/server/index.mjs
 ```
 
+### `buildAssetsCrossOrigin`
+
+CORS mode for SSR-rendered tags that load build assets (`<script>`, `<link rel="stylesheet">`, `<link rel="modulepreload">`, and related resource hints).
+
+The default (`''`) emits a bare `crossorigin` attribute, which is anonymous CORS. Set `'use-credentials'` when assets are served from another origin that requires cookies (for example Cloudflare Under Attack Mode).
+
+This does not change Vite's client-side dynamic `modulepreload` injection.
+
+- **Type**: `'' | 'anonymous' | 'use-credentials'`
+- **Default:** `""`
+
+**Example**:
+```ts
+export default defineNuxtConfig({
+  app: {
+    cdnURL: 'https://mycdn.org/',
+    buildAssetsCrossOrigin: 'use-credentials',
+  },
+})
+```
+
 ### `head`
 
 Set default configuration for `<head>` on every page.

--- a/packages/kit/src/internal/renderer.ts
+++ b/packages/kit/src/internal/renderer.ts
@@ -51,6 +51,7 @@ export type RendererConfigName =
   | 'NUXT_SSR_STREAMING'
   | 'NUXT_SSR_STREAMING_BOT_RE'
   | 'appHead'
+  | 'appBuildAssetsCrossOrigin'
   | 'appRootTag'
   | 'appRootAttrs'
   | 'appTeleportTag'
@@ -113,6 +114,7 @@ export function getRendererConfig (options: RendererConfigOptions = {}, nuxt: Nu
     NUXT_SSR_STREAMING: String(streamingEnabled),
     NUXT_SSR_STREAMING_BOT_RE: streamingEnabled && streaming.botRegex instanceof RegExp ? String(streaming.botRegex) : '/^$/',
     appHead: JSON.stringify(app.head),
+    appBuildAssetsCrossOrigin: JSON.stringify(app.buildAssetsCrossOrigin ?? ''),
     appRootTag: JSON.stringify(app.rootTag),
     appRootAttrs: JSON.stringify(app.rootAttrs),
     appTeleportTag: JSON.stringify(app.teleportTag),

--- a/packages/kit/test/renderer.test.ts
+++ b/packages/kit/test/renderer.test.ts
@@ -79,6 +79,25 @@ describe('getRendererConfig', () => {
     expect(code).toContain('export const spaTemplate = "<span/>"')
   })
 
+  it('inlines app.buildAssetsCrossOrigin', () => {
+    const anonymous = getRendererConfig({}, nuxt())
+    expect(anonymous).toContain('export const appBuildAssetsCrossOrigin = ""')
+
+    const credentials = getRendererConfig({}, nuxt({
+      app: {
+        head: { title: 'app' },
+        rootTag: 'div',
+        rootAttrs: { id: '__nuxt' },
+        teleportTag: 'div',
+        teleportAttrs: { id: 'teleports' },
+        spaLoaderTag: 'div',
+        spaLoaderAttrs: { id: '__nuxt-loader' },
+        buildAssetsCrossOrigin: 'use-credentials',
+      },
+    }))
+    expect(credentials).toContain('export const appBuildAssetsCrossOrigin = "use-credentials"')
+  })
+
   it('re-exports the head module templates rather than inlining their values', () => {
     const code = getRendererConfig({}, nuxt())
 

--- a/packages/nitro-server/src/runtime/handlers/island.ts
+++ b/packages/nitro-server/src/runtime/handlers/island.ts
@@ -14,6 +14,7 @@ import type { NuxtIslandContext, NuxtIslandResponse } from '#app/types'
 import { traceAsync } from '#app/internal/tracing'
 import { runtimeCompiler, tracingChannelNuxt } from '#internal/nuxt.config.mjs'
 import { serverDiagnostics } from '../diagnostics'
+import { appBuildAssetsCrossOrigin } from 'nuxt/internal/renderer-config'
 import { createSSRContext, rethrowWithResponseHeaders, returnRenderResponse } from 'nuxt/internal/renderer/app'
 import { renderInlineStyles } from 'nuxt/internal/renderer/inline-styles'
 import { getClientIslandResponse, getServerComponentHTML, getSlotIslandResponse } from 'nuxt/internal/renderer/islands'
@@ -187,7 +188,7 @@ async function renderIsland (event: H3Event): Promise<IslandRenderResult> {
       // The dev CSS set covers the whole module graph, so restrict it to the styles of the
       // components this island rendered.
       if (isStyleOfModule(resource.file, modules)) {
-        link.push({ rel: 'stylesheet', href: renderer.rendererContext.buildAssetsURL(resource.file), crossorigin: '' })
+        link.push({ rel: 'stylesheet', href: renderer.rendererContext.buildAssetsURL(resource.file), crossorigin: appBuildAssetsCrossOrigin })
       }
     }
     if (link.length) {

--- a/packages/nuxt/src/runtime/server/renderer-config.ts
+++ b/packages/nuxt/src/runtime/server/renderer-config.ts
@@ -49,6 +49,8 @@ export const NUXT_SSR_STREAMING_BOT_RE: RegExp = /^$/
 
 /** Head entries configured in `app.head`. */
 export const appHead: SerializableHead = {}
+/** CORS mode for SSR-rendered build-asset tags. */
+export const appBuildAssetsCrossOrigin: '' | 'anonymous' | 'use-credentials' = ''
 export const appRootTag: string = 'div'
 export const appRootAttrs: Record<string, string> = { id: '__nuxt' }
 export const appTeleportTag: string = 'div'

--- a/packages/nuxt/src/runtime/server/renderer/crossorigin.ts
+++ b/packages/nuxt/src/runtime/server/renderer/crossorigin.ts
@@ -1,0 +1,38 @@
+/**
+ * CORS mode for SSR-rendered build-asset tags. Matches the HTML `crossorigin` attribute.
+ */
+export type BuildAssetsCrossOrigin = '' | 'anonymous' | 'use-credentials'
+
+/**
+ * Rewrite vue-bundle-renderer resource hints that currently use anonymous CORS
+ * so they match the configured {@link BuildAssetsCrossOrigin}.
+ *
+ * Hints with `crossorigin: null` (no CORS) are left unchanged.
+ */
+export function applyBuildAssetsCrossOrigin<T extends { crossorigin?: string | null }> (
+  links: Iterable<T>,
+  value: BuildAssetsCrossOrigin,
+): T[] {
+  const result: T[] = []
+  for (const link of links) {
+    if (value && (link.crossorigin === '' || link.crossorigin === 'anonymous')) {
+      result.push({ ...link, crossorigin: value })
+    } else {
+      result.push(link)
+    }
+  }
+  return result
+}
+
+/** HTML attribute fragment for tags interpolated outside unhead (streaming stylesheets). */
+export function buildAssetsCrossoriginHtmlAttr (value: BuildAssetsCrossOrigin): string {
+  return value ? ` crossorigin="${value}"` : ' crossorigin'
+}
+
+/** Rewrite `crossorigin` tokens on HTTP `Link` headers from vue-bundle-renderer. */
+export function applyBuildAssetsCrossOriginHeader (header: string, value: BuildAssetsCrossOrigin): string {
+  if (!value) {
+    return header
+  }
+  return header.replaceAll('; crossorigin', `; crossorigin="${value}"`)
+}

--- a/packages/nuxt/src/runtime/server/renderer/index.ts
+++ b/packages/nuxt/src/runtime/server/renderer/index.ts
@@ -26,11 +26,12 @@ import { renderStreamedIslandTeleports, replaceIslandTeleports } from './islands
 import { rendererDiagnostics } from './diagnostics'
 import { warnNoScriptsClientReliance } from './no-scripts'
 import { extractCspNonce } from './csp-nonce'
+import { applyBuildAssetsCrossOrigin, applyBuildAssetsCrossOriginHeader, buildAssetsCrossoriginHtmlAttr } from './crossorigin'
 import { addPrerenderRoutes, appEvent, getRequestState } from './runtime'
 import { createRendererInstance } from './instance'
 import type { NuxtRendererInstance } from './instance'
 import type { NuxtRendererOptions, RendererEvent, RendererRouteRules } from './runtime'
-import { NUXT_EARLY_404, NUXT_EARLY_HINTS, NUXT_INLINE_STYLES, NUXT_NO_SCRIPTS, NUXT_NO_SCRIPTS_PATTERNS, NUXT_NO_SCRIPTS_PROD, NUXT_PAGE_PATTERNS, NUXT_PAYLOAD_EXTRACTION, NUXT_PAYLOAD_INLINE, NUXT_PRERENDER_ERROR_PAGES, NUXT_RUNTIME_PAYLOAD_EXTRACTION, NUXT_SSR_STREAMING, NUXT_SSR_STREAMING_BOT_RE, NUXT_VIEW_TRANSITIONS, PARSE_ERROR_DATA, appHead, appTeleportAttrs, appTeleportTag, componentIslands, componentIslandsActive, iifeChunkFileName, renderSSRHeadOptions, tracingChannelNuxt } from 'nuxt/internal/renderer-config'
+import { NUXT_EARLY_404, NUXT_EARLY_HINTS, NUXT_INLINE_STYLES, NUXT_NO_SCRIPTS, NUXT_NO_SCRIPTS_PATTERNS, NUXT_NO_SCRIPTS_PROD, NUXT_PAGE_PATTERNS, NUXT_PAYLOAD_EXTRACTION, NUXT_PAYLOAD_INLINE, NUXT_PRERENDER_ERROR_PAGES, NUXT_RUNTIME_PAYLOAD_EXTRACTION, NUXT_SSR_STREAMING, NUXT_SSR_STREAMING_BOT_RE, NUXT_VIEW_TRANSITIONS, PARSE_ERROR_DATA, appBuildAssetsCrossOrigin, appHead, appTeleportAttrs, appTeleportTag, componentIslands, componentIslandsActive, iifeChunkFileName, renderSSRHeadOptions, tracingChannelNuxt } from 'nuxt/internal/renderer-config'
 import entryIds from 'nuxt/internal/entry-ids'
 import { entryFileName } from 'nuxt/internal/entry-chunk'
 
@@ -340,7 +341,7 @@ async function renderRoute (instance: NuxtRendererInstance, event: RendererEvent
     // Add CSS links in <head> for CSS files
     // - in production
     // - in dev mode when not rendering an island
-    link.push({ rel: 'stylesheet', href: renderer.rendererContext.buildAssetsURL(resource.file), crossorigin: '' })
+    link.push({ rel: 'stylesheet', href: renderer.rendererContext.buildAssetsURL(resource.file), crossorigin: appBuildAssetsCrossOrigin })
   }
 
   if (link.length) {
@@ -367,12 +368,12 @@ async function renderRoute (instance: NuxtRendererInstance, event: RendererEvent
       }
     }
     const hints: Link[] = []
-    for (const l of getPreloadLinks(ssrContext, renderer.rendererContext, dependencyOptions) as Link[]) {
+    for (const l of applyBuildAssetsCrossOrigin(getPreloadLinks(ssrContext, renderer.rendererContext, dependencyOptions) as Link[], appBuildAssetsCrossOrigin)) {
       if (!excludeHrefs.has(l.href)) {
         hints.push(l)
       }
     }
-    for (const l of getPrefetchLinks(ssrContext, renderer.rendererContext, dependencyOptions) as Link[]) {
+    for (const l of applyBuildAssetsCrossOrigin(getPrefetchLinks(ssrContext, renderer.rendererContext, dependencyOptions) as Link[], appBuildAssetsCrossOrigin)) {
       if (!excludeHrefs.has(l.href)) {
         hints.push(l)
       }
@@ -404,7 +405,7 @@ async function renderRoute (instance: NuxtRendererInstance, event: RendererEvent
         // if we are rendering script tag payloads that import an async payload
         // we need to ensure this resolves before executing the Nuxt entry
         tagPosition: 'head',
-        crossorigin: '',
+        crossorigin: appBuildAssetsCrossOrigin,
       })),
     })
   }
@@ -457,7 +458,7 @@ async function renderStreamedResponse (ctx: {
   // 1. Set HTTP Link headers with entry-point preload hints (fastest resource hinting)
   const { link: linkHeader } = renderResourceHeaders({}, renderer.rendererContext)
   if (linkHeader) {
-    event.res.headers.append('link', linkHeader)
+    event.res.headers.append('link', applyBuildAssetsCrossOriginHeader(linkHeader, appBuildAssetsCrossOrigin))
   }
 
   // 2. Pre-compute entry-point inline styles for the shell
@@ -475,7 +476,7 @@ async function renderStreamedResponse (ctx: {
   const shellLinks: Link[] = []
   for (const resource of Object.values(entryStyles)) {
     if (import.meta.dev && 'inline' in getURLQuery(resource.file)) { continue }
-    shellLinks.push({ rel: 'stylesheet', href: renderer.rendererContext.buildAssetsURL(resource.file), crossorigin: '' })
+    shellLinks.push({ rel: 'stylesheet', href: renderer.rendererContext.buildAssetsURL(resource.file), crossorigin: appBuildAssetsCrossOrigin })
   }
   if (shellLinks.length) {
     ssrContext.head.push({ link: shellLinks })
@@ -498,10 +499,10 @@ async function renderStreamedResponse (ctx: {
   // Entry preload/prefetch links
   if (!NO_SCRIPTS) {
     ssrContext.head.push({
-      link: getPreloadLinks({}, renderer.rendererContext) as Link[],
+      link: applyBuildAssetsCrossOrigin(getPreloadLinks({}, renderer.rendererContext) as Link[], appBuildAssetsCrossOrigin),
     })
     ssrContext.head.push({
-      link: getPrefetchLinks({}, renderer.rendererContext) as Link[],
+      link: applyBuildAssetsCrossOrigin(getPrefetchLinks({}, renderer.rendererContext) as Link[], appBuildAssetsCrossOrigin),
     })
   }
 
@@ -513,7 +514,7 @@ async function renderStreamedResponse (ctx: {
         src: renderer.rendererContext.buildAssetsURL(resource.file),
         defer: resource.module ? null : true,
         tagPosition: 'head',
-        crossorigin: '',
+        crossorigin: appBuildAssetsCrossOrigin,
       })),
     })
   }
@@ -697,7 +698,7 @@ async function renderStreamedResponse (ctx: {
       if (emittedStyles.has(resource.file)) { continue }
       if (import.meta.dev && 'inline' in getURLQuery(resource.file)) { continue }
       emittedStyles.add(resource.file)
-      tags += `<link rel="stylesheet" crossorigin href="${renderer.rendererContext.buildAssetsURL(resource.file)}">`
+      tags += `<link rel="stylesheet"${buildAssetsCrossoriginHtmlAttr(appBuildAssetsCrossOrigin)} href="${renderer.rendererContext.buildAssetsURL(resource.file)}">`
     }
     return tags
   }

--- a/packages/nuxt/test/renderer/crossorigin.test.ts
+++ b/packages/nuxt/test/renderer/crossorigin.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import { applyBuildAssetsCrossOrigin, applyBuildAssetsCrossOriginHeader, buildAssetsCrossoriginHtmlAttr } from '../../src/runtime/server/renderer/crossorigin.ts'
+
+describe('applyBuildAssetsCrossOrigin', () => {
+  const hints = [
+    { rel: 'modulepreload', href: '/_nuxt/entry.js', crossorigin: '' as const },
+    { rel: 'preload', href: '/_nuxt/entry.css', as: 'style', crossorigin: '' as const },
+    { rel: 'preload', href: '/_nuxt/font.woff2', as: 'font', crossorigin: 'anonymous' as const },
+    { rel: 'preload', href: '/img.png', as: 'image', crossorigin: null },
+  ]
+
+  it('leaves anonymous CORS unchanged by default', () => {
+    expect(applyBuildAssetsCrossOrigin(hints, '')).toEqual(hints)
+  })
+
+  it('rewrites anonymous hints to use-credentials when configured', () => {
+    expect(applyBuildAssetsCrossOrigin(hints, 'use-credentials')).toEqual([
+      { rel: 'modulepreload', href: '/_nuxt/entry.js', crossorigin: 'use-credentials' },
+      { rel: 'preload', href: '/_nuxt/entry.css', as: 'style', crossorigin: 'use-credentials' },
+      { rel: 'preload', href: '/_nuxt/font.woff2', as: 'font', crossorigin: 'use-credentials' },
+      { rel: 'preload', href: '/img.png', as: 'image', crossorigin: null },
+    ])
+  })
+
+  it('emits explicit anonymous when that value is configured', () => {
+    expect(applyBuildAssetsCrossOrigin(hints, 'anonymous').map(h => h.crossorigin)).toEqual([
+      'anonymous',
+      'anonymous',
+      'anonymous',
+      null,
+    ])
+  })
+})
+
+describe('buildAssetsCrossoriginHtmlAttr', () => {
+  it('keeps a bare crossorigin attribute for the default anonymous mode', () => {
+    expect(buildAssetsCrossoriginHtmlAttr('')).toBe(' crossorigin')
+  })
+
+  it('emits use-credentials when configured', () => {
+    expect(buildAssetsCrossoriginHtmlAttr('use-credentials')).toBe(' crossorigin="use-credentials"')
+    expect(buildAssetsCrossoriginHtmlAttr('anonymous')).toBe(' crossorigin="anonymous"')
+  })
+})
+
+describe('applyBuildAssetsCrossOriginHeader', () => {
+  const header = '</_nuxt/entry.js>; rel="modulepreload"; crossorigin, </img.png>; rel="preload"; as="image"'
+
+  it('leaves Link headers unchanged by default', () => {
+    expect(applyBuildAssetsCrossOriginHeader(header, '')).toBe(header)
+  })
+
+  it('rewrites crossorigin tokens when credentials are required', () => {
+    expect(applyBuildAssetsCrossOriginHeader(header, 'use-credentials'))
+      .toBe('</_nuxt/entry.js>; rel="modulepreload"; crossorigin="use-credentials", </img.png>; rel="preload"; as="image"')
+  })
+})

--- a/packages/schema/src/config/app.ts
+++ b/packages/schema/src/config/app.ts
@@ -72,6 +72,15 @@ export default defineResolvers({
       },
     },
 
+    buildAssetsCrossOrigin: {
+      $resolve: (val) => {
+        if (val === 'anonymous' || val === 'use-credentials' || val === '') {
+          return val
+        }
+        return ''
+      },
+    },
+
     head: {
       $resolve: (_val) => {
         const val: Partial<NuxtAppConfig['head']> = _val && typeof _val === 'object' ? _val : {}

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -2,7 +2,7 @@
 export type { NuxtCompatibility, NuxtCompatibilityIssue, NuxtCompatibilityIssues } from './types/compatibility.ts'
 export type { Component, ComponentMeta, ComponentsDir, ComponentsOptions, ScanDir } from './types/components.ts'
 export type { NuxtCompilerOptions, KeyedFunction, KeyedFunctionFactory, CompilerScanDir } from './types/compiler.ts'
-export type { AppConfig, AppConfigInput, CustomAppConfig, DefineNuxtConfig, NuxtAppConfig, NuxtBuilder, NuxtConfig, NuxtConfigInput, NuxtOptions, PublicRuntimeConfig, RuntimeConfig, RuntimeConfigApp, RuntimeValue, SchemaDefinition, SharedAppConfig, UpperSnakeCase, ViteConfig, VitePlugin, ViteOptions, WebpackConfig, WebpackPluginInstance, ViewTransitionOptions, ViewTransitionPageOptions } from './types/config.ts'
+export type { AppConfig, AppConfigInput, BuildAssetsCrossOrigin, CustomAppConfig, DefineNuxtConfig, NuxtAppConfig, NuxtBuilder, NuxtConfig, NuxtConfigInput, NuxtOptions, PublicRuntimeConfig, RuntimeConfig, RuntimeConfigApp, RuntimeValue, SchemaDefinition, SharedAppConfig, UpperSnakeCase, ViteConfig, VitePlugin, ViteOptions, WebpackConfig, WebpackPluginInstance, ViewTransitionOptions, ViewTransitionPageOptions } from './types/config.ts'
 export type { NuxtConfigLayer, NuxtConfigLayerMeta, NuxtDotenvOptions, NuxtLayerSourceOptions } from './types/layers.ts'
 // eslint-disable-next-line @typescript-eslint/no-deprecated
 export type { ImportPresetWithDeprecation } from './types/hooks.ts'

--- a/packages/schema/src/types/config.ts
+++ b/packages/schema/src/types/config.ts
@@ -50,6 +50,15 @@ type RuntimeConfigNamespace = Record<string, unknown>
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface PublicRuntimeConfig extends RuntimeConfigNamespace { }
 
+/**
+ * CORS mode for SSR-rendered tags that load build assets
+ * (`<script>`, `<link rel="stylesheet">`, `<link rel="modulepreload">`).
+ *
+ * Matches the HTML `crossorigin` attribute: `''` and `'anonymous'` are the
+ * anonymous CORS mode; `'use-credentials'` sends cookies with the request.
+ */
+export type BuildAssetsCrossOrigin = '' | 'anonymous' | 'use-credentials'
+
 /** Runtime configuration of the app itself, set at build time from `app` and `buildId`. */
 export interface RuntimeConfigApp extends RuntimeConfigNamespace {
   /** The base path the app is served from. */

--- a/packages/schema/src/types/schema.ts
+++ b/packages/schema/src/types/schema.ts
@@ -34,7 +34,7 @@ import type { ModuleMeta, NuxtModule } from './module.ts'
 import type { NuxtDebugOptions } from './debug.ts'
 import type { Nuxt, NuxtPlugin, NuxtTemplate } from './nuxt.ts'
 import type { SerializableHtmlAttributes } from './head.ts'
-import type { NuxtAppConfig, NuxtOptions, RuntimeConfig, Serializable, SharedAppConfig, ViewTransitionOptions, ViteOptions } from './config.ts'
+import type { BuildAssetsCrossOrigin, NuxtAppConfig, NuxtOptions, RuntimeConfig, Serializable, SharedAppConfig, ViewTransitionOptions, ViteOptions } from './config.ts'
 import type { NuxtIgnoreOptions } from './ignore.ts'
 import type { ImportsOptions } from './imports.ts'
 import type { ComponentsOptions } from './components.ts'
@@ -203,6 +203,20 @@ export interface ConfigSchema {
      * ```
      */
     cdnURL: string
+
+    /**
+     * CORS mode for SSR-rendered tags that load build assets (`<script>`,
+     * `<link rel="stylesheet">`, `<link rel="modulepreload">`, and related resource hints).
+     *
+     * The default (`''`) emits a bare `crossorigin` attribute, which is anonymous CORS
+     * (the previous behaviour). Set `'use-credentials'` when assets are served from another
+     * origin that requires cookies, such as Cloudflare Under Attack Mode.
+     *
+     * This does not change Vite's client-side dynamic `modulepreload` injection.
+     *
+     * @default ''
+     */
+    buildAssetsCrossOrigin: BuildAssetsCrossOrigin
 
     /**
      * Set default configuration for `<head>` on every page.

--- a/packages/schema/test/build-assets-cross-origin.spec.ts
+++ b/packages/schema/test/build-assets-cross-origin.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest'
+import { applyDefaults } from 'untyped'
+
+import { NuxtConfigSchema } from '../src/index.ts'
+import type { NuxtOptions } from '../src/index.ts'
+
+vi.mock('node:fs', () => ({
+  existsSync: (id: string) => id.endsWith('app'),
+}))
+
+describe('app.buildAssetsCrossOrigin', () => {
+  it('defaults to anonymous CORS (empty string)', async () => {
+    const result = await applyDefaults(NuxtConfigSchema, {})
+    expect((result as unknown as NuxtOptions).app.buildAssetsCrossOrigin).toBe('')
+  })
+
+  it('accepts use-credentials and anonymous', async () => {
+    const credentials = await applyDefaults(NuxtConfigSchema, { app: { buildAssetsCrossOrigin: 'use-credentials' } })
+    expect((credentials as unknown as NuxtOptions).app.buildAssetsCrossOrigin).toBe('use-credentials')
+
+    const anonymous = await applyDefaults(NuxtConfigSchema, { app: { buildAssetsCrossOrigin: 'anonymous' } })
+    expect((anonymous as unknown as NuxtOptions).app.buildAssetsCrossOrigin).toBe('anonymous')
+  })
+
+  it('falls back to the default for unknown values', async () => {
+    const result = await applyDefaults(NuxtConfigSchema, { app: { buildAssetsCrossOrigin: 'invalid' as never } })
+    expect((result as unknown as NuxtOptions).app.buildAssetsCrossOrigin).toBe('')
+  })
+})

--- a/test/renderer/standalone.test.ts
+++ b/test/renderer/standalone.test.ts
@@ -58,6 +58,9 @@ describe('renderer without a server builder', () => {
     expect(html).toContain(`<script type="importmap">{"imports":{"#entry":"${BUILD_ASSETS_DIR}`)
     expect(html).toContain(`<script type="module" src="${BUILD_ASSETS_DIR}`)
     expect(html).not.toContain('src="/_nuxt/')
+    expect(html).toMatch(/<script type="module"[^>]* crossorigin>/)
+    expect(html).toMatch(/rel="modulepreload"[^>]* crossorigin/)
+    expect(html).not.toContain('crossorigin="use-credentials"')
   })
 
   it('serves the client-only shell for a route the rules opt out of ssr', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

Refs #30003

### ❓ Type of change

- [x] ✨ New feature (non-breaking change which adds functionality)

### 📚 Description

Adds `app.buildAssetsCrossOrigin` (`''` | `'anonymous'` | `'use-credentials'`) so Nitro SSR head tags for build assets can send cookies when JS/CSS is served from another origin/CDN (e.g. Cloudflare Under Attack Mode). Default remains anonymous CORS (bare `crossorigin`).

Covers SSR `<script>`, `<link rel="modulepreload">`, stylesheets, related resource hints, and streaming `Link` headers. Vite client-side dynamic `modulepreload` is unchanged (still needs a Vite plugin; noted as follow-up). Separate from `experimental.crossOriginPrefetch`.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.

Drafted with Cursor (Grok); reviewed before opening.
