### PR TITLE
fix(nitro): render deferred virtuals after the app is generated

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -63,7 +63,7 @@
         "~/*": ["./*"],
         "#shared/*": ["./shared/*"]
       },
-      "ignoreUnresolved": ["#compat-virtual/nitro-dependent"]
+      "ignoreUnresolved": ["#compat-virtual/nitro-dependent", "#compat-virtual/app-dependent"]
     },
     "test/fixtures/basic": {
       "entry": [

--- a/packages/nitro-server/src/compat.ts
+++ b/packages/nitro-server/src/compat.ts
@@ -1015,17 +1015,11 @@ export async function setupNitroCompat (nuxt: Nuxt, nitroConfig: NitroConfig, le
     rescan(nitro.options.plugins as string[], nitro.options.handlers, nitro.options.virtual)
     invalidateScopeCache()
 
-    // a template may just as well wait on an event that first fires later in the build,
-    // such as `pages:resolved`, which modules like `@nuxtjs/sitemap` await from a
-    // `nitro:config`-registered virtual. Rendering the deferred templates here deadlocks:
-    // that event first fires inside `buildNuxt`, which runs only after `nuxt.ready()`
-    // resolves — and resolving `nuxt.ready()` is what invokes this. The dev listener
-    // keeps the event loop alive, so not even `NUXT_B1022` surfaces and the CLI hangs on
-    // "Preparing app" forever. Rendering once the app is generated stays ahead of every
-    // consumer instead: the bundler renders the templates itself, and the transform
-    // consults the scope only at build time. This hook is registered before the one
-    // that runs the nitro build, so the rescan below fills `virtualSources` in before
-    // the build can read the scope.
+    // a template may equally await an event that first fires inside `buildNuxt`, such
+    // as `pages:resolved`: rendering it here deadlocks, because `buildNuxt` runs only
+    // after `nuxt.ready()` — the step that invokes this — resolves. Rendered once the
+    // app is generated instead, still ahead of the nitro build, so the rescan below
+    // fills `virtualSources` in before the scope is read.
     let rendered = false
     nuxt.hook('build:done', async () => {
       if (rendered) {

--- a/packages/nitro-server/src/compat.ts
+++ b/packages/nitro-server/src/compat.ts
@@ -540,7 +540,7 @@ export async function getServerImportsPresets (legacy: ResolvedNitroLegacyOption
  * Returns a callback that absorbs registrations made after the build config was assembled;
  * call it once the nitro instance exists.
  */
-export async function setupNitroCompat (nuxt: Nuxt, nitroConfig: NitroConfig, legacy: ResolvedNitroLegacyOptions, modulePresets: LegacyImportsPreset[], installedModules: InstalledModule[] = [], unusedVariants: string[] = []): Promise<(nitro: { options: NitroOptions }) => Promise<void>> {
+export async function setupNitroCompat (nuxt: Nuxt, nitroConfig: NitroConfig, legacy: ResolvedNitroLegacyOptions, modulePresets: LegacyImportsPreset[], installedModules: InstalledModule[] = [], unusedVariants: string[] = []): Promise<(nitro: { options: NitroOptions }) => void> {
   // a module may register its handler through an alias it added for the server build only
   const aliases: Record<string, string> = { ...nitroConfig.alias as Record<string, string>, ...nuxt.options.alias }
   const files = new Map<string, CompatScope>()
@@ -988,18 +988,7 @@ export async function setupNitroCompat (nuxt: Nuxt, nitroConfig: NitroConfig, le
 
   // modules pushing straight into `nitro.options` from `nitro:init` are too late for the
   // pass above, but the transform only consults the scope at build time
-  const registerLateScope = async (nitro: { options: NitroOptions }) => {
-    for (const [id, template] of deferredVirtuals.splice(0)) {
-      try {
-        const code = await trackPendingTemplate(id, template)
-        if (typeof code === 'string') {
-          virtualSources.set(id, code)
-        }
-      } catch {
-        // reported by the bundler when it renders the template itself
-      }
-    }
-
+  const registerLateScope = (nitro: { options: NitroOptions }) => {
     for (const handler of nitro.options.handlers || []) {
       const entry = handler as { handler?: unknown }
       if (isMigrated(serverApiOf(entry)) || typeof entry.handler !== 'string') {
@@ -1025,6 +1014,37 @@ export async function setupNitroCompat (nuxt: Nuxt, nitroConfig: NitroConfig, le
 
     rescan(nitro.options.plugins as string[], nitro.options.handlers, nitro.options.virtual)
     invalidateScopeCache()
+
+    // a template may just as well wait on an event that first fires later in the build,
+    // such as `pages:resolved`, which modules like `@nuxtjs/sitemap` await from a
+    // `nitro:config`-registered virtual. Rendering the deferred templates here deadlocks:
+    // that event first fires inside `buildNuxt`, which runs only after `nuxt.ready()`
+    // resolves — and resolving `nuxt.ready()` is what invokes this. The dev listener
+    // keeps the event loop alive, so not even `NUXT_B1022` surfaces and the CLI hangs on
+    // "Preparing app" forever. Rendering once the app is generated stays ahead of every
+    // consumer instead: the bundler renders the templates itself, and the transform
+    // consults the scope only at build time. This hook is registered before the one
+    // that runs the nitro build, so the rescan below fills `virtualSources` in before
+    // the build can read the scope.
+    let rendered = false
+    nuxt.hook('build:done', async () => {
+      if (rendered) {
+        return
+      }
+      rendered = true
+      for (const [id, template] of deferredVirtuals.splice(0)) {
+        try {
+          const code = await trackPendingTemplate(id, template)
+          if (typeof code === 'string') {
+            virtualSources.set(id, code)
+          }
+        } catch {
+          // reported by the bundler when it renders the template itself
+        }
+      }
+      rescan(nitro.options.plugins as string[], nitro.options.handlers, nitro.options.virtual)
+      invalidateScopeCache()
+    })
   }
 
   // baked in at build time, so that an app with no v2 code keeps Nitro's error semantics

--- a/packages/nitro-server/test/compat.test.ts
+++ b/packages/nitro-server/test/compat.test.ts
@@ -19,6 +19,7 @@ function declared<T extends object> (entry: T, api: string): any {
 }
 
 function createNuxt (options: Record<string, any> = {}) {
+  const listeners: Record<string, Array<(...args: any[]) => any>> = {}
   return {
     options: {
       alias: {},
@@ -33,6 +34,16 @@ function createNuxt (options: Record<string, any> = {}) {
       nitro: {},
       _layers: [{ config: { rootDir: '/project', srcDir: '/project' }, cwd: '/project' }],
       ...options,
+    },
+    hook: (name: string, listener: (...args: any[]) => any) => {
+      (listeners[name] ||= []).push(listener)
+    },
+    hooks: {
+      callHook: async (name: string, ...args: any[]) => {
+        for (const listener of listeners[name] || []) {
+          await listener(...args)
+        }
+      },
     },
   } as unknown as Nuxt
 }
@@ -412,7 +423,8 @@ describe('setupNitroCompat', () => {
       },
       handlers: [{ route: '/virtual', handler: '#virtual-module/handler' } as any],
     }
-    const registerLateScope = await setupNitroCompat(createNuxt(), nitroConfig, legacyOff, [])
+    const nuxt = createNuxt()
+    const registerLateScope = await setupNitroCompat(nuxt, nitroConfig, legacyOff, [])
 
     const plugin = (nitroConfig.rollupConfig!.plugins as any[])[0]
     const transformed = await plugin.transform.handler.call(null, `import { useStorage } from 'nitropack/runtime'`, '#virtual-module/template')
@@ -422,8 +434,9 @@ describe('setupNitroCompat', () => {
     expect(nitroConfig.plugins!.map(String)).toEqual([expect.stringMatching(/compat[\\/]event-plugin/), expect.stringMatching(/compat[\\/]hooks-plugin/)])
     expect(report.mock.calls[0]![0]).toMatchObject({ count: 1, modules: expect.stringContaining('`#virtual-module/template` (imports `nitropack/runtime`)') })
 
-    // a template function is rendered once nitro exists, so its evidence arrives late
+    // a template function is rendered once the app has been generated, so its evidence arrives late
     await registerLateScope({ options: { alias: {}, plugins: nitroConfig.plugins, handlers: nitroConfig.handlers } } as any)
+    await nuxt.hooks.callHook('build:done')
 
     expect(report.mock.calls[1]![0]).toMatchObject({ count: 1, modules: expect.stringContaining('`#virtual-module/handler` (imports `h3`)') })
     report.mockRestore()
@@ -443,10 +456,12 @@ describe('setupNitroCompat', () => {
       handlers: [{ route: '/late', handler: '#virtual-module/late' } as any],
     }
 
-    const registerLateScope = await setupNitroCompat(createNuxt(), nitroConfig, legacyOff, [])
+    const nuxt = createNuxt()
+    const registerLateScope = await setupNitroCompat(nuxt, nitroConfig, legacyOff, [])
 
     nitroReady!()
     await registerLateScope({ options: { alias: {}, plugins: nitroConfig.plugins, handlers: nitroConfig.handlers } } as any)
+    await nuxt.hooks.callHook('build:done')
 
     const plugin = (nitroConfig.rollupConfig!.plugins as any[])[0]
     const transformed = await plugin.transform.handler.call(null, `import { useStorage } from 'nitropack/runtime'`, '#virtual-module/late')

--- a/scripts/check-docs-links.mjs
+++ b/scripts/check-docs-links.mjs
@@ -1,7 +1,7 @@
 // Internal docs links must not carry a version segment: nuxt.com inserts the
 // segment of the branch a page was built from, so version-less links survive
 // cherry-picks between branches. Deliberate cross-version links use a full URL.
-import { readdir, readFile } from 'node:fs/promises'
+import { readFile, readdir } from 'node:fs/promises'
 import { join } from 'node:path'
 
 const VERSIONED_INTERNAL_LINK = /(["'(=])\/docs\/\d+\.x\//g

--- a/test/fixtures/nitro-module-compat/modules/runtime/app-dependent-handler.ts
+++ b/test/fixtures/nitro-module-compat/modules/runtime/app-dependent-handler.ts
@@ -1,0 +1,11 @@
+// @ts-expect-error `#imports` is typed for the Nuxt app, not the server build
+import { useRuntimeConfig } from '#imports'
+// @ts-expect-error a virtual rendered only once the app has been generated
+import { templates } from '#compat-virtual/app-dependent'
+
+export default defineEventHandler((event) => {
+  return {
+    flavour: useRuntimeConfig(event).public.flavour,
+    templates,
+  }
+})

--- a/test/fixtures/nitro-module-compat/modules/untagged.ts
+++ b/test/fixtures/nitro-module-compat/modules/untagged.ts
@@ -84,6 +84,24 @@ export default defineNuxtModule({
       handler: resolver.resolve('./runtime/nitro-dependent-handler'),
     })
 
+    // a module virtual whose contents are only knowable once the app has been generated:
+    // rendering it any earlier than `build:done` deadlocks the build, because the event
+    // it awaits first fires inside `buildNuxt`, which runs after `nuxt.ready()` resolves
+    let appReady: (count: number) => void
+    const templateCount = new Promise<number>((resolve) => { appReady = resolve })
+    nuxt.hook('nitro:config', (nitroConfig) => {
+      nitroConfig.virtual ||= {}
+      nitroConfig.virtual['#compat-virtual/app-dependent'] = async () => `export const templates = ${JSON.stringify(await templateCount)}`
+    })
+    nuxt.hook('app:templatesGenerated', (app) => {
+      appReady(app.templates.length)
+    })
+
+    addServerHandler({
+      route: '/api/app-dependent',
+      handler: resolver.resolve('./runtime/app-dependent-handler'),
+    })
+
     // some modules bypass kit entirely and push into `nitro.options` directly
     nuxt.hook('nitro:init', (nitro) => {
       nitro.options.handlers.push({

--- a/test/nitro-module-compat.test.ts
+++ b/test/nitro-module-compat.test.ts
@@ -60,6 +60,13 @@ describe.skipIf(!shouldRun)('nitro v2 module compatibility without `nitroLegacy`
     })
   })
 
+  it('transforms a module virtual whose contents need the generated app', async () => {
+    expect(await $fetch<Record<string, unknown>>('/api/app-dependent')).toMatchObject({
+      flavour: 'earl-grey',
+      templates: expect.any(Number),
+    })
+  })
+
   it('transforms a utility registered through `addServerImports`', async () => {
     expect(await $fetch<Record<string, unknown>>('/api/via-imports')).toEqual({
       flavour: 'earl-grey',


### PR DESCRIPTION
### 🔗 Linked PRs/Issues

N/A

### 📚 Description

`registerLateNitroCompatScope` renders module virtual templates ("deferred virtuals") right after `nitro:init`. But a template may equally await an event that first fires inside `buildNuxt` — `@nuxtjs/sitemap` awaits `pages:resolved` this way — so rendering it there deadlocks `nuxt dev` and `nuxt build`: `buildNuxt` runs only after `nuxt.ready()` resolves, and resolving it is what invokes this. With the dev listener keeping the event loop alive, not even `NUXT_B1022` surfaces and the CLI hangs on "Preparing app" forever.

This renders the deferred templates from `build:done` instead.

### 📝 Checklist

- [ ] I have created an issue for the PR/linked to an existing issue
- [x] My PR is based on a branch created from `main` (not `3.x`)
- [x] I have updated the corresponding fixtures and/or integration tests
- [x] I have run `pnpm lint`, `pnpm typecheck` and the relevant `vitest` projects

---

*This pull request was created with assistance from a code agent.*
