### PR TITLE
feat(nuxt): pass cause to asyncData handler

### DIFF
--- a/packages/nuxt/src/app/composables/asyncData.ts
+++ b/packages/nuxt/src/app/composables/asyncData.ts
@@ -21,7 +21,7 @@ export type AsyncDataRequestStatus = 'idle' | 'pending' | 'success' | 'error'
 
 export type _Transform<Input = any, Output = any> = (input: Input) => Output | Promise<Output>
 
-export type AsyncDataHandler<ResT> = (nuxtApp: NuxtApp, options: { signal: AbortSignal }) => Promise<ResT>
+export type AsyncDataHandler<ResT> = (nuxtApp: NuxtApp, options: { signal: AbortSignal, cause: AsyncDataRefreshCause | undefined }) => Promise<ResT>
 
 export type PickFrom<T, K extends Array<string>> = KeysOf<T> extends K
   ? T // Nothing to pick; short-circuit so a generic `T` stays resolvable
@@ -909,7 +909,7 @@ function buildAsyncData<
               reject(reason instanceof Error ? reason : new DOMException(String(reason ?? 'Aborted'), 'AbortError'))
             }, { once: true, signal: cleanupController.signal })
 
-            return Promise.resolve(handler(nuxtApp, { signal: mergedSignal })).then(resolve, reject)
+            return Promise.resolve(handler(nuxtApp, { signal: mergedSignal, cause: opts.cause })).then(resolve, reject)
           } catch (err) {
             reject(err)
           }

--- a/scripts/check-docs-links.mjs
+++ b/scripts/check-docs-links.mjs
@@ -1,7 +1,7 @@
 // Internal docs links must not carry a version segment: nuxt.com inserts the
 // segment of the branch a page was built from, so version-less links survive
 // cherry-picks between branches. Deliberate cross-version links use a full URL.
-import { readdir, readFile } from 'node:fs/promises'
+import { readFile, readdir } from 'node:fs/promises'
 import { join } from 'node:path'
 
 const VERSIONED_INTERNAL_LINK = /(["'(=])\/docs\/\d+\.x\//g

--- a/test/nuxt/use-async-data.test.ts
+++ b/test/nuxt/use-async-data.test.ts
@@ -475,6 +475,54 @@ describe('useAsyncData', () => {
     expect(data.value).toBe('watch')
   })
 
+  it('handler should receive cause on initial fetch', async () => {
+    const promiseFn = vi.fn((_nuxtApp: NuxtApp, ctx: { cause: AsyncDataRefreshCause | undefined }) => Promise.resolve(ctx.cause))
+    const { data } = await useAsyncData(uniqueKey, promiseFn, { getCachedData: () => undefined })
+    expect(data.value).toBe('initial')
+  })
+
+  it('handler should receive an explicit cause passed to refresh', async () => {
+    const promiseFn = vi.fn((_nuxtApp: NuxtApp, ctx: { cause: AsyncDataRefreshCause | undefined }) => Promise.resolve(ctx.cause))
+    const { data, refresh } = await useAsyncData(uniqueKey, promiseFn, { getCachedData: () => undefined })
+    await refresh({ cause: 'refresh:manual' })
+    expect(data.value).toBe('refresh:manual')
+  })
+
+  it('handler should receive an undefined cause when refresh is called without one', async () => {
+    const promiseFn = vi.fn((_nuxtApp: NuxtApp, ctx: { cause: AsyncDataRefreshCause | undefined }) => Promise.resolve(ctx.cause ?? 'no-cause'))
+    const { data, refresh } = await useAsyncData(uniqueKey, promiseFn, { getCachedData: () => undefined })
+    await refresh()
+    expect(data.value).toBe('no-cause')
+  })
+
+  it('handler should receive cause on refreshNuxtData', async () => {
+    const promiseFn = vi.fn((_nuxtApp: NuxtApp, ctx: { cause: AsyncDataRefreshCause | undefined }) => Promise.resolve(ctx.cause))
+    const { data } = await useAsyncData(uniqueKey, promiseFn, { getCachedData: () => undefined })
+    await refreshNuxtData(uniqueKey)
+    expect(data.value).toBe('refresh:hook')
+  })
+
+  it('handler should receive cause on watch', async () => {
+    const number = ref(0)
+    const promiseFn = vi.fn((_nuxtApp: NuxtApp, ctx: { cause: AsyncDataRefreshCause | undefined }) => Promise.resolve(ctx.cause))
+    const { data } = await useAsyncData(uniqueKey, promiseFn, { getCachedData: () => undefined, watch: [number] })
+    number.value = 1
+    await flushPromises()
+    expect(data.value).toBe('watch')
+  })
+
+  it('handler should receive both signal and cause', async () => {
+    let captured: { signal?: AbortSignal, cause?: AsyncDataRefreshCause } = {}
+    const promiseFn = vi.fn((_nuxtApp: NuxtApp, ctx: { signal: AbortSignal, cause: AsyncDataRefreshCause | undefined }) => {
+      captured = { signal: ctx.signal, cause: ctx.cause }
+      return Promise.resolve('ok')
+    })
+    await useAsyncData(uniqueKey, promiseFn, { getCachedData: () => undefined })
+    expect(captured.signal).toBeInstanceOf(AbortSignal)
+    expect(captured.signal!.aborted).toBe(false)
+    expect(captured.cause).toBe('initial')
+  })
+
   it('should use default while pending', async () => {
     const promise = useAsyncData(() => Promise.resolve('test'), { default: () => 'default' })
     const { data, pending } = promise


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This PR paddes the cause option from execute calls to the asyncData handler.

Maybe we could even think about adding other options to the handler.

Draft for now to be evaluated.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
