### PR TITLE
fix(nuxt): widen `nuxt/server` helper event types

### DIFF
--- a/packages/nuxt/src/server/index.ts
+++ b/packages/nuxt/src/server/index.ts
@@ -85,6 +85,13 @@ export function toNuxtRequestEvent (event: RequestEvent): NuxtRequestEvent {
 
 export { createError, NuxtError }
 
+type EventWithRequest = Pick<RequestEvent, 'req'>
+
+/** `url` is optional because a runtime need not parse it up front; the request always carries it. */
+type EventWithURL = EventWithRequest & { url?: URL }
+
+type EventWithResponse = Pick<RequestEvent, 'res'>
+
 /**
  * The shape shared by every HTTP error reachable in server code: the ones
  * {@link createError} constructs, and the ones the server runtime throws for
@@ -130,8 +137,8 @@ export function isNuxtError<DataT = unknown> (error: unknown): error is NuxtErro
  *
  * @since 5.0.0
  */
-export function getRequestURL (event: RequestEvent): URL {
-  return event.url
+export function getRequestURL (event: EventWithURL): URL {
+  return event.url ?? new URL(event.req.url)
 }
 
 /**
@@ -141,7 +148,7 @@ export function getRequestURL (event: RequestEvent): URL {
  *
  * @since 5.0.0
  */
-export function getRequestHeader (event: RequestEvent, name: string): string | undefined {
+export function getRequestHeader (event: EventWithRequest, name: string): string | undefined {
   return event.req.headers.get(name) ?? undefined
 }
 
@@ -150,7 +157,7 @@ export function getRequestHeader (event: RequestEvent, name: string): string | u
  *
  * @since 5.0.0
  */
-export function getRequestHeaders (event: RequestEvent): Record<string, string> {
+export function getRequestHeaders (event: EventWithRequest): Record<string, string> {
   return Object.fromEntries(event.req.headers)
 }
 
@@ -159,7 +166,7 @@ export function getRequestHeaders (event: RequestEvent): Record<string, string> 
  *
  * @since 5.0.0
  */
-export function setResponseStatus (event: RequestEvent, status: number, statusText?: string): void {
+export function setResponseStatus (event: EventWithResponse, status: number, statusText?: string): void {
   const res = event.res
   res.status = status
   if (statusText !== undefined) {
@@ -172,7 +179,7 @@ export function setResponseStatus (event: RequestEvent, status: number, statusTe
  *
  * @since 5.0.0
  */
-export function setResponseHeader (event: RequestEvent, name: string, value: string): void {
+export function setResponseHeader (event: EventWithResponse, name: string, value: string): void {
   event.res.headers.set(name, value)
 }
 
@@ -181,7 +188,7 @@ export function setResponseHeader (event: RequestEvent, name: string, value: str
  *
  * @since 5.0.0
  */
-export function setResponseHeaders (event: RequestEvent, headers: Record<string, string>): void {
+export function setResponseHeaders (event: EventWithResponse, headers: Record<string, string>): void {
   const target = event.res.headers
   for (const name in headers) {
     target.set(name, headers[name]!)
@@ -194,8 +201,8 @@ export function setResponseHeaders (event: RequestEvent, headers: Record<string,
  *
  * @since 5.0.0
  */
-export function getQuery<T extends Record<string, unknown> = Record<string, string | string[]>> (event: RequestEvent): T {
-  return parseQuery(event.url.search) as T
+export function getQuery<T extends Record<string, unknown> = Record<string, string | string[]>> (event: EventWithURL): T {
+  return parseQuery(getRequestURL(event).search) as T
 }
 
 /**
@@ -210,7 +217,7 @@ export function getQuery<T extends Record<string, unknown> = Record<string, stri
  *
  * @since 5.0.0
  */
-export async function readBody<T = unknown> (event: RequestEvent): Promise<T> {
+export async function readBody<T = unknown> (event: EventWithRequest): Promise<T> {
   const request = event.req
   const contentType = request.headers.get('content-type') || ''
   const text = await request.text()
@@ -251,7 +258,7 @@ function collectEntries (entries: Iterable<[string, string]>): Record<string, st
  *
  * @since 5.0.0
  */
-export function getCookie (event: RequestEvent, name: string): string | undefined {
+export function getCookie (event: EventWithRequest, name: string): string | undefined {
   const header = event.req.headers.get('cookie')
   return header ? parse(header)[name] : undefined
 }
@@ -262,7 +269,7 @@ export function getCookie (event: RequestEvent, name: string): string | undefine
  *
  * @since 5.0.0
  */
-export function setCookie (event: RequestEvent, name: string, value: string, options?: CookieSerializeOptions): void {
+export function setCookie (event: EventWithResponse, name: string, value: string, options?: CookieSerializeOptions): void {
   event.res.headers.append('set-cookie', serialize(name, value, { path: '/', ...options }))
 }
 
@@ -272,7 +279,7 @@ export function setCookie (event: RequestEvent, name: string, value: string, opt
  *
  * @since 5.0.0
  */
-export function deleteCookie (event: RequestEvent, name: string, options?: CookieSerializeOptions): void {
+export function deleteCookie (event: EventWithResponse, name: string, options?: CookieSerializeOptions): void {
   setCookie(event, name, '', { ...options, maxAge: 0 })
 }
 
@@ -288,7 +295,7 @@ export function deleteCookie (event: RequestEvent, name: string, options?: Cooki
  *
  * @since 5.0.0
  */
-export function sendRedirect (event: RequestEvent, location: string, status = 302): string {
+export function sendRedirect (event: EventWithResponse, location: string, status = 302): string {
   setResponseStatus(event, status)
   setResponseHeader(event, 'location', location)
   setResponseHeader(event, 'content-type', 'text/html')
@@ -305,7 +312,7 @@ const REDIRECT_UNSAFE_RE = /["'<>&]/g
  *
  * @since 5.0.0
  */
-export function getRouteRules (_event: RequestEvent): AppRouteRules {
+export function getRouteRules (_event: Pick<RequestEvent, 'context'>): AppRouteRules {
   return {}
 }
 

--- a/packages/nuxt/test/server-surface.test.ts
+++ b/packages/nuxt/test/server-surface.test.ts
@@ -52,6 +52,12 @@ describe('request', () => {
     expect(getRequestURL(event(new Request('https://nuxt.com/api/hello?a=1'))).pathname).toBe('/api/hello')
   })
 
+  it('falls back to the request when the runtime has not parsed the URL', () => {
+    const e = { req: new Request('https://nuxt.com/api/hello?a=1') }
+    expect(getRequestURL(e).pathname).toBe('/api/hello')
+    expect(getQuery(e)).toEqual({ a: '1' })
+  })
+
   it('reads a request header case-insensitively, or `undefined`', () => {
     const e = event(new Request('https://nuxt.com/', { headers: { 'X-Custom': 'value' } }))
     expect(getRequestHeader(e, 'x-custom')).toBe('value')
@@ -226,10 +232,11 @@ describe('errors', () => {
 })
 
 describe('the event the surface is typed against', () => {
-  it('is the web-standard event, never a runtime\'s own', () => {
-    expectTypeOf<Parameters<typeof getRequestURL>[0]>().toEqualTypeOf<RequestEvent>()
-    expectTypeOf<Parameters<typeof getCookie>[0]>().toEqualTypeOf<RequestEvent>()
-    expectTypeOf<Parameters<typeof readBody>[0]>().toEqualTypeOf<RequestEvent>()
+  it('is the web-standard event, never a runtime\'s own, and only the part each helper reads', () => {
+    expectTypeOf<Parameters<typeof getRequestURL>[0]>().toEqualTypeOf<Pick<RequestEvent, 'req'> & { url?: URL }>()
+    expectTypeOf<Parameters<typeof getCookie>[0]>().toEqualTypeOf<Pick<RequestEvent, 'req'>>()
+    expectTypeOf<Parameters<typeof readBody>[0]>().toEqualTypeOf<Pick<RequestEvent, 'req'>>()
+    expectTypeOf<Parameters<typeof setResponseHeader>[0]>().toEqualTypeOf<Pick<RequestEvent, 'res'>>()
   })
 
   it('describes the request, its URL and the response, and nothing a runtime adds', () => {

--- a/packages/schema/src/types/server.ts
+++ b/packages/schema/src/types/server.ts
@@ -136,6 +136,8 @@ export interface NuxtRequestContext {
 /** The context of a {@link RequestEvent}, which carries Nuxt's own per-request state. */
 export interface RequestEventContext extends Record<string, unknown> {
   nuxt?: NuxtRequestContext
+  /** The dynamic segments matched for the request, as the server builder resolved them. */
+  params?: Record<string, string | undefined>
 }
 
 /**

--- a/scripts/check-docs-links.mjs
+++ b/scripts/check-docs-links.mjs
@@ -1,7 +1,7 @@
 // Internal docs links must not carry a version segment: nuxt.com inserts the
 // segment of the branch a page was built from, so version-less links survive
 // cherry-picks between branches. Deliberate cross-version links use a full URL.
-import { readdir, readFile } from 'node:fs/promises'
+import { readFile, readdir } from 'node:fs/promises'
 import { join } from 'node:path'
 
 const VERSIONED_INTERNAL_LINK = /(["'(=])\/docs\/\d+\.x\//g

--- a/test/fixtures/basic-types/server/type-context.ts
+++ b/test/fixtures/basic-types/server/type-context.ts
@@ -1,8 +1,9 @@
 import { expectTypeOf } from 'vitest'
 import type { H3Event } from 'nitro/h3'
 import { getRouterParam, handleCors, useSession } from 'nitro/h3'
+import { defineCachedHandler } from 'nitro/cache'
 import type { NuxtRequestEvent, RequestEvent, RequestEventContext } from 'nuxt/server'
-import { defineEventHandler, getRequestURL, getRouteRules, toNuxtRequestEvent } from 'nuxt/server'
+import { defineEventHandler, getQuery, getRequestURL, getRouteRules, toNuxtRequestEvent } from 'nuxt/server'
 
 // @ts-expect-error Fromage is 'cheese'
 const _fake: Fromage = 'babybel'
@@ -30,6 +31,7 @@ const portableHandler = defineEventHandler(async (event) => {
 
   // h3 helpers that only read the request take it directly
   expectTypeOf(getRouterParam(event, 'id')).toEqualTypeOf<string | undefined>()
+  expectTypeOf(event.context.params?.id).toEqualTypeOf<string | undefined>()
   await useSession(event, { password: '0'.repeat(32) })
 
   // @ts-expect-error `node` is not part of the portable event
@@ -52,3 +54,7 @@ const portableHandler = defineEventHandler(async (event) => {
 })
 
 expectTypeOf(portableHandler).returns.toEqualTypeOf<Promise<{ greeting: string }>>()
+
+defineCachedHandler(event => getQuery(event), {
+  getKey: event => getRequestURL(event).search,
+})


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

this makes `nuxt/server` utils more permissive (so, for example, they can accept the event in a `CachedEventHandler` from nitro...)